### PR TITLE
Fix Windows compatibility for resource import and UTF-8 encoding

### DIFF
--- a/backend/plugin_lifecycle.py
+++ b/backend/plugin_lifecycle.py
@@ -101,7 +101,7 @@ class PluginManager:
             # Read manifest to know which events and slash commands this plugin subscribes to
             manifest_path = os.path.join(plugin_dir, 'plugin.json')
             if os.path.isfile(manifest_path):
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     manifest = json.load(f)
                 events = manifest.get('events', [])
                 slash_commands = manifest.get('slash_commands', [])
@@ -221,7 +221,7 @@ class PluginManager:
         plugin_dir = os.path.join(PLUGINS_DIR, plugin_id)
         manifest_path = os.path.join(plugin_dir, 'plugin.json')
         if os.path.isfile(manifest_path):
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding='utf-8') as f:
                 manifest = json.load(f)
             for sc in manifest.get('slash_commands', []):
                 sc_name = sc.get('id', '')
@@ -330,7 +330,7 @@ class PluginManager:
             if not os.path.isfile(manifest_path):
                 continue
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     manifest = json.load(f)
                 manifest['_dir'] = plugin_dir
                 manifest['event_count'] = len(manifest.get('events', []))
@@ -409,7 +409,7 @@ class PluginManager:
         if not os.path.isfile(manifest_path):
             return None
         try:
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding='utf-8') as f:
                 manifest = json.load(f)
             manifest['_dir'] = plugin_dir
             return manifest
@@ -434,7 +434,7 @@ class PluginManager:
             if not manifest_path:
                 return {'error': 'No plugin.json found in zip'}
 
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding='utf-8') as f:
                 manifest = json.load(f)
 
             plugin_id = manifest.get('id', '')
@@ -460,7 +460,7 @@ class PluginManager:
         if not os.path.isfile(manifest_path):
             return {'error': f'No plugin.json found in {source_dir}'}
 
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
 
         plugin_id = manifest.get('id', '')
@@ -544,7 +544,7 @@ class PluginManager:
             config_path = os.path.join(PLUGINS_DIR, plugin_id, 'config.json')
             if os.path.isfile(config_path):
                 try:
-                    with open(config_path) as f:
+                    with open(config_path, encoding='utf-8') as f:
                         file_config = json.load(f)
                     var_names = {v['name'] for v in variables}
                     for name, val in file_config.items():

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -355,7 +355,7 @@ def run_setup(
         # 7. Enable all installed plugins
         for manifest_path in glob.glob(os.path.join(config.BASE_DIR, 'plugins', '*', 'plugin.json')):
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     manifest = json.load(f)
                 plugin_id = manifest.get('id', '')
                 if plugin_id:
@@ -366,7 +366,7 @@ def run_setup(
         # 8. Enable all installed skills
         for manifest_path in glob.glob(os.path.join(config.BASE_DIR, 'skills', '*', 'skill.json')):
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     manifest = json.load(f)
                 skill_id = manifest.get('id', '')
                 if skill_id:

--- a/backend/skills_manager.py
+++ b/backend/skills_manager.py
@@ -27,7 +27,7 @@ def _load_global_config() -> Dict[str, Any]:
     if not os.path.isfile(CONFIG_PATH):
         return {}
     try:
-        with open(CONFIG_PATH) as f:
+        with open(CONFIG_PATH, encoding='utf-8') as f:
             return json.load(f)
     except (json.JSONDecodeError, IOError):
         return {}
@@ -53,7 +53,7 @@ class SkillsManager:
             if not os.path.isfile(manifest_path):
                 continue
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding='utf-8') as f:
                     manifest = json.load(f)
                 manifest['_dir'] = skill_dir
                 manifest['tool_count'] = len(self._load_tool_defs(skill_dir, manifest))
@@ -69,7 +69,7 @@ class SkillsManager:
         manifest_path = os.path.join(skill_dir, 'skill.json')
         if not os.path.isfile(manifest_path):
             return None
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
         manifest['enabled'] = self.is_skill_enabled(skill_id)
         tool_defs = self._load_tool_defs(skill_dir, manifest)
@@ -89,7 +89,7 @@ class SkillsManager:
         manifest_path = os.path.join(skill_dir, 'skill.json')
         if not os.path.isfile(manifest_path):
             return []
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
         if not self.is_skill_enabled(skill_id):
             return []
@@ -138,7 +138,7 @@ class SkillsManager:
             if not manifest_path:
                 return {'error': 'No skill.json found in zip (must be at root or one directory deep)'}
 
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding='utf-8') as f:
                 manifest = json.load(f)
 
             skill_id = manifest.get('id', '')
