### PR TITLE
fix: restore load_dotenv() in config.py for non-app.py entrypoints

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,16 +6,26 @@ import logging
 _envcrypt_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib', 'envcrypt', 'libs', 'python')
 sys.path.append(_envcrypt_path)
 
-# Only try envcrypt if the config file (~/.envcrypt.yaml) exists
-# Note: load_dotenv() for plain .env is handled by the entrypoint (app.py)
-# before importing config, so it's not needed here.
+# Load .env from the config module itself so every entrypoint gets it —
+# not just app.py. The CLI (`evonic`), supervisor subprocesses, management
+# scripts, and tests all import config without going through app.py, so
+# relying on a single load_dotenv() in app.py leaves them with an empty
+# environment and falls back to hardcoded defaults (e.g. PORT=8080).
+#
+# Calling load_dotenv() here is safe even when app.py also calls it: python-dotenv
+# defaults to override=False, so a second call is a no-op for variables that
+# already exist in os.environ. No duplicate work, no surprises.
 _envcrypt_config = os.path.join(os.path.expanduser('~'), '.envcrypt.yaml')
 if os.path.exists(_envcrypt_config):
     try:
         import envcrypt
         envcrypt.load(".env")
     except Exception:
-        pass  # .env already loaded by the entrypoint
+        from dotenv import load_dotenv
+        load_dotenv()
+else:
+    from dotenv import load_dotenv
+    load_dotenv()
 
 _logger = logging.getLogger(__name__)
 
@@ -94,44 +104,22 @@ if not os.path.isdir(_shared_db_dir):
 DB_PATH = os.path.join(_shared_db_dir, "evonic.db")
 TEST_DB_PATH = os.path.join(BASE_DIR, "seed", "test_db.sqlite")
 
-# Flask — SECRET_KEY: auto-generate once and persist to .env if missing
+# Flask — SECRET_KEY: auto-generate once and persist to .env if missing.
+# The previous manual .env regex scanner (added when load_dotenv() was absent
+# from config.py) is gone — load_dotenv() above already makes SECRET_KEY
+# visible via os.getenv() for every entrypoint.
 _SECRET_KEY_ENV = os.getenv("SECRET_KEY")
-if not _SECRET_KEY_ENV:
-    # Double-check: maybe .env has SECRET_KEY but the env var wasn't loaded yet
-    # (e.g. daemonized subprocess, systemd, or restart via exec)
-    import re as _re
-    _env_path = os.path.join(BASE_DIR, ".env")
-    _found_in_file = False
-    if os.path.exists(_env_path):
-        try:
-            with open(_env_path, "r") as _f:
-                for _line in _f:
-                    _stripped = _line.strip()
-                    if not _stripped or _stripped.startswith("#"):
-                        continue
-                    _m = _re.match(r"^SECRET_KEY=(.+)", _stripped)
-                    if _m:
-                        _SECRET_KEY_ENV = _m.group(1).strip()
-                        _found_in_file = True
-                        _logger.info("Loaded SECRET_KEY from .env file")
-                        break
-        except Exception:
-            pass
-
 if not _SECRET_KEY_ENV:
     import secrets
     import tempfile
 
     _SECRET_KEY_ENV = secrets.token_urlsafe(48)
+    _env_path = os.path.join(BASE_DIR, ".env")
 
     # Atomic write: update existing .env or create a new one
-    if _found_in_file and os.path.exists(_env_path):
-        # SECRET_KEY was found in .env but couldn't be parsed — do NOT append duplicate
-        _logger.warning(".env has SECRET_KEY but value could not be read; generating new one anyway")
     if os.path.exists(_env_path):
         with open(_env_path, "r") as _f:
             _lines = _f.readlines()
-        # Append SECRET_KEY (it's not present since the env var was empty)
         if _lines and not _lines[-1].endswith("\n"):
             _lines.append("\n")
         _lines.append(f"SECRET_KEY={_SECRET_KEY_ENV}\n")


### PR DESCRIPTION
This PR restores `load_dotenv()` in `config.py` to fix a regression where customized `.env` values get silently ignored on most entrypoints. Also removes a now-unreachable workaround for `SECRET_KEY` that existed because of the same root cause.

## The bug

```
$ cat .env
HOST=127.0.0.1
PORT=20129

$ evonic start
Starting server (Ctrl+C to stop)
Host: 0.0.0.0
Port: 8080      # <-- ignored .env, fell back to hardcoded defaults
```

`.env` set custom host/port, but the server boots on `0.0.0.0:8080`. `evonic status` shows the same mismatch — reports 8080 even when the server was started with explicit `--port` flags.

## Root cause

Traced it to 4a6093c (`#165 [FINDING-014] Remove redundant load_dotenv() calls from config.py`). The reasoning was "app.py already loads .env before importing config, so it's redundant" — true for `python app.py`, but not for the other entrypoints:

| Entrypoint | Loads `.env`? |
|---|---|
| `app.py` | Yes |
| `cli/__main__.py` (`evonic`) | No |
| `supervisor/supervisor.py` | No |
| `run_improve.py`, `scripts/manage_*.py` | No |
| Test suite | No |

Once `config.py` stopped loading `.env`, all of these silently fell back to hardcoded defaults. `evonic start` resolves port/host *before* spawning the subprocess, and `python-dotenv` defaults to `override=False` — so the pre-set env from the parent wins over `.env` in the child too.

Side note: 7e8235d already hit this same root cause and band-aided it for `SECRET_KEY` only (manual `.env` regex scan in config.py). Other vars never got the same treatment.

## About the "redundant" worry

There are now two `load_dotenv()` calls (`app.py:8` and `config.py`). This is safe — `python-dotenv` defaults to `override=False`, so the second call is a no-op for variables already in `os.environ`. No double parsing, no overwrite.

Mental model: **`config.py` consumes env vars, so it self-loads.** Entrypoints can optionally pre-load if they need env *before* importing config (which `app.py` does, for `configure_logging()` and `EVONIC_LOG_QUIET`).

## Cleanup: SECRET_KEY scanner

The manual `.env` regex scanner from 7e8235d is removed. With `load_dotenv()` running in `config.py`, `os.getenv("SECRET_KEY")` already returns the value from `.env` directly — the scanner's branch was unreachable. Auto-generate + atomic write logic is preserved for the genuinely-missing case.

If there's another reason `load_dotenv()` was removed in #165, let me know — happy to revisit.