### PR TITLE
fix: remove duplicate _is_safe_redirect_url and correct weekend logic in check _price

### DIFF
--- a/backend/tools/check_price.py
+++ b/backend/tools/check_price.py
@@ -32,7 +32,7 @@ def execute(agent, args: dict) -> dict:
     total = 0
     current = start
     while current < end:
-        is_weekend = current.weekday() in (4, 5, 6)
+        is_weekend = current.weekday() in (5, 6)
         price = rate["weekend"] if is_weekend else rate["weekday"]
         prices.append({
             "date": current.strftime("%Y-%m-%d"),

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -28,23 +28,6 @@ def _is_safe_redirect_url(target):
     return target.startswith('/')
 
 
-def _is_safe_redirect_url(target):
-    """Validate that a redirect target is a safe relative URL.
-
-    Rejects absolute URLs (http://..., https://..., etc.), protocol-relative
-    URLs (//evil.com), and anything else that doesn't start with a single /.
-    This prevents open redirect attacks.
-    """
-    # Reject anything containing :// (catches http://, https://, ftp://, etc.)
-    if '://' in target:
-        return False
-    # Reject protocol-relative URLs (//evil.com)
-    if target.startswith('//'):
-        return False
-    # Must be a relative path starting with /
-    return target.startswith('/')
-
-
 @auth_bp.route('/login', methods=['GET'])
 def login_page():
     if session.get('authenticated'):


### PR DESCRIPTION
Halo Mas, aku izin PR lagi.

Ada duplikat kode di [routes/auth.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/routes/auth.py:0:0-0:0) yaitu fungsi [_is_safe_redirect_url()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/routes/auth.py:13:0-27:33) didefinisikan **dua kali** dengan implementasi identik (line 14-28 dan 31-45). Python cuma pakai definisi terakhir, jadi yang pertama dead code. kalau orang baca file ini, bingung mana yang dipake

Sekalian aku benerin bug di [backend/tools/check_price.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/check_price.py:0:0-0:0). Logika weekend-nya salah:

```python
# Sebelum (salah, Jumat masuk weekend)
is_weekend = current.weekday() in (4, 5, 6)

# Sesudah (benar, cuma Sabtu & Minggu)
is_weekend = current.weekday() in (5, 6)
```

`weekday()` return 0=Senin sampai 6=Minggu, jadi weekend itu `(5, 6)` buat Sabtu-Minggu. Tuple lama `(4, 5, 6)` salah masukin Jumat sebagai weekend.

### Yang berubah
- [routes/auth.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/routes/auth.py:0:0-0:0) — hapus definisi duplikat [_is_safe_redirect_url()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/routes/auth.py:13:0-27:33)
- [backend/tools/check_price.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/check_price.py:0:0-0:0) — perbaiki tuple weekend dari `(4,5,6)` ke `(5,6)`

### Testing
Cukup code review, gak perlu run app.

### Note
Kalo semisal dari Mas-nya emang 4,5,6 sebagai weekend, fairs tinggal revert bagian check_price aja.