@@ -162,13 +162,13 @@ class SkillsManager:
             saved_config = None
             config_path = os.path.join(skill_dest, 'config.json')
             if os.path.isfile(config_path):
-                with open(config_path) as f:
+                with open(config_path, encoding='utf-8') as f:
                     saved_config = f.read()
             if os.path.exists(skill_dest):
                 shutil.rmtree(skill_dest)
             shutil.copytree(skill_src, skill_dest)
             if saved_config is not None:
-                with open(os.path.join(skill_dest, 'config.json'), 'w') as f:
+                with open(os.path.join(skill_dest, 'config.json'), 'w', encoding='utf-8') as f:
                     f.write(saved_config)
 
             # Run setup.install() if available
@@ -183,7 +183,7 @@ class SkillsManager:
         if not os.path.isfile(manifest_path):
             return {'error': f'No skill.json found in {source_dir}'}
 
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
 
         skill_id = manifest.get('id', '')
@@ -201,13 +201,13 @@ class SkillsManager:
             saved_config = None
             config_path = os.path.join(skill_dest, 'config.json')
             if os.path.isfile(config_path):
-                with open(config_path) as f:
+                with open(config_path, encoding='utf-8') as f:
                     saved_config = f.read()
             if os.path.exists(skill_dest):
                 shutil.rmtree(skill_dest)
             shutil.copytree(source_dir, skill_dest)
             if saved_config is not None:
-                with open(os.path.join(skill_dest, 'config.json'), 'w') as f:
+                with open(os.path.join(skill_dest, 'config.json'), 'w', encoding='utf-8') as f:
                     f.write(saved_config)
 
         # Run setup.install()
@@ -241,7 +241,7 @@ class SkillsManager:
         from models.db import db
         db.set_setting(f'skill_enabled:{skill_id}', '1' if enabled else '0')
 
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
         manifest['enabled'] = enabled
         return manifest
@@ -252,7 +252,7 @@ class SkillsManager:
         manifest_path = os.path.join(skill_dir, 'skill.json')
         if not os.path.isfile(manifest_path):
             return []
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
         return manifest.get('variables', [])
 
@@ -362,7 +362,7 @@ class SkillsManager:
         manifest_path = os.path.join(skill_dir, 'skill.json')
         if not os.path.isfile(manifest_path):
             return {'error': f"Skill '{skill_id}' not found"}
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding='utf-8') as f:
             manifest = json.load(f)
         tools_file = manifest.get('tools_file', '')
         if not tools_file:
@@ -370,7 +370,7 @@ class SkillsManager:
         tools_path = os.path.join(skill_dir, tools_file)
         if not os.path.isfile(tools_path):
             return {'error': f"Tools file not found: {tools_file}"}
-        with open(tools_path) as f:
+        with open(tools_path, encoding='utf-8') as f:
             defs = json.load(f)
         updated = False
         for entry in defs:
@@ -380,7 +380,7 @@ class SkillsManager:
                 break
         if not updated:
             return {'error': f"Tool '{fn_name}' not found in skill '{skill_id}'"}
-        with open(tools_path, 'w') as f:
+        with open(tools_path, 'w', encoding='utf-8') as f:
             json.dump(defs, f, indent=2, ensure_ascii=False)
         return {'success': True}
 
@@ -393,7 +393,7 @@ class SkillsManager:
         if not os.path.isfile(tools_path):
             return []
         try:
-            with open(tools_path) as f:
+            with open(tools_path, encoding='utf-8') as f:
                 data = json.load(f)
             # The tools file is an array of OpenAI function defs
             if isinstance(data, list):

--- a/backend/slash_commands.py
+++ b/backend/slash_commands.py
@@ -349,7 +349,6 @@ def _register_builtins():
 
         def _do_restart():
             import time
-            import resource
             time.sleep(1.5)  # Brief delay so response is sent first
 
             # Stop all channels cleanly so Telegram releases its long-poll
@@ -359,14 +358,18 @@ def _register_builtins():
             time.sleep(1.0)  # Give Telegram server-side time to release
 
             # Close all inherited file descriptors (including Flask's bound
