### PR TITLE
feat: add OpenCode Zen and OpenCode Go providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,14 @@ keys/
 data/
 plan/
 run/
+
+# Ignore Other Agents settings and Editor configs
+.codex/
+.opencode/
+.claude/
+.windsurf/
+.windsurfrules
+.codeium/
+.codeiumignore
+AGENTS.md
+CLAUDE.md

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -53,6 +53,26 @@ PROVIDER_DEFAULTS = {
         "description": "Cloud · API key required",
         "api_format": "ollama",
     },
+    "opencode_zen": {
+        "type": "remote",
+        "base_url": "https://opencode.ai/zen/v1",
+        "api_key_required": True,
+        "placeholder_model": "qwen3.6-plus",
+        "label": "OpenCode Zen",
+        "description": "Cloud · API key required",
+    },
+    "opencode_go": {
+        "type": "remote",
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "api_key_required": True,
+        "placeholder_model": "kimi-k2.6",
+        "label": "OpenCode Go",
+        "description": "Cloud · API key required",
+        # Go's catalog is dominated by always-thinking models (Kimi K2, DeepSeek V4,
+        # MiniMax M2). The upstream rejects requests that omit reasoning_content on
+        # prior assistant messages, so default thinking on for this provider.
+        "default_thinking": True,
+    },
     "llama.cpp": {
         "type": "local",
         "base_url": "http://localhost:8080/v1",
@@ -386,6 +406,7 @@ def run_setup(
                 "is_default": 1,
                 "enabled": 1,
                 "api_format": model_api_format,
+                "thinking": 1 if provider_cfg.get("default_thinking") else 0,
             }
         )
 
@@ -534,8 +555,10 @@ def run_reconfigure(
         }
         existing_model = db.get_model_by_id(model_id)
         if existing_model:
+            # Update preserves the user's manual thinking toggle
             db.update_model(model_id, model_data)
         else:
+            model_data["thinking"] = 1 if provider_cfg.get("default_thinking") else 0
             db.create_model(model_data)
 
         # 2. Build new system prompt (tone + language)

--- a/routes/models.py
+++ b/routes/models.py
@@ -63,7 +63,7 @@ def api_create_model():
         return jsonify({"success": False, "error": "type must be remote or local"}), 400
 
     # Validate provider
-    valid_providers = ("openrouter", "togetherai", "ollama", "ollama_cloud", "llama.cpp", "custom")
+    valid_providers = ("openrouter", "togetherai", "ollama", "ollama_cloud", "opencode_zen", "opencode_go", "llama.cpp", "custom")
     if data["provider"] not in valid_providers:
         return jsonify(
             {"success": False, "error": f"provider must be one of {valid_providers}"}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -370,6 +370,8 @@ block content %}
                     <option value="togetherai">TogetherAI</option>
                     <option value="ollama">Ollama</option>
                     <option value="ollama_cloud">Ollama Cloud</option>
+                    <option value="opencode_zen">OpenCode Zen</option>
+                    <option value="opencode_go">OpenCode Go</option>
                     <option value="llama.cpp">llama.cpp</option>
                     <option value="custom">Custom</option>
                 </select>
@@ -416,6 +418,20 @@ block content %}
                     placeholder="anthropic/claude-3.5-sonnet"
                     class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400 dark:bg-gray-700 dark:text-gray-100"
                 />
+                <p
+                    id="model-id-hint"
+                    class="text-xs text-gray-400 dark:text-gray-500 mt-1"
+                >
+                    The exact ID format depends on the provider. Browse the
+                    catalog at
+                    <a
+                        href="https://models.dev/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 underline"
+                        >models.dev</a
+                    >.
+                </p>
             </div>
 
             <div class="mb-4">
@@ -2042,6 +2058,10 @@ block content %}
             apiKeyGroup.style.display = "none";
         } else {
             apiKeyGroup.style.display = "block";
+        }
+        const idHint = document.getElementById("model-id-hint");
+        if (idHint) {
+            idHint.style.display = type === "remote" ? "block" : "none";
         }
     }
 

--- a/templates/settings_models.html
+++ b/templates/settings_models.html
@@ -71,6 +71,8 @@
                     <option value="togetherai">TogetherAI</option>
                     <option value="ollama">Ollama</option>
                     <option value="ollama_cloud">Ollama Cloud</option>
+                    <option value="opencode_zen">OpenCode Zen</option>
+                    <option value="opencode_go">OpenCode Go</option>
                     <option value="llama.cpp">llama.cpp</option>
                     <option value="custom">Custom</option>
                 </select>
@@ -89,6 +91,10 @@
             <div class="form-group">
                 <label>Model Name *</label>
                 <input type="text" id="model-name-param" required class="form-input" placeholder="anthropic/claude-3.5-sonnet">
+                <p id="model-id-hint" class="form-hint">
+                    The exact ID format depends on the provider. Browse the catalog at
+                    <a href="https://models.dev/" target="_blank" rel="noopener noreferrer">models.dev</a>.
+                </p>
             </div>
 
             <div class="form-group">
@@ -559,13 +565,17 @@ function closeModal() {
 function toggleModelFields() {
     const type = document.getElementById('model-type').value;
     const provider = document.getElementById('model-provider').value;
-    
+
     // Show/hide API key field based on type
     const apiKeyGroup = document.getElementById('api-key-group');
     if (type === 'local' && (provider === 'ollama' || provider === 'llama.cpp')) {
         apiKeyGroup.style.display = 'none';
     } else {
         apiKeyGroup.style.display = 'block';
+    }
+    const idHint = document.getElementById('model-id-hint');
+    if (idHint) {
+        idHint.style.display = type === 'remote' ? 'block' : 'none';
     }
 }
 


### PR DESCRIPTION
- Two new entries in PROVIDER_DEFAULTS pointing at  https://opencode.ai/zen/v1 and https://opencode.ai/zen/go/v1 (both OpenAI-compatible, Bearer auth via OPENCODE_API_KEY)
- New `default_thinking` provider flag pre-enables thinking on newly created model rows. Set True for OpenCode Go because its catalog is dominated by always-thinking models (Kimi K2, DeepSeek V4, MiniMax M2) whose upstream rejects requests that omit reasoning_content on prior assistant messages. Applied only on creation — reconfigure preserves the user's manual thinking toggle.
- Add models.dev hint under the Model ID input, visible only when Type is Remote
- Mirror dropdown + hint changes across settings.html (live) and settings_models.html (orphan, kept consistent)
- Ignore AI agent local configs and editor metadata(.codex/, .opencode/, .claude/, .windsurf/, .codeium/, AGENTS.md, CLAUDE.md)