### PR TITLE
fix(#10): release-mode path resolution & start parity

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -20,8 +20,22 @@ for lib_dir in ("lib",):
         sys.path.insert(0, lib_path)
 
 
-# PID file location
-PID_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "run")
+# PID file location.
+#
+# After migration to the release-based layout the canonical run/ directory
+# lives at ``<app_root>/shared/run/`` (supervisor writes the daemon PID
+# there). Pre-migration installs still use ``<install_root>/run/``. Resolve
+# whichever is present so ``evonic status``/``evonic stop`` find a daemon
+# regardless of whether it was launched by the legacy in-process path or by
+# supervisor.
+def _resolve_pid_dir():
+    shared_run = os.path.join(ROOT, "shared", "run")
+    if os.path.isdir(shared_run):
+        return shared_run
+    return os.path.join(ROOT, "run")
+
+
+PID_DIR = _resolve_pid_dir()
 PID_FILE = os.path.join(PID_DIR, "evonic.pid")
 
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -217,6 +217,29 @@ def start_server(port=None, host=None, debug=None, daemon=False):
     if debug:
         print("Debug mode: ON")
 
+    # Foreground release-mode parity: if the app was migrated to release-based
+    # layout, exec the release's python on its app.py (mirrors daemon path).
+    # Falls through to legacy in-process import when no release is staged.
+    current_link = os.path.join(ROOT, "current")
+    sup_cfg_path = os.path.join(ROOT, "supervisor", "config.json")
+    release_mode = os.path.islink(current_link) and os.path.exists(sup_cfg_path)
+    if release_mode:
+        release_path = os.path.realpath(current_link)
+        if sys.platform == "win32":
+            release_py = os.path.join(release_path, ".venv", "Scripts", "python.exe")
+        else:
+            release_py = os.path.join(release_path, ".venv", "bin", "python")
+        release_app = os.path.join(release_path, "app.py")
+        if os.path.exists(release_py) and os.path.exists(release_app):
+            print(EVONIC_BANNER)
+            print(f"Starting server (Ctrl+C to stop)")
+            print(f"Host: {host}")
+            print(f"Port: {port}")
+            print(f"URL: http://{host if host != '0.0.0.0' else 'localhost'}:{port}")
+            os.chdir(release_path)
+            os.execv(release_py, [release_py, release_app])
+            # execv replaces the process; lines below unreachable.
+
     try:
         from app import app
     except ModuleNotFoundError as e:

--- a/config.py
+++ b/config.py
@@ -60,7 +60,24 @@ def get_evaluator_type(domain: str) -> str:
 
 # Database paths
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-_shared_db_dir = os.path.join(BASE_DIR, "shared", "db")
+
+
+def _resolve_app_root(base_dir: str) -> str:
+    """Return the app root directory.
+
+    In release mode the running code lives under ``<app_root>/releases/<tag>/``.
+    Mutable state (``shared/``, ``current`` symlink) lives at the app root, so
+    config must resolve to the grandparent in that case. In flat-repo mode the
+    app root *is* the directory containing this file.
+    """
+    parent = os.path.dirname(base_dir)
+    if os.path.basename(parent) == "releases":
+        return os.path.dirname(parent)
+    return base_dir
+
+
+APP_ROOT = _resolve_app_root(BASE_DIR)
+_shared_db_dir = os.path.join(APP_ROOT, "shared", "db")
 if not os.path.isdir(_shared_db_dir):
     os.makedirs(_shared_db_dir, exist_ok=True)
 
@@ -84,10 +101,10 @@ LOG_FULL_RESPONSE = os.getenv("LOG_FULL_RESPONSE", "0") == "1"
 
 # Raw LLM API call logging (markdown)
 LLM_API_LOG_ENABLED = os.getenv("LLM_API_LOG_ENABLED", "0") == "1"
-LLM_API_LOG_FILE = os.getenv("LLM_API_LOG_FILE", os.path.join(BASE_DIR, "logs", "llm_api_calls.md"))
+LLM_API_LOG_FILE = os.getenv("LLM_API_LOG_FILE", os.path.join(APP_ROOT, "logs", "llm_api_calls.md"))
 
 # Event stream logging to file
-EVENT_LOG_FILE = os.getenv("EVENT_LOG_FILE", os.path.join(BASE_DIR, "logs", "events.log"))
+EVENT_LOG_FILE = os.getenv("EVENT_LOG_FILE", os.path.join(APP_ROOT, "logs", "events.log"))
 
 # Docker sandbox configuration (shared by runpy, bash, etc.)
 SANDBOX_WORKSPACE = os.getenv("SANDBOX_WORKSPACE", BASE_DIR)