-            # socket) so the new process can bind the same port cleanly
-            try:
-                maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                    maxfd = 4096
-                os.closerange(3, maxfd)
-            except Exception:
-                pass
+            # socket) so the new process can bind the same port cleanly.
+            # `resource` is POSIX-only; on Windows os.execv inherits handles
+            # through the CRT and there's no RLIMIT_NOFILE to bound the loop.
+            if sys.platform != 'win32':
+                try:
+                    import resource
+                    maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+                    if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
+                        maxfd = 4096
+                    os.closerange(3, maxfd)
+                except Exception:
+                    pass
 
             os.execv(sys.executable, [sys.executable] + sys.argv)
 

--- a/backend/tools/clear_log_file.py
+++ b/backend/tools/clear_log_file.py
@@ -18,13 +18,13 @@ def execute(agent: dict, args: dict) -> dict:
     marker = "---log-reset---\n"
 
     try:
-        with open(log_path, 'w') as f:
+        with open(log_path, 'w', encoding='utf-8') as f:
             f.write(marker)
     except Exception as e:
         return {"error": f"Error clearing llm.log: {str(e)}"}
 
     try:
-        with open(recap_path, 'w') as f:
+        with open(recap_path, 'w', encoding='utf-8') as f:
             f.write(marker)
     except Exception as e:
         return {"error": f"Error clearing sessrecap.log: {str(e)}"}

--- a/backend/tools/patch.py
+++ b/backend/tools/patch.py
@@ -572,7 +572,7 @@ def test_execute():
     passed += 1
 
     print('Test 2: Insert lines')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('alpha\nbeta\ngamma\n')
     r = apply_patch(tmp, '@@ -1,2 +1,4 @@\n alpha\n+inserted1\n+inserted2\n beta\n')
     assert r['result'] == 'success', r
@@ -580,7 +580,7 @@ def test_execute():
     passed += 1
 
     print('Test 3: Insertion-only hunk (no context at all)')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('line1\nline2\nline3\n')
     r = apply_hunks(tmp, '@@ -2,0 +2,2 @@\n+new_a\n+new_b\n')
     assert r['result'] == 'success', r
@@ -598,7 +598,7 @@ def test_execute():
     passed += 1
 
     print('Test 5: Multiple hunks')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('a\nb\nc\nd\ne\nf\n')
     r = apply_patch(tmp, '@@ -1,2 +1,2 @@\n a\n-b\n+B\n@@ -5,2 +5,2 @@\n e\n-f\n+F\n')
     assert r['result'] == 'success', r
@@ -606,14 +606,14 @@ def test_execute():
     passed += 1
 
     print('Test 6: Context mismatch → error (Python fallback)')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('line1\nline2\nline3\n')
     r = apply_hunks(tmp, '@@ -1,2 +1,2 @@\n WRONG_CONTEXT\n-line2\n+LINE2\n')
     assert 'error' in r, r
     passed += 1
 
     print('Test 7: Git-style headers skipped')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('foo\nbar\n')
     patch = 'diff --git a/f b/f\nindex a..b 100644\n--- a/f\n+++ b/f\n@@ -1,2 +1,2 @@\n foo\n-bar\n+BAR\n'
     r = apply_patch(tmp, patch)
@@ -643,7 +643,7 @@ def test_execute():
     passed += 1
 
     print('Test 11: Implicit hunk count=1')
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.write('only line\n')
     r = apply_patch(tmp, '@@ -1 +1 @@\n-only line\n+ONLY LINE\n')
     assert r['result'] == 'success', r
@@ -653,7 +653,7 @@ def test_execute():
     print('Test 12: Python fallback drift tolerance (±50 lines)')
     lines = [f'filler_{i}\n' for i in range(44)]
     lines += ['target line\n', 'after target\n']
-    with open(tmp, 'w') as f:
+    with open(tmp, 'w', encoding='utf-8') as f:
         f.writelines(lines)
     r = apply_hunks(tmp, '@@ -1,2 +1,2 @@\n target line\n-after target\n+REPLACED\n')
     assert r['result'] == 'success', r

--- a/backend/tools/super_agent_tools.py
+++ b/backend/tools/super_agent_tools.py
@@ -559,7 +559,6 @@ def _exec_restart(args: dict, agent_context: dict = None) -> dict:
     import sys as _sys
     import threading
     import time
-    import resource
     import json as _json
     import logging
 
@@ -619,13 +618,16 @@ def _exec_restart(args: dict, agent_context: dict = None) -> dict:
         from backend.channels.registry import channel_manager
         channel_manager.stop_all()
         time.sleep(1.0)
