### PR TITLE
refactor: extract triplicate file_stat code into shared helpers

### DIFF
--- a/backend/tools/lib/backends/ssh_backend.py
+++ b/backend/tools/lib/backends/ssh_backend.py
@@ -14,7 +14,7 @@ import os
 import shlex
 import time
 
-from backend.tools.lib.exec_backend import ExecutionBackend, truncate
+from backend.tools.lib.exec_backend import ExecutionBackend, truncate, file_stat_code, parse_file_stat_output
 
 logger = logging.getLogger(__name__)
 
@@ -220,31 +220,8 @@ class SSHBackend(ExecutionBackend):
         return r.get('stdout', '').strip() == 'yes'
 
     def file_stat(self, path: str) -> dict:
-        code = f"""
-import os
-p = {repr(path)}
-if not os.path.exists(p):
-    print('exists=0 size=0 is_binary=0')
-else:
-    size = os.path.getsize(p)
-    try:
-        chunk = open(p, 'rb').read(8192)
-        is_binary = b'\\x00' in chunk
-    except Exception:
-        is_binary = True
-    print(f'exists=1 size={{size}} is_binary={{1 if is_binary else 0}}')
-"""
-        r = self.run_python(code, 10, {})
-        out = r.get('stdout', '').strip()
-        try:
-            parts = dict(kv.split('=') for kv in out.split())
-            return {
-                'exists': parts.get('exists') == '1',
-                'size': int(parts.get('size', 0)),
-                'is_binary': parts.get('is_binary') == '1',
-            }
-        except Exception:
-            return {'exists': False, 'size': 0, 'is_binary': False}
+        r = self.run_python(file_stat_code(path), 10, {})
+        return parse_file_stat_output(r.get('stdout', ''))
 
     def read_file(self, path: str) -> dict:
         r = self._exec(f'cat {shlex.quote(path)}', '', 30)

--- a/backend/tools/lib/exec_backend.py
+++ b/backend/tools/lib/exec_backend.py
@@ -35,6 +35,47 @@ def validate_env_keys(env: dict) -> tuple:
     return env, None
 
 
+def file_stat_code(path: str) -> str:
+    """Return a Python code snippet that prints exists/size/is_binary for *path*.
+
+    Used by SSH-based backends (SSHBackend, RemoteWorkplaceBackend,
+    CloudWorkplaceBackend) to query file metadata on a remote host.
+    The snippet prints ``exists=0|1 size=<int> is_binary=0|1`` on a
+    single line, parseable by :func:`parse_file_stat_output`.
+    """
+    return f"""
+import os
+p = {repr(path)}
+if not os.path.exists(p):
+    print('exists=0 size=0 is_binary=0')
+else:
+    size = os.path.getsize(p)
+    try:
+        chunk = open(p, 'rb').read(8192)
+        is_binary = b'\\x00' in chunk
+    except Exception:
+        is_binary = True
+    print(f'exists=1 size={{size}} is_binary={{1 if is_binary else 0}}')
+"""
+
+
+def parse_file_stat_output(output: str) -> dict:
+    """Parse the ``exists=… size=… is_binary=…`` output produced by :func:`file_stat_code`.
+
+    Returns ``{'exists': bool, 'size': int, 'is_binary': bool}``.
+    On parse failure, returns ``{'exists': False, 'size': 0, 'is_binary': False}``.
+    """
+    try:
+        parts = dict(kv.split('=') for kv in output.strip().split())
+        return {
+            'exists': parts.get('exists') == '1',
+            'size': int(parts.get('size', 0)),
+            'is_binary': parts.get('is_binary') == '1',
+        }
+    except Exception:
+        return {'exists': False, 'size': 0, 'is_binary': False}
+
+
 # ---------------------------------------------------------------------------
 # Abstract base
 # ---------------------------------------------------------------------------

--- a/backend/workplaces/backends/cloud_workplace.py
+++ b/backend/workplaces/backends/cloud_workplace.py
@@ -25,7 +25,7 @@ import threading
 import uuid
 import logging
 
-from backend.tools.lib.exec_backend import ExecutionBackend
+from backend.tools.lib.exec_backend import ExecutionBackend, file_stat_code, parse_file_stat_output
 
 _logger = logging.getLogger(__name__)
 
@@ -133,31 +133,8 @@ class CloudWorkplaceBackend(ExecutionBackend):
         return r.get('stdout', '').strip() == 'yes'
 
     def file_stat(self, path: str) -> dict:
-        code = f"""
-import os
-p = {repr(path)}
-if not os.path.exists(p):
-    print('exists=0 size=0 is_binary=0')
-else:
-    size = os.path.getsize(p)
-    try:
-        chunk = open(p, 'rb').read(8192)
-        is_binary = b'\\x00' in chunk
-    except Exception:
-        is_binary = True
-    print(f'exists=1 size={{size}} is_binary={{1 if is_binary else 0}}')
-"""
-        r = self.run_python(code, 10, {})
-        out = r.get('stdout', '').strip()
-        try:
-            parts = dict(kv.split('=') for kv in out.split())
-            return {
-                'exists': parts.get('exists') == '1',
-                'size': int(parts.get('size', 0)),
-                'is_binary': parts.get('is_binary') == '1',
-            }
-        except Exception:
-            return {'exists': False, 'size': 0, 'is_binary': False}
+        r = self.run_python(file_stat_code(path), 10, {})
+        return parse_file_stat_output(r.get('stdout', ''))
 
     def read_file(self, path: str) -> dict:
         r = self._call('read_file', {'path': path}, timeout=30)

--- a/backend/workplaces/backends/remote_workplace.py
+++ b/backend/workplaces/backends/remote_workplace.py
@@ -19,7 +19,7 @@ Config keys expected in workplace.config:
 import base64
 import shlex
 
-from backend.tools.lib.exec_backend import ExecutionBackend
+from backend.tools.lib.exec_backend import ExecutionBackend, file_stat_code, parse_file_stat_output
 
 
 class RemoteWorkplaceBackend(ExecutionBackend):
@@ -91,31 +91,8 @@ class RemoteWorkplaceBackend(ExecutionBackend):
 
     def file_stat(self, path: str) -> dict:
         path = self._resolve_path(path)
-        code = f"""
-import os
-p = {repr(path)}
-if not os.path.exists(p):
-    print('exists=0 size=0 is_binary=0')
-else:
-    size = os.path.getsize(p)
-    try:
-        chunk = open(p, 'rb').read(8192)
-        is_binary = b'\\x00' in chunk
-    except Exception:
-        is_binary = True
-    print(f'exists=1 size={{size}} is_binary={{1 if is_binary else 0}}')
-"""
-        r = self._ssh.run_python(code, 10, {})
-        out = r.get('stdout', '').strip()
-        try:
-            parts = dict(kv.split('=') for kv in out.split())
-            return {
-                'exists': parts.get('exists') == '1',
-                'size': int(parts.get('size', 0)),
-                'is_binary': parts.get('is_binary') == '1',
-            }
-        except Exception:
-            return {'exists': False, 'size': 0, 'is_binary': False}
+        r = self._ssh.run_python(file_stat_code(path), 10, {})
+        return parse_file_stat_output(r.get('stdout', ''))
 
     def read_file(self, path: str) -> dict:
         path = self._resolve_path(path)


### PR DESCRIPTION
Mas, ini PR lanjutan yang tadi.

Aku nemu kode [file_stat()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/backends/ssh_backend.py:221:4-246:67) yang **di-copy-paste 3 kali** di file beda:

1. [backend/tools/lib/backends/ssh_backend.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/backends/ssh_backend.py:0:0-0:0)
2. [backend/workplaces/backends/remote_workplace.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/workplaces/backends/remote_workplace.py:0:0-0:0)
3. [backend/workplaces/backends/cloud_workplace.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/workplaces/backends/cloud_workplace.py:0:0-0:0)

Ketiganya punya inline Python code string yang identik buat cek `exists/size/is_binary`, plus parsing output yang juga sama. Kalau ada bug di satu, harus fix di tiga tempat, ribet.

Jadi aku extract jadi dua helper di [exec_backend.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:0:0-0:0) (modul yang udah di-import sama ketiga backend itu):

- [file_stat_code(path)](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:37:0-58:3) — generate snippet Python buat remote execution
- [parse_file_stat_output(output)](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:61:0-75:63) — parse output `exists=... size=... is_binary=...` jadi dict

Sekarang masing-masing backend cuma 2 baris:

```python
def file_stat(self, path: str) -> dict:
    r = self.run_python(file_stat_code(path), 10, {})
    return parse_file_stat_output(r.get('stdout', ''))
```

Dari ~15 baris per file jadi 2 baris

### Yang berubah
- [backend/tools/lib/exec_backend.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:0:0-0:0) — tambah [file_stat_code()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:37:0-58:3) + [parse_file_stat_output()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/exec_backend.py:61:0-75:63)
- [backend/tools/lib/backends/ssh_backend.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/backends/ssh_backend.py:0:0-0:0) — [file_stat()](cci:1://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/tools/lib/backends/ssh_backend.py:221:4-246:67) pakai shared helper
- [backend/workplaces/backends/remote_workplace.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/workplaces/backends/remote_workplace.py:0:0-0:0) — sama
- [backend/workplaces/backends/cloud_workplace.py](cci:7://file:///D:/Portfolio%20Data/Learning%20PR/evonic/backend/workplaces/backends/cloud_workplace.py:0:0-0:0) — sama

### Testing
No run app, cuman naruh kode yang sama di satu tempat saja.
