### PR TITLE
fix(security): generate random SECRET_KEY when not configured

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ logging.getLogger('werkzeug').setLevel(logging.ERROR)
 
 app = Flask(__name__)
 sock = Sock(app)
-app.secret_key = os.getenv('SECRET_KEY', 'dev-secret-key-change-in-production')
+app.secret_key = config.SECRET_KEY
 
 # Global upload size limit (defense-in-depth for all endpoints)
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50 MB

--- a/config.py
+++ b/config.py
@@ -68,7 +68,16 @@ DB_PATH = os.path.join(_shared_db_dir, "evonic.db")
 TEST_DB_PATH = os.path.join(BASE_DIR, "seed", "test_db.sqlite")
 
 # Flask
-SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+_secret_key = os.getenv("SECRET_KEY", "")
+if _secret_key:
+    SECRET_KEY = _secret_key
+else:
+    import secrets as _secrets
+    SECRET_KEY = _secrets.token_hex(32)
+    _logger.warning(
+        "SECRET_KEY not set — generated a random key. "
+        "Set the SECRET_KEY env var for persistent sessions across restarts."
+    )
 HOST = os.getenv("HOST", "0.0.0.0")
 PORT = _get_env_int("PORT", 8080, min_val=1, max_val=65535)
 DEBUG = os.getenv("DEBUG", "1") == "1"


### PR DESCRIPTION
Halo Mas, izin request PR.

## Masalah

`SECRET_KEY` Flask fallback-nya string hardcoded `'dev-secret-key-change-in-production'`. String ini ada di dua file: [config.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/config.py:0:0-0:0) dan [app.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/app.py:0:0-0:0).

Siapa aja yang baca source code ini (repo public) bisa pakai string itu buat forge session cookie. Tinggal sign cookie pakai string yang sama, bypass login terus masuk.

Flask pakai `SECRET_KEY` buat sign session via `itsdangerous`. Kalau key-nya bocor, cookie-nya bisa dipalsukan. String `'dev-secret-key-change-in-production'` ada di GitHub, di [.env.example](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/.env.example:0:0-0:0), ada di tutorial Flask yang gak pernah diganti orang.

Masalahnya: default gak crash dan gak warning. Waktu deploy ke production, lupa set env var `SECRET_KEY` lalu aplikasi jalan normal. Padahal sessionnya bisa dipalsuin dari awal

## Solusi

1. Kalau `SECRET_KEY` env var diset, mending pakai itu supaya behaviour gak berubah
2. Kalau env var kosong jadinya generate key random pakai `secrets.token_hex(32)` (64 karakter hex, cryptographically secure). Log warning biar orang tahu user bakal ke-logout setiap kali app di-restart, jadi mereka harus set env var SECRET_KEY kalau mau session tetap hidup.
3. [app.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/app.py:0:0-0:0) sekarang pakai `config.SECRET_KEY` langsung, bukan baca env var lagi pakai fallback hardcoded yang sama.

## Trade-off

Key yang di-generate otomatis berubah setiap restart. User yang lagi login bakal ke-drop tiap app restart dan lebih baik daripada key yang bocor. Setidaknya di antara restart, session-nya aman dan warningnya cukup jelas: kalau orang baca log, mereka tahu harus set env var.

## Changes

- [config.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/config.py:0:0-0:0) — logic baru buat generate key kalau env var kosong + warning log
- [app.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/app.py:0:0-0:0) — pakai `config.SECRET_KEY` daripada hardcoded fallback

*Not an agent but helped by GLM-5.1