### PR TITLE
fix: forward sub-agent replies to parent agent

### DIFF
--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -673,7 +673,16 @@ def run_tool_loop(agent: Dict[str, Any],
                                     'content': content or '(No response)',
                                     'metadata': {'thinking_duration': _dup_dur, 'loop_terminated': True}})
                     chatlog.append({'type': 'turn_end', 'session_id': session_id, 'thinking_duration': _dup_dur})
-                    return content or "(No response)", tool_trace, timeline
+                    # Emit final_answer so auto-forward (e.g. sub-agent → parent) still fires
+                    # on this hard-stop exit path. Without this, sub-agent replies are silently lost.
+                    _final_loop_term = content or "(No response)"
+                    event_stream.emit('final_answer', {
+                        'agent_id': agent_id, 'session_id': session_id,
+                        'external_user_id': external_user_id, 'channel_id': channel_id,
+                        'answer': _final_loop_term, 'tool_trace': tool_trace, 'timeline': timeline,
+                        'loop_terminated': True,
+                    })
+                    return _final_loop_term, tool_trace, timeline
             else:
                 _last_intermediate_text = content
                 _intermediate_dup_count = 0

--- a/backend/tools/agent_messaging.py
+++ b/backend/tools/agent_messaging.py
@@ -312,15 +312,32 @@ def _exec_send_agent_message(args: dict, agent_context: dict) -> dict:
     # Fix: fall back to the sender's most recent human session so the reply chain
     # always terminates in a human-visible session.
     if report_to_id.startswith(_AGENT_MSG_PREFIX):
+        # Sub-agents are ephemeral / in-memory only — they have no row in `agents`
+        # and no human session in `chat_sessions`. Resolve to the parent agent first
+        # so the human-session lookup actually finds something.
+        lookup_id = sender_id
+        if agent_context.get('is_subagent'):
+            parent_id_for_lookup = agent_context.get('parent_id', '')
+            if parent_id_for_lookup:
+                lookup_id = parent_id_for_lookup
+                _logger.debug(
+                    "sender '%s' is a sub-agent — using parent '%s' for human-session lookup.",
+                    sender_id, parent_id_for_lookup,
+                )
         _logger.debug(
-            "sender '%s' is in inter-agent session ('%s') — looking up human session for report_to_id.",
-            sender_id, report_to_id,
+            "sender '%s' is in inter-agent session ('%s') — looking up human session for report_to_id (lookup_id=%s).",
+            sender_id, report_to_id, lookup_id,
         )
-        human_sess = db.get_latest_human_session(sender_id)
+        human_sess = db.get_latest_human_session(lookup_id)
         if human_sess:
             report_to_id = human_sess.get('external_user_id', '')
             report_to_channel_id = human_sess.get('channel_id') or ''
         else:
+            _logger.warning(
+                "send_agent_message: no human session found for sender '%s' (lookup_id=%s). "
+                "Reply auto-forward will be skipped.",
+                sender_id, lookup_id,
+            )
             report_to_id = ''
             report_to_channel_id = ''
 


### PR DESCRIPTION
## Summary

Fix sub-agent replies being silently dropped before reaching the parent agent.

Refs anvie/evonic#21

## Root cause

Two independent bugs along the same code path:

1. **`backend/tools/agent_messaging.py`** — when a sub-agent calls `send_agent_message` (typically the auto-forward of its final answer back to its parent), the code looked up the human session via `db.get_latest_human_session(sender_id)`. Sub-agents are ephemeral / in-memory only — they have no row in `agents` and no record in `chat_sessions`, so the lookup returned `None`, `report_to_id` was left empty, and the message was dropped.

2. **`backend/agent_runtime/llm_loop.py`** — the `loop_terminated` exit path returned the answer directly without emitting a `final_answer` event. The auto-forward hook that relays a sub-agent's final answer to its parent listens on `final_answer`, so sub-agent results never made it out when the loop exited via this branch.

## Fix

- `agent_messaging.py`: when the sender is a sub-agent (detected via `agent_context['is_subagent']`), resolve the human-session lookup against `parent_id` instead of the ephemeral sub-agent id. Also added a `warning` log when no human session is found so this kind of silent drop is observable in production.
- `llm_loop.py`: emit `final_answer` on the `loop_terminated` exit path so the auto-forward hook fires regardless of which exit path the loop takes.

## Verification

Tested end-to-end on a live Evonic instance after the patch:

- Parent agent calls `subagent_spawn(task=...)`.
- Sub-agent processes the task, hits the `loop_terminated` exit path, emits `final_answer`.
- Parent agent receives the reply as an automatic incoming message — no polling, no `subagent_list()` workaround.

Before the patch, the same flow produced no reply at all.

## Notes

- `skills/subagent/backend/tools/subagent_spawn.py` was inspected but did not need changes — it already passes the correct `parent_id` into the sub-agent context.
- No new tests added; this path is exercised by the live sub-agent flow and there is no existing test harness for the messaging loop in this repo. Happy to add one if maintainers want.

---
*Issue discovery and root-cause analysis assisted by an AI agent; the patch was authored and verified by a human.*