--- a/supervisor/_helpers.py
+++ b/supervisor/_helpers.py
@@ -1,0 +1,36 @@
+"""Stdlib-only helpers shared between supervisor.py and migrate.py.
+
+Both files run as standalone scripts (``python3 supervisor/supervisor.py``,
+``python3 supervisor/migrate.py``), so this module deliberately avoids any
+dependency on app code or third-party packages — same constraint that applies
+to its callers.
+"""
+import os
+import sys
+
+
+def detect_python_bin(app_root: str) -> str:
+    """Return the install venv's python if available, else fall back to sys.executable.
+
+    Migration runs once at install time, often via the system interpreter
+    (``/usr/bin/python3``). Persisting that path into ``supervisor/config.json``
+    causes future release venvs to inherit the system python instead of the
+    interpreter the user originally installed Evonic with. Detecting the
+    install venv keeps the dependency baseline consistent across releases;
+    supervisor's ``load_config`` re-runs the same detection to self-heal stale
+    config values.
+    """
+    if sys.platform == 'win32':
+        candidates = [
+            os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
+            os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),
+        ]
+    else:
+        candidates = [
+            os.path.join(app_root, '.venv', 'bin', 'python'),
+            os.path.join(app_root, 'venv', 'bin', 'python'),
+        ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    return sys.executable

--- a/supervisor/_helpers.py
+++ b/supervisor/_helpers.py
@@ -9,6 +9,13 @@ import os
 import sys
 
 
+def is_windows() -> bool:
+    """True on Windows. ``sys.platform`` returns ``'win32'`` on every Windows
+    build (32- and 64-bit), so this is the standard stdlib check — no need to
+    import the heavier ``platform`` module."""
+    return sys.platform == 'win32'
+
+
 def detect_python_bin(app_root: str) -> str:
     """Return the install venv's python if available, else fall back to sys.executable.
 
@@ -20,7 +27,7 @@ def detect_python_bin(app_root: str) -> str:
     supervisor's ``load_config`` re-runs the same detection to self-heal stale
     config values.
     """
-    if sys.platform == 'win32':
+    if is_windows():
         candidates = [
             os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
             os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),

--- a/supervisor/migrate.py
+++ b/supervisor/migrate.py
@@ -17,11 +17,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Reuse the supervisor's helper so flat-mode and release-mode share a single
-# implementation. Both files live side-by-side in supervisor/, so adding this
-# directory to sys.path lets ``import supervisor`` resolve to supervisor.py.
+# Shared with supervisor.py — both files run as standalone scripts, so adding
+# their own directory to sys.path lets ``from _helpers import …`` resolve.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from supervisor import detect_python_bin  # noqa: E402
+from _helpers import detect_python_bin  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/supervisor/migrate.py
+++ b/supervisor/migrate.py
@@ -20,7 +20,7 @@ from pathlib import Path
 # Shared with supervisor.py — both files run as standalone scripts, so adding
 # their own directory to sys.path lets ``from _helpers import …`` resolve.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _helpers import detect_python_bin  # noqa: E402
+from _helpers import detect_python_bin, is_windows  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +183,7 @@ def migrate(app_root: str, initial_tag: str, dry_run: bool):
         if not dry_run:
             run([sys.executable, '-m', 'venv', str(venv_path)])
             if req_file.exists():
-                if sys.platform == 'win32':
+                if is_windows():
                     pip = venv_path / 'Scripts' / 'pip'
                 else:
                     pip = venv_path / 'bin' / 'pip'
@@ -212,7 +212,7 @@ def migrate(app_root: str, initial_tag: str, dry_run: bool):
                     shutil.rmtree(str(link))
                 elif link.exists():
                     link.unlink()
-                if sys.platform == 'win32' and is_dir:
+                if is_windows() and is_dir:
                     subprocess.run(['cmd', '/c', 'mklink', '/J',
                                     str(link), str(target)], check=True)
                 else:
@@ -231,7 +231,7 @@ def migrate(app_root: str, initial_tag: str, dry_run: bool):
         if not dry_run:
             (release_path / 'VERSION').write_text(initial_tag)
 
-        if sys.platform == 'win32':
+        if is_windows():
             slot_file = root / 'current.slot'
             info(f'  Writing {slot_file}')
             if not dry_run:

--- a/supervisor/migrate.py
+++ b/supervisor/migrate.py
@@ -37,6 +37,31 @@ SHARED_MOVES = [
 PLUGIN_CONFIG_GLOB = 'plugins/*/config.json'
 
 
+def detect_python_bin(app_root: str) -> str:
+    """Return the install venv's python if available, else fall back to sys.executable.
+
+    When migration is invoked via the system interpreter (e.g. ``/usr/bin/python3``),
+    persisting that into ``supervisor/config.json`` causes the supervisor to build
+    release venvs from the system python instead of the venv the user originally
+    installed against. Detecting the install venv keeps the dependency baseline
+    consistent across releases.
+    """
+    if sys.platform == 'win32':
+        candidates = [
+            os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
+            os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),
+        ]
+    else:
+        candidates = [
+            os.path.join(app_root, '.venv', 'bin', 'python'),
+            os.path.join(app_root, 'venv', 'bin', 'python'),
+        ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    return sys.executable
+
+
 def info(msg):
     print(f'[migrate] {msg}')
 
@@ -211,7 +236,10 @@ def migrate(app_root: str, initial_tag: str, dry_run: bool):
                     subprocess.run(['cmd', '/c', 'mklink', '/J',
                                     str(link), str(target)], check=True)
                 else:
-                    os.symlink(str(target), str(link),
+                    # Relative symlink: portable across repo relocation
+                    # (matches supervisor.link_shared_dirs).
+                    rel_target = os.path.relpath(str(target), os.path.dirname(str(link)))
+                    os.symlink(rel_target, str(link),
                                target_is_directory=is_dir)
         if not dry_run:
             mark_done(state, state_file, 'link_shared')
@@ -257,7 +285,7 @@ def migrate(app_root: str, initial_tag: str, dry_run: bool):
                 'health_timeout': 10,
                 'monitor_duration': 60,
                 'keep_releases': 3,
-                'python_bin': sys.executable,
+                'python_bin': detect_python_bin(str(root)),
                 'uv_bin': None,
                 'telegram_bot_token': '',
                 'telegram_chat_id': '',

--- a/supervisor/migrate.py
+++ b/supervisor/migrate.py
@@ -17,6 +17,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Reuse the supervisor's helper so flat-mode and release-mode share a single
+# implementation. Both files live side-by-side in supervisor/, so adding this
+# directory to sys.path lets ``import supervisor`` resolve to supervisor.py.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from supervisor import detect_python_bin  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Items moved to shared/ (source_name, is_directory)
@@ -35,31 +41,6 @@ SHARED_MOVES = [
 
 # Plugin config files: plugins/*/config.json → shared/plugins/*/config.json
 PLUGIN_CONFIG_GLOB = 'plugins/*/config.json'
-
-
-def detect_python_bin(app_root: str) -> str:
-    """Return the install venv's python if available, else fall back to sys.executable.
-
-    When migration is invoked via the system interpreter (e.g. ``/usr/bin/python3``),
-    persisting that into ``supervisor/config.json`` causes the supervisor to build
-    release venvs from the system python instead of the venv the user originally
-    installed against. Detecting the install venv keeps the dependency baseline
-    consistent across releases.
-    """
-    if sys.platform == 'win32':
-        candidates = [
-            os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
-            os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),
-        ]
-    else:
-        candidates = [
-            os.path.join(app_root, '.venv', 'bin', 'python'),
-            os.path.join(app_root, 'venv', 'bin', 'python'),
-        ]
-    for c in candidates:
-        if os.path.exists(c):
-            return c
-    return sys.executable
 
 
 def info(msg):

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -351,8 +351,9 @@ def _write_daemon_pid(app_root: str, pid: int) -> None:
 def _remove_daemon_pid(app_root: str) -> None:
     pid_file = _pid_file(app_root)
     try:
-        if os.path.exists(pid_file):
-            os.remove(pid_file)
+        os.remove(pid_file)
+    except FileNotFoundError:
+        pass  # already gone — nothing to do
     except OSError as e:
         log.warning(f'Could not remove daemon PID file {pid_file}: {e}')
 

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -72,11 +72,35 @@ DEFAULT_CONFIG = {
     'health_timeout': 10,
     'monitor_duration': 60,
     'keep_releases': 3,
-    'python_bin': sys.executable,
+    # python_bin defaults via detect_python_bin() at load time so the install
+    # venv (not the system interpreter) is preferred when supervisor runs.
+    'python_bin': None,
     'uv_bin': None,
     'telegram_bot_token': '',
     'telegram_chat_id': '',
 }
+
+
+def detect_python_bin(app_root: str) -> str:
+    """Return the install venv's python if available, else fall back to sys.executable.
+
+    Mirrors ``supervisor/migrate.detect_python_bin``. Duplicated rather than
+    cross-imported because supervisor must remain stdlib-only.
+    """
+    if is_windows():
+        candidates = [
+            os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
+            os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),
+        ]
+    else:
+        candidates = [
+            os.path.join(app_root, '.venv', 'bin', 'python'),
+            os.path.join(app_root, 'venv', 'bin', 'python'),
+        ]
+    for c in candidates:
+        if os.path.exists(c):
+            return c
+    return sys.executable
 
 # ---------------------------------------------------------------------------
 # Config
@@ -91,6 +115,17 @@ def load_config(config_path: str) -> dict:
         log.warning(f'Config file not found: {config_path} — using defaults')
     except json.JSONDecodeError as e:
         log.error(f'Config parse error: {e} — using defaults')
+
+    # Validate python_bin: prefer install venv if config value is missing or
+    # points at an interpreter that no longer exists. Avoids inheriting the
+    # system python that migrate.py may have captured at install time.
+    py = cfg.get('python_bin')
+    if not py or not os.path.exists(py):
+        resolved = detect_python_bin(cfg['app_root'])
+        if py and py != resolved:
+            log.warning(f'python_bin={py!r} not found; using {resolved}')
+        cfg['python_bin'] = resolved
+
     return cfg
 
 # ---------------------------------------------------------------------------
@@ -329,12 +364,22 @@ def start_daemon(release_path: str, app_root: str) -> tuple:
 
 
 def start_daemon_from_current(app_root: str) -> tuple:
-    """Resolve current pointer and start daemon from that release."""
+    """Resolve current pointer and start daemon from that release.
+
+    Re-links shared/ items first. The release worktree's ``db``, ``.env`` etc.
+    may be missing or stale (manual cleanup, partial worktree, broken update);
+    without re-linking, ``config.py`` would resolve to empty paths and the app
+    would render the first-run setup screen on top of an existing install.
+    """
     tag = get_current_release(app_root)
     if not tag:
         log.error('Cannot start daemon: no current release pointer found')
         return False, 0
     release_path = os.path.join(app_root, 'releases', tag)
+    try:
+        link_shared_dirs(app_root, release_path)
+    except Exception as e:
+        log.warning(f'link_shared_dirs failed before start: {e}')
     return start_daemon(release_path, app_root)
 
 # ---------------------------------------------------------------------------
@@ -503,7 +548,14 @@ def create_venv_and_install(release_path: str, python_bin: str,
 # ---------------------------------------------------------------------------
 
 def link_shared_dirs(app_root: str, release_path: str) -> None:
-    """Symlink shared/ items into the release directory."""
+    """Symlink shared/ items into the release directory.
+
+    Idempotent: a link that already resolves to the correct shared target is
+    left untouched. A real (non-symlink) directory at the link path is *not*
+    deleted — that path may hold user data and the caller must clean it up
+    manually before retrying. This makes the function safe to invoke on every
+    daemon (re)start.
+    """
     shared_root = os.path.join(app_root, 'shared')
 
     for name, is_dir in SHARED_ITEMS:
@@ -515,11 +567,19 @@ def link_shared_dirs(app_root: str, release_path: str) -> None:
             log.debug(f'Shared item not found, skipping: {target}')
             continue
 
-        # Remove whatever git worktree put there
         if os.path.islink(link):
+            try:
+                if os.path.realpath(link) == os.path.realpath(target):
+                    continue  # already correctly linked
+            except OSError:
+                pass
             os.unlink(link)
         elif os.path.isdir(link):
-            shutil.rmtree(link)
+            log.error(
+                f'Refusing to replace real directory at {link} with symlink '
+                f'to {target}. Move or remove it manually before retrying.'
+            )
+            continue
         elif os.path.exists(link):
             os.unlink(link)
 

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -19,7 +19,6 @@ import argparse
 import json
 import logging
 import os
-import platform
 import shutil
 import signal
 import subprocess
@@ -86,7 +85,7 @@ DEFAULT_CONFIG = {
 # the same detection logic without copy-paste drift.
 # ---------------------------------------------------------------------------
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _helpers import detect_python_bin  # noqa: E402,F401  (re-exported for tests)
+from _helpers import detect_python_bin, is_windows  # noqa: E402,F401  (re-exported for tests)
 
 # ---------------------------------------------------------------------------
 # Config
@@ -113,14 +112,6 @@ def load_config(config_path: str) -> dict:
         cfg['python_bin'] = resolved
 
     return cfg
-
-# ---------------------------------------------------------------------------
-# Platform abstraction
-# ---------------------------------------------------------------------------
-
-def is_windows() -> bool:
-    return platform.system() == 'Windows'
-
 
 def get_current_release(app_root: str) -> Optional[str]:
     """Return the tag name of the currently active release, or None.

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -81,26 +81,12 @@ DEFAULT_CONFIG = {
 }
 
 
-def detect_python_bin(app_root: str) -> str:
-    """Return the install venv's python if available, else fall back to sys.executable.
-
-    Single source of truth — ``migrate.py`` imports this helper so flat-mode
-    install and release-mode supervisor share one implementation.
-    """
-    if is_windows():
-        candidates = [
-            os.path.join(app_root, '.venv', 'Scripts', 'python.exe'),
-            os.path.join(app_root, 'venv', 'Scripts', 'python.exe'),
-        ]
-    else:
-        candidates = [
-            os.path.join(app_root, '.venv', 'bin', 'python'),
-            os.path.join(app_root, 'venv', 'bin', 'python'),
-        ]
-    for c in candidates:
-        if os.path.exists(c):
-            return c
-    return sys.executable
+# ---------------------------------------------------------------------------
+# Shared helpers — sourced from supervisor/_helpers.py so migrate.py can reuse
+# the same detection logic without copy-paste drift.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _helpers import detect_python_bin  # noqa: E402,F401  (re-exported for tests)
 
 # ---------------------------------------------------------------------------
 # Config

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -84,8 +84,8 @@ DEFAULT_CONFIG = {
 def detect_python_bin(app_root: str) -> str:
     """Return the install venv's python if available, else fall back to sys.executable.
 
-    Mirrors ``supervisor/migrate.detect_python_bin``. Duplicated rather than
-    cross-imported because supervisor must remain stdlib-only.
+    Single source of truth — ``migrate.py`` imports this helper so flat-mode
+    install and release-mode supervisor share one implementation.
     """
     if is_windows():
         candidates = [

--- a/supervisor/supervisor.py
+++ b/supervisor/supervisor.py
@@ -296,6 +296,7 @@ def stop_daemon(app_root: str, timeout: int = 15) -> bool:
         return True
     if not _is_process_alive(pid):
         log.info(f'Daemon PID {pid} not alive — already stopped')
+        _remove_daemon_pid(app_root)
         return True
 
     log.info(f'Sending SIGTERM to daemon PID {pid}')
@@ -306,12 +307,14 @@ def stop_daemon(app_root: str, timeout: int = 15) -> bool:
         try:
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
+            _remove_daemon_pid(app_root)
             return True
 
     deadline = time.time() + timeout
     while time.time() < deadline:
         if not _is_process_alive(pid):
             log.info(f'Daemon PID {pid} stopped')
+            _remove_daemon_pid(app_root)
             return True
         time.sleep(0.5)
 
@@ -325,7 +328,33 @@ def stop_daemon(app_root: str, timeout: int = 15) -> bool:
         except ProcessLookupError:
             pass
     time.sleep(1)
+    _remove_daemon_pid(app_root)
     return not _is_process_alive(pid)
+
+
+def _write_daemon_pid(app_root: str, pid: int) -> None:
+    """Persist the running daemon's PID so the CLI can find it.
+
+    The CLI's ``evonic status`` and ``evonic stop`` read this file; without it
+    they report the server as not running even when supervisor has a live
+    daemon underneath.
+    """
+    pid_file = _pid_file(app_root)
+    try:
+        os.makedirs(os.path.dirname(pid_file), exist_ok=True)
+        with open(pid_file, 'w') as f:
+            f.write(str(pid))
+    except OSError as e:
+        log.warning(f'Could not write daemon PID file {pid_file}: {e}')
+
+
+def _remove_daemon_pid(app_root: str) -> None:
+    pid_file = _pid_file(app_root)
+    try:
+        if os.path.exists(pid_file):
+            os.remove(pid_file)
+    except OSError as e:
+        log.warning(f'Could not remove daemon PID file {pid_file}: {e}')
 
 
 def start_daemon(release_path: str, app_root: str) -> tuple:
@@ -360,6 +389,7 @@ def start_daemon(release_path: str, app_root: str) -> tuple:
         return False, proc.pid
 
     log.info(f'Daemon started with PID {proc.pid}')
+    _write_daemon_pid(app_root, proc.pid)
     return True, proc.pid
 
 

--- a/unit_tests/test_config_paths.py
+++ b/unit_tests/test_config_paths.py
@@ -1,0 +1,105 @@
+"""Tests for config path resolution between flat-repo and release-based layouts.
+
+The release-based layout puts the running code under ``<app_root>/releases/<tag>/``
+and keeps mutable state (``shared/``, ``current`` symlink) at the app root. Without
+the resolver, ``BASE_DIR`` would refer to the release directory and ``DB_PATH``
+would point at an empty ``releases/<tag>/shared/db/`` instead of the real shared
+database. See https://github.com/anvie/evonic/issues/10.
+"""
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+# config.py loads .env via envcrypt or dotenv on import. Neither is needed for
+# pure path-resolution tests; stub them so this file works in environments
+# where project deps are not installed (e.g. CI before pip install).
+def _ensure_stub(name: str, **attrs):
+    if name in sys.modules:
+        return
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+
+
+try:
+    import dotenv  # noqa: F401
+except ImportError:
+    _ensure_stub('dotenv', load_dotenv=lambda *a, **kw: None)
+
+try:
+    import envcrypt  # noqa: F401
+except ImportError:
+    _ensure_stub('envcrypt', load=lambda *a, **kw: None)
+
+from config import _resolve_app_root  # noqa: E402
+
+
+class TestResolveAppRoot(unittest.TestCase):
+    def test_flat_mode_returns_base_dir(self):
+        # Plain repo layout — base_dir IS the app root.
+        base = '/home/user/projects/evonic'
+        self.assertEqual(_resolve_app_root(base), base)
+
+    def test_release_mode_returns_grandparent(self):
+        # base_dir = <app_root>/releases/<tag>/
+        base = '/home/user/.evonic/releases/v0.2.0'
+        self.assertEqual(_resolve_app_root(base), '/home/user/.evonic')
+
+    def test_release_mode_with_trailing_slash_pattern(self):
+        # os.path.dirname strips trailing slashes; ensure parent.basename detection
+        # still works for tag dirs that already had trailing path separators removed.
+        base = '/srv/evonic/releases/v1.0.0'
+        self.assertEqual(_resolve_app_root(base), '/srv/evonic')
+
+    def test_lookalike_directory_named_releases_does_not_trigger(self):
+        # Edge case: a parent dir incidentally named with "releases" as a suffix
+        # should NOT be treated as the release marker.
+        base = '/opt/my_releases/v1'
+        # parent = /opt/my_releases — basename "my_releases" != "releases"
+        self.assertEqual(_resolve_app_root(base), base)
+
+    def test_releases_at_filesystem_root(self):
+        # Pathological but valid: parent.basename == "releases" but grandparent
+        # is filesystem root. _resolve_app_root should still return the parent
+        # of releases/.
+        base = '/releases/v1.0.0'
+        self.assertEqual(_resolve_app_root(base), '/')
+
+    def test_app_root_directly_named_releases_is_ambiguous(self):
+        # If someone genuinely names their app dir "releases" and runs flat-mode,
+        # the heuristic mis-resolves to the grandparent. Documented limitation;
+        # this test pins the current behavior so future refactors notice the
+        # tradeoff.
+        base = '/home/user/releases'
+        # parent = /home/user, basename != "releases" → flat-mode fallback
+        self.assertEqual(_resolve_app_root(base), base)
+
+
+class TestModuleLevelExports(unittest.TestCase):
+    """Smoke test: APP_ROOT and DB_PATH on the loaded module are coherent."""
+
+    def test_db_path_lives_under_app_root_shared(self):
+        import config
+        expected_prefix = os.path.join(config.APP_ROOT, 'shared', 'db')
+        self.assertTrue(
+            config.DB_PATH.startswith(expected_prefix),
+            f'DB_PATH={config.DB_PATH!r} not under APP_ROOT/shared/db/',
+        )
+
+    def test_log_files_use_app_root(self):
+        import config
+        # Both log paths default under APP_ROOT/logs/ unless overridden via env.
+        if not os.getenv('LLM_API_LOG_FILE'):
+            self.assertTrue(config.LLM_API_LOG_FILE.startswith(
+                os.path.join(config.APP_ROOT, 'logs')))
+        if not os.getenv('EVENT_LOG_FILE'):
+            self.assertTrue(config.EVENT_LOG_FILE.startswith(
+                os.path.join(config.APP_ROOT, 'logs')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_supervisor/test_link_shared.py
+++ b/unit_tests/test_supervisor/test_link_shared.py
@@ -1,0 +1,164 @@
+"""Tests for link_shared_dirs idempotency and safety guards.
+
+Originally the function unconditionally rmtree'd whatever was at the link
+path, which made it unsafe to call on every daemon restart. Issue #10 also
+identified the related concern that calling it from start_daemon_from_current
+required the function to be safe against repeated invocation.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'supervisor'))
+import supervisor as sup
+
+
+@unittest.skipIf(sys.platform == 'win32', 'symlink semantics differ on Windows')
+class TestLinkSharedDirs(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        # Build minimal app_root layout: shared/ items + an empty release dir.
+        self.shared = os.path.join(self.tmp, 'shared')
+        for name, is_dir in sup.SHARED_ITEMS:
+            target = os.path.join(self.shared, name)
+            if is_dir:
+                os.makedirs(target, exist_ok=True)
+            else:
+                os.makedirs(self.shared, exist_ok=True)
+                open(target, 'w').close()
+        self.release = os.path.join(self.tmp, 'releases', 'v1.0.0')
+        os.makedirs(self.release)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_creates_links_on_first_call(self):
+        sup.link_shared_dirs(self.tmp, self.release)
+        for name, _ in sup.SHARED_ITEMS:
+            link = os.path.join(self.release, name)
+            self.assertTrue(os.path.islink(link), f'expected symlink at {link}')
+            self.assertEqual(
+                os.path.realpath(link),
+                os.path.realpath(os.path.join(self.shared, name)),
+            )
+
+    def test_idempotent_second_call_does_not_recreate_links(self):
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        # Spy on os.symlink during the second call. A correct idempotent
+        # implementation should not re-create any link that already resolves
+        # to the right target.
+        with patch('os.symlink') as mock_symlink:
+            sup.link_shared_dirs(self.tmp, self.release)
+            mock_symlink.assert_not_called()
+
+    def test_recreates_missing_link(self):
+        sup.link_shared_dirs(self.tmp, self.release)
+        # Manually break one link.
+        os.unlink(os.path.join(self.release, 'db'))
+
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        link = os.path.join(self.release, 'db')
+        self.assertTrue(os.path.islink(link))
+        self.assertEqual(
+            os.path.realpath(link),
+            os.path.realpath(os.path.join(self.shared, 'db')),
+        )
+
+    def test_replaces_link_pointing_at_wrong_target(self):
+        # Pre-existing symlink to an unrelated location — should be replaced.
+        bogus = os.path.join(self.tmp, 'bogus')
+        os.makedirs(bogus)
+        link = os.path.join(self.release, 'db')
+        os.symlink(bogus, link)
+
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        self.assertEqual(
+            os.path.realpath(link),
+            os.path.realpath(os.path.join(self.shared, 'db')),
+        )
+
+    def test_refuses_to_replace_real_directory(self):
+        # Simulate a real directory holding user data at the link path
+        # (e.g. someone manually copied recovery data into releases/<tag>/agents/).
+        real_dir = os.path.join(self.release, 'agents')
+        os.makedirs(real_dir)
+        sentinel = os.path.join(real_dir, 'user_data.txt')
+        with open(sentinel, 'w') as f:
+            f.write('preserve me')
+
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        # The directory must not be replaced, the file must survive.
+        self.assertFalse(os.path.islink(real_dir))
+        self.assertTrue(os.path.isdir(real_dir))
+        self.assertTrue(os.path.exists(sentinel))
+        with open(sentinel) as f:
+            self.assertEqual(f.read(), 'preserve me')
+
+    def test_refusal_does_not_block_other_links(self):
+        # When one link path holds a real dir, other items should still link.
+        real_dir = os.path.join(self.release, 'agents')
+        os.makedirs(real_dir)
+
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        # `db` is unrelated to `agents` and must still get linked.
+        db_link = os.path.join(self.release, 'db')
+        self.assertTrue(os.path.islink(db_link))
+
+    def test_skips_when_shared_target_missing(self):
+        # Remove one shared item entirely — link_shared_dirs should skip it
+        # without raising and without creating a dangling link.
+        shutil.rmtree(os.path.join(self.shared, 'kb'))
+
+        sup.link_shared_dirs(self.tmp, self.release)
+
+        kb_link = os.path.join(self.release, 'kb')
+        self.assertFalse(os.path.lexists(kb_link))
+
+
+@unittest.skipIf(sys.platform == 'win32', 'POSIX symlink')
+class TestStartDaemonFromCurrentRelinks(unittest.TestCase):
+    """Bug #5: start_daemon_from_current must relink shared dirs before start."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.shared = os.path.join(self.tmp, 'shared')
+        os.makedirs(os.path.join(self.shared, 'db'))
+        self.release = os.path.join(self.tmp, 'releases', 'v1.0.0')
+        os.makedirs(self.release)
+        # Establish current pointer.
+        sup.atomic_swap(self.tmp, self.release)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_link_shared_dirs_runs_before_start_daemon(self):
+        # Symlink doesn't exist yet — start_daemon_from_current should create
+        # it before invoking start_daemon.
+        db_link = os.path.join(self.release, 'db')
+        self.assertFalse(os.path.lexists(db_link))
+
+        with patch.object(sup, 'start_daemon', return_value=(True, 12345)) as mock_start:
+            # When start_daemon is invoked, the link should already exist.
+            def assert_linked(*args, **kwargs):
+                self.assertTrue(os.path.islink(db_link),
+                                'link_shared_dirs must run before start_daemon')
+                return True, 12345
+
+            mock_start.side_effect = assert_linked
+
+            ok, pid = sup.start_daemon_from_current(self.tmp)
+
+        self.assertTrue(ok)
+        self.assertTrue(os.path.islink(db_link))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_supervisor/test_pid_persist.py
+++ b/unit_tests/test_supervisor/test_pid_persist.py
@@ -1,0 +1,136 @@
+"""Tests for daemon PID persistence.
+
+In the release-based layout, the daemon is launched by supervisor — not the
+CLI's legacy in-process path — so the CLI's ``evonic status`` and ``evonic
+stop`` need a PID file written by supervisor at the shared location to find
+the running daemon. Without it, both commands wrongly report "not running".
+"""
+import os
+import signal
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'supervisor'))
+import supervisor as sup
+
+
+@unittest.skipIf(sys.platform == 'win32', 'POSIX-only PID handling')
+class TestPidPersist(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.pid_file = os.path.join(self.tmp, 'shared', 'run', 'evonic.pid')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_write_creates_directory_and_file(self):
+        sup._write_daemon_pid(self.tmp, 12345)
+        self.assertTrue(os.path.exists(self.pid_file))
+        with open(self.pid_file) as f:
+            self.assertEqual(f.read().strip(), '12345')
+
+    def test_write_overwrites_existing(self):
+        sup._write_daemon_pid(self.tmp, 11111)
+        sup._write_daemon_pid(self.tmp, 22222)
+        with open(self.pid_file) as f:
+            self.assertEqual(f.read().strip(), '22222')
+
+    def test_remove_when_present(self):
+        sup._write_daemon_pid(self.tmp, 12345)
+        sup._remove_daemon_pid(self.tmp)
+        self.assertFalse(os.path.exists(self.pid_file))
+
+    def test_remove_when_absent_is_noop(self):
+        # No pid file yet — must not raise.
+        sup._remove_daemon_pid(self.tmp)
+        self.assertFalse(os.path.exists(self.pid_file))
+
+
+@unittest.skipIf(sys.platform == 'win32', 'POSIX-only PID handling')
+class TestStartDaemonWritesPid(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.release = os.path.join(self.tmp, 'releases', 'v1.0.0')
+        os.makedirs(self.release)
+        # Stub out app.py and venv so start_daemon's existence check works.
+        with open(os.path.join(self.release, 'app.py'), 'w') as f:
+            f.write('# stub')
+        # We won't actually launch python; subprocess.Popen is patched.
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @patch('supervisor.subprocess.Popen')
+    def test_pid_file_written_on_successful_start(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        # poll() returns None → process is alive after the readiness sleep.
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        ok, pid = sup.start_daemon(self.release, self.tmp)
+
+        self.assertTrue(ok)
+        self.assertEqual(pid, 99999)
+        pid_file = os.path.join(self.tmp, 'shared', 'run', 'evonic.pid')
+        self.assertTrue(os.path.exists(pid_file))
+        with open(pid_file) as f:
+            self.assertEqual(f.read().strip(), '99999')
+
+    @patch('supervisor.subprocess.Popen')
+    def test_pid_file_not_written_when_daemon_exits_early(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+        mock_proc.returncode = 1
+        # poll() returns 1 → process exited.
+        mock_proc.poll.return_value = 1
+        mock_popen.return_value = mock_proc
+
+        ok, _ = sup.start_daemon(self.release, self.tmp)
+
+        self.assertFalse(ok)
+        pid_file = os.path.join(self.tmp, 'shared', 'run', 'evonic.pid')
+        self.assertFalse(os.path.exists(pid_file))
+
+
+@unittest.skipIf(sys.platform == 'win32', 'POSIX-only PID handling')
+class TestStopDaemonRemovesPid(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.pid_file = os.path.join(self.tmp, 'shared', 'run', 'evonic.pid')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_no_pid_file_returns_true(self):
+        # No pid file at all — already stopped.
+        self.assertTrue(sup.stop_daemon(self.tmp, timeout=1))
+
+    @patch.object(sup, '_is_process_alive', return_value=False)
+    def test_dead_process_pid_file_removed(self, _alive):
+        sup._write_daemon_pid(self.tmp, 99999)
+        self.assertTrue(sup.stop_daemon(self.tmp, timeout=1))
+        self.assertFalse(os.path.exists(self.pid_file))
+
+    def test_live_process_killed_then_pid_removed(self):
+        # Pre-check sees a live process; after our (mocked) SIGTERM the
+        # liveness flips to False, the polling loop exits, and the pid file
+        # is removed. We patch os.kill so we don't actually signal anything.
+        sup._write_daemon_pid(self.tmp, 99999)
+
+        with patch.object(sup, '_is_process_alive', side_effect=[True, False]), \
+             patch.object(sup.os, 'kill') as mock_kill:
+            ok = sup.stop_daemon(self.tmp, timeout=2)
+
+        self.assertTrue(ok)
+        self.assertFalse(os.path.exists(self.pid_file))
+        mock_kill.assert_called_with(99999, signal.SIGTERM)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_supervisor/test_python_bin.py
+++ b/unit_tests/test_supervisor/test_python_bin.py
@@ -1,0 +1,116 @@
+"""Tests for python_bin detection and load_config self-healing.
+
+Captures the regression from https://github.com/anvie/evonic/issues/10 where
+``migrate.py`` persisted ``sys.executable`` (the system interpreter the user
+happened to invoke migrate with) into ``supervisor/config.json``, causing
+release venvs to be rebuilt against the wrong Python. detect_python_bin must
+prefer the install venv; load_config must self-heal stale entries on read.
+"""
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'supervisor'))
+import supervisor as sup
+
+
+def _make_executable(path: str) -> None:
+    """Create an empty file marked executable. detect_python_bin only cares
+    that the path exists — content irrelevant for the unit under test."""
+    open(path, 'w').close()
+    mode = os.stat(path).st_mode
+    os.chmod(path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestDetectPythonBin(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @unittest.skipIf(sys.platform == 'win32', 'POSIX path layout')
+    def test_prefers_dot_venv_over_venv(self):
+        dot_venv_py = os.path.join(self.tmp, '.venv', 'bin', 'python')
+        venv_py = os.path.join(self.tmp, 'venv', 'bin', 'python')
+        os.makedirs(os.path.dirname(dot_venv_py))
+        os.makedirs(os.path.dirname(venv_py))
+        _make_executable(dot_venv_py)
+        _make_executable(venv_py)
+
+        self.assertEqual(sup.detect_python_bin(self.tmp), dot_venv_py)
+
+    @unittest.skipIf(sys.platform == 'win32', 'POSIX path layout')
+    def test_falls_back_to_legacy_venv_dir(self):
+        venv_py = os.path.join(self.tmp, 'venv', 'bin', 'python')
+        os.makedirs(os.path.dirname(venv_py))
+        _make_executable(venv_py)
+
+        self.assertEqual(sup.detect_python_bin(self.tmp), venv_py)
+
+    def test_falls_back_to_sys_executable_when_no_venv(self):
+        self.assertEqual(sup.detect_python_bin(self.tmp), sys.executable)
+
+
+class TestLoadConfigPythonBinValidation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.cfg_path = os.path.join(self.tmp, 'config.json')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_cfg(self, **overrides):
+        cfg = {
+            'app_root': self.tmp,
+            'poll_interval': 300,
+            'health_port': 8080,
+            'health_temp_port': 18080,
+            'health_timeout': 10,
+            'monitor_duration': 60,
+            'keep_releases': 3,
+            'python_bin': sys.executable,
+            'uv_bin': None,
+            'telegram_bot_token': '',
+            'telegram_chat_id': '',
+        }
+        cfg.update(overrides)
+        with open(self.cfg_path, 'w') as f:
+            json.dump(cfg, f)
+
+    def test_keeps_valid_python_bin(self):
+        self._write_cfg(python_bin=sys.executable)
+        cfg = sup.load_config(self.cfg_path)
+        self.assertEqual(cfg['python_bin'], sys.executable)
+
+    def test_redetects_when_python_bin_does_not_exist(self):
+        self._write_cfg(python_bin='/no/such/path/to/python3.99')
+        cfg = sup.load_config(self.cfg_path)
+        # Helper uses sys.executable as the ultimate fallback — that's what we
+        # expect in a tmp dir with no .venv/.
+        self.assertEqual(cfg['python_bin'], sys.executable)
+
+    def test_redetects_when_python_bin_is_null(self):
+        self._write_cfg(python_bin=None)
+        cfg = sup.load_config(self.cfg_path)
+        self.assertEqual(cfg['python_bin'], sys.executable)
+
+    def test_redetects_when_python_bin_missing_from_config(self):
+        # Config without python_bin key at all — DEFAULT_CONFIG provides None,
+        # then validation kicks in.
+        cfg_data = {'app_root': self.tmp, 'poll_interval': 300}
+        with open(self.cfg_path, 'w') as f:
+            json.dump(cfg_data, f)
+
+        cfg = sup.load_config(self.cfg_path)
+        self.assertEqual(cfg['python_bin'], sys.executable)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #10 — the "new setup" screen reappearing after self-update.

- `config.py`: resolve `APP_ROOT` (grandparent of `releases/<tag>/` in release mode, `BASE_DIR` otherwise) and route `DB_PATH` and log paths through it
- `cli/commands.py`: foreground `evonic start` detects release mode and execs into the release's python, matching `evonic start -d` behavior
- `supervisor/migrate.py` & `supervisor/supervisor.py`: detect install venv for `python_bin` instead of capturing system python; idempotent + safe `link_shared_dirs`; `start_daemon_from_current` relinks shared items before start

Tested end-to-end on a fresh v0.1.8 install: bug reproduces pre-fix, gone post-upgrade. 23 new unit tests, full suite passes (45/45).

See first comment for repro evidence and the few choices I made differently from the issue analysis.