### PR TITLE
fix(llm_client): explicitly set stream: false in OpenAI-compatible payload

### DIFF
--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -423,6 +423,7 @@ class LLMClient:
                 "model": self.model,
                 "messages": processed_messages,
                 "max_tokens": max_tokens,
+                "stream": False,
             }
             if effective_temperature is not None:
                 payload["temperature"] = effective_temperature


### PR DESCRIPTION
## Summary

Closes #7

Adds `"stream": False` explicitly to the OpenAI-compatible chat completion payload in `backend/llm_client.py`. This prevents a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` crash that occurs when using evonic with providers or routers that default to streaming when the `stream` field is omitted (confirmed with [9router](https://github.com/decolua/9router)).

## Root Cause

The [OpenAI Chat Completions spec](https://platform.openai.com/docs/api-reference/chat/create) defines `stream` as optional with default `false`. Most providers honor this. However, 9router uses the following logic:

```js
let stream = providerRequiresStreaming ? true : (body.stream !== false);
```

When `body.stream` is `undefined` (field omitted), `undefined !== false` → `true` → router returns `text/event-stream`. Evonic calls `response.json()` on the SSE body and crashes.

## Changes

- `backend/llm_client.py` — add `"stream": False` to the OpenAI-compatible payload (1 line)

## Why This Is Safe

- `stream` is a standard OpenAI spec field — no compliant provider will reject it
- Providers that already default to `false`: no behavior change
- Providers that deviate from spec: now receive explicit instruction
- The Ollama-format path already sets `stream: False` — this mirrors that behavior
- Evonic has no SSE parser; explicit `false` matches actual capability

## Test Plan

- [ ] Start evonic with a 9router model configured (default 9router config)
- [ ] Send a message to an agent — confirm no `unknown_error` in logs
- [ ] Send a message using a standard OpenAI-compatible provider — confirm no regression