-        try:
-            maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-            if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                maxfd = 4096
-            os.closerange(3, maxfd)
-        except Exception:
-            pass
+        # `resource` is POSIX-only; skip FD cleanup on Windows.
+        if _sys.platform != 'win32':
+            try:
+                import resource
+                maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+                if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
+                    maxfd = 4096
+                os.closerange(3, maxfd)
+            except Exception:
+                pass
         os.execv(_sys.executable, [_sys.executable] + _sys.argv)
 
     t = threading.Thread(target=_do_restart, daemon=True)

--- a/backend/tools/use_skill.py
+++ b/backend/tools/use_skill.py
@@ -82,7 +82,7 @@ def execute(agent: dict, args: dict) -> dict:
     manifest = {}
     if os.path.isfile(manifest_path):
         try:
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding='utf-8') as f:
                 manifest = json.load(f)
         except (json.JSONDecodeError, IOError):
             pass

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -7,7 +7,6 @@ import time
 import subprocess
 import shutil
 import tempfile
-import fcntl
 from datetime import datetime
 
 # Ensure the project root is on sys.path so we can import backend modules
@@ -239,14 +238,18 @@ def stop_server():
             _remove_pid()
             return
 
-    # Force kill if still running
-    print("Server didn't stop gracefully. Sending SIGKILL...")
+    # Force kill if still running. SIGKILL is POSIX-only, so on Windows we
+    # use `taskkill /F` (the same approach as supervisor/supervisor.py).
+    print("Server didn't stop gracefully. Force-killing...")
     try:
-        os.kill(pid, signal.SIGKILL)
+        if sys.platform == 'win32':
+            subprocess.run(['taskkill', '/F', '/PID', str(pid)], capture_output=True)
+        else:
+            os.kill(pid, signal.SIGKILL)
         time.sleep(1)
         print(f"Server killed (PID: {pid})")
     except OSError as e:
-        print(f"Failed to SIGKILL: {e}")
+        print(f"Failed to force-kill: {e}")
 
     _remove_pid()
 

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 
 import logging
 import threading
@@ -14,7 +15,11 @@ from backend.skillsets import list_skillsets
 from backend.setup import (run_setup, test_connection, PROVIDER_DEFAULTS,
                             TONE_PRESETS, LANGUAGE_PRESETS, check_docker_available)
 import config
-import resource
+
+# `resource` is a POSIX-only stdlib module — absent on Windows.
+# Guarded so the app can boot; restart-time FD cleanup is skipped there.
+if sys.platform != 'win32':
+    import resource
 
 dashboard_bp = Blueprint('dashboard', __name__)
 
@@ -76,13 +81,13 @@ def api_setup():
                 from backend.channels.registry import channel_manager
                 channel_manager.stop_all()
                 time.sleep(1.0)
-                maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                    maxfd = 4096
-                os.closerange(3, maxfd)
+                if sys.platform != 'win32':
+                    maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+                    if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
+                        maxfd = 4096
+                    os.closerange(3, maxfd)
             except Exception as e:
                 _log.error("Error during restart cleanup: %s", e, exc_info=True)
-            import sys
             _log.info("Re-executing server process")
             os.execv(sys.executable, [sys.executable] + sys.argv)
 


### PR DESCRIPTION
# Windows compatibility fixes

  `python app.py` doesn't start on Windows after the `task#1`/`task#2` series. A
  couple of POSIX-only imports need guarding before the app reaches Flask, plus
  a few text-mode `open()` calls decode under cp1252 by default and crash on the
  Indonesian content in the default plugin manifests.

 ## What's broken

  1. **Boot: `import resource`** — `routes/dashboard.py` imports `resource`
     (POSIX-only stdlib) at module level. `python app.py` fails with
     `ModuleNotFoundError: No module named 'resource'` before Flask initializes.

  2. **Boot: cp1252 decoding** — once `resource` is guarded, the next failure
     is `UnicodeDecodeError` reading `plugins/kanban/plugin.json` in
     `PluginManager()` and `SkillsManager()` constructors. Python on Windows
     defaults `open()` to `cp1252`, which can't decode the Indonesian text in
     default plugin/skill manifests.

  3. **Runtime: `/restart`** — the slash command handler and the super-agent
     restart tool both lazy-import `resource`. Same root cause, runtime path.

  4. **CLI: unused `import fcntl`** — `cli/commands.py` imports `fcntl` at the
     top but never calls it. The unused import alone breaks the CLI on Windows.

  5. **CLI: `signal.SIGKILL`** — doesn't exist on Windows; `stop_server()`
     crashes if SIGTERM doesn't take.

  6. **Tools: unencoded writes** — `patch`, `clear_log_file`, and `use_skill`
     have text-mode `open()` calls that crash on non-ASCII file content.