### PR TITLE
feat(plugins,skills): add update check and version comparison

### DIFF
--- a/backend/plugin_update_manager.py
+++ b/backend/plugin_update_manager.py
@@ -1,0 +1,277 @@
+"""
+Plugin and Skill Update Manager
+
+Provides update checking and installation for plugins and skills.
+Supports version comparison and update notifications.
+"""
+
+import logging
+import os
+import re
+from typing import Dict, Any, List, Optional, Tuple
+
+_logger = logging.getLogger(__name__)
+
+
+def _parse_version(version_str: str) -> Tuple[int, ...]:
+    """
+    Parse a semantic version string into a comparable tuple.
+    
+    Examples:
+        "1.0.0" -> (1, 0, 0, 0)
+        "2.1" -> (2, 1, 0, 0)
+        "1.0.0-beta" -> (1, 0, 0, -1)  # pre-release versions sort lower
+    
+    Returns:
+        Tuple of integers for comparison. Invalid versions return (0, 0, 0, 0).
+    """
+    if not version_str or not isinstance(version_str, str):
+        return (0, 0, 0, 0)
+    
+    # Remove 'v' prefix if present
+    version_str = version_str.strip().lower()
+    if version_str.startswith('v'):
+        version_str = version_str[1:]
+    
+    # Split on '-' to separate pre-release suffix
+    parts = version_str.split('-', 1)
+    version_part = parts[0]
+    is_prerelease = len(parts) > 1
+    
+    # Parse numeric version parts
+    try:
+        numbers = []
+        for part in version_part.split('.'):
+            if part.isdigit():
+                numbers.append(int(part))
+            else:
+                break
+        
+        # Pad to at least 3 parts
+        while len(numbers) < 3:
+            numbers.append(0)
+        
+        # Add pre-release marker (sorts before stable)
+        # Use -1 for pre-release, 0 for stable so pre-release < stable
+        if is_prerelease:
+            numbers.append(-1)
+        else:
+            numbers.append(0)
+        
+        return tuple(numbers)
+    except (ValueError, AttributeError):
+        return (0, 0, 0, 0)
+
+
+def compare_versions(current: str, latest: str) -> int:
+    """
+    Compare two version strings.
+    
+    Returns:
+        1 if latest > current (update available)
+        0 if latest == current (up to date)
+        -1 if latest < current (current is newer)
+    """
+    current_tuple = _parse_version(current)
+    latest_tuple = _parse_version(latest)
+    
+    if latest_tuple > current_tuple:
+        return 1
+    elif latest_tuple < current_tuple:
+        return -1
+    else:
+        return 0
+
+
+class PluginUpdateManager:
+    """Manages plugin updates and version checking."""
+    
+    def __init__(self):
+        from backend.plugin_lifecycle import PluginManager
+        self.plugin_manager = PluginManager()
+    
+    def check_plugin_updates(self) -> List[Dict[str, Any]]:
+        """
+        Check for available updates for all installed plugins.
+        
+        Returns:
+            List of plugins with available updates, each containing:
+            - id: plugin identifier
+            - name: plugin display name
+            - current_version: currently installed version
+            - latest_version: available version
+            - update_available: boolean
+            - update_url: URL to download update (if available)
+        """
+        updates = []
+        plugins = self.plugin_manager.list_plugins()
+        
+        for plugin in plugins:
+            plugin_id = plugin.get('id', '')
+            current_version = plugin.get('version', '0.0.0')
+            
+            # Check for update info in manifest
+            update_info = plugin.get('update', {})
+            if not update_info:
+                continue
+            
+            latest_version = update_info.get('latest_version')
+            update_url = update_info.get('url')
+            
+            if not latest_version:
+                continue
+            
+            # Compare versions
+            comparison = compare_versions(current_version, latest_version)
+            
+            if comparison > 0:  # Update available
+                updates.append({
+                    'id': plugin_id,
+                    'name': plugin.get('name', plugin_id),
+                    'current_version': current_version,
+                    'latest_version': latest_version,
+                    'update_available': True,
+                    'update_url': update_url,
+                    'category': plugin.get('category', 'general'),
+                })
+        
+        return updates
+    
+    def get_plugin_update_status(self, plugin_id: str) -> Dict[str, Any]:
+        """
+        Get update status for a specific plugin.
+        
+        Returns:
+            Dictionary with update information or error.
+        """
+        plugin = self.plugin_manager.get_plugin(plugin_id)
+        if not plugin:
+            return {'error': f'Plugin not found: {plugin_id}'}
+        
+        current_version = plugin.get('version', '0.0.0')
+        update_info = plugin.get('update', {})
+        
+        if not update_info:
+            return {
+                'id': plugin_id,
+                'current_version': current_version,
+                'update_available': False,
+                'message': 'No update information available',
+            }
+        
+        latest_version = update_info.get('latest_version')
+        if not latest_version:
+            return {
+                'id': plugin_id,
+                'current_version': current_version,
+                'update_available': False,
+                'message': 'No version information in update manifest',
+            }
+        
+        comparison = compare_versions(current_version, latest_version)
+        
+        return {
+            'id': plugin_id,
+            'name': plugin.get('name', plugin_id),
+            'current_version': current_version,
+            'latest_version': latest_version,
+            'update_available': comparison > 0,
+            'update_url': update_info.get('url'),
+            'changelog': update_info.get('changelog'),
+        }
+
+
+class SkillUpdateManager:
+    """Manages skill updates and version checking."""
+    
+    def __init__(self):
+        from backend.skills_manager import skills_manager
+        self.skills_manager = skills_manager
+    
+    def check_skill_updates(self) -> List[Dict[str, Any]]:
+        """
+        Check for available updates for all installed skills.
+        
+        Returns:
+            List of skills with available updates.
+        """
+        updates = []
+        skills = self.skills_manager.list_skills()
+        
+        for skill in skills:
+            skill_id = skill.get('id', '')
+            current_version = skill.get('version', '0.0.0')
+            
+            # Check for update info in manifest
+            update_info = skill.get('update', {})
+            if not update_info:
+                continue
+            
+            latest_version = update_info.get('latest_version')
+            update_url = update_info.get('url')
+            
+            if not latest_version:
+                continue
+            
+            # Compare versions
+            comparison = compare_versions(current_version, latest_version)
+            
+            if comparison > 0:  # Update available
+                updates.append({
+                    'id': skill_id,
+                    'name': skill.get('name', skill_id),
+                    'current_version': current_version,
+                    'latest_version': latest_version,
+                    'update_available': True,
+                    'update_url': update_url,
+                })
+        
+        return updates
+    
+    def get_skill_update_status(self, skill_id: str) -> Dict[str, Any]:
+        """
+        Get update status for a specific skill.
+        
+        Returns:
+            Dictionary with update information or error.
+        """
+        skill = self.skills_manager.get_skill(skill_id)
+        if not skill:
+            return {'error': f'Skill not found: {skill_id}'}
+        
+        current_version = skill.get('version', '0.0.0')
+        update_info = skill.get('update', {})
+        
+        if not update_info:
+            return {
+                'id': skill_id,
+                'current_version': current_version,
+                'update_available': False,
+                'message': 'No update information available',
+            }
+        
+        latest_version = update_info.get('latest_version')
+        if not latest_version:
+            return {
+                'id': skill_id,
+                'current_version': current_version,
+                'update_available': False,
+                'message': 'No version information in update manifest',
+            }
+        
+        comparison = compare_versions(current_version, latest_version)
+        
+        return {
+            'id': skill_id,
+            'name': skill.get('name', skill_id),
+            'current_version': current_version,
+            'latest_version': latest_version,
+            'update_available': comparison > 0,
+            'update_url': update_info.get('url'),
+            'changelog': update_info.get('changelog'),
+        }
+
+
+# Singleton instances
+plugin_update_manager = PluginUpdateManager()
+skill_update_manager = SkillUpdateManager()

--- a/routes/plugins.py
+++ b/routes/plugins.py
@@ -8,6 +8,7 @@ import zipfile
 from flask import Blueprint, render_template, jsonify, request, redirect, send_file
 from backend.plugin_manager import plugin_manager
 from backend.plugin_lifecycle import PLUGINS_DIR
+from backend.plugin_update_manager import plugin_update_manager
 from backend.zip_validator import validate_upload_zip, MAX_UPLOAD_BYTES
 
 plugins_bp = Blueprint('plugins', __name__)
@@ -185,3 +186,19 @@ def api_delete_plugin(plugin_id):
     if 'error' in result:
         return jsonify(result), 400
     return jsonify(result)
+
+
+@plugins_bp.route('/api/plugins/updates/check')
+def api_check_plugin_updates():
+    """Check for available updates for all installed plugins."""
+    updates = plugin_update_manager.check_plugin_updates()
+    return jsonify({'updates': updates, 'count': len(updates)})
+
+
+@plugins_bp.route('/api/plugins/<plugin_id>/updates/status')
+def api_get_plugin_update_status(plugin_id):
+    """Get update status for a specific plugin."""
+    status = plugin_update_manager.get_plugin_update_status(plugin_id)
+    if 'error' in status:
+        return jsonify(status), 404
+    return jsonify(status)

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from flask import Blueprint, render_template, jsonify, request, redirect, url_for
 from backend.skills_manager import skills_manager
+from backend.plugin_update_manager import skill_update_manager
 from backend.skillsets import list_skillsets, get_skillset, resolve_skillset, apply_skillset, update_skillset
 from backend.zip_validator import validate_upload_zip, MAX_UPLOAD_BYTES
 
@@ -313,3 +314,19 @@ def edit_skillset_page(skill_id):
 def edit_skillset_page_legacy(skill_id):
     """Legacy redirect for old edit URL."""
     return redirect(f'/skillset/{skill_id}')
+
+
+@skills_bp.route('/api/skills/updates/check')
+def api_check_skill_updates():
+    """Check for available updates for all installed skills."""
+    updates = skill_update_manager.check_skill_updates()
+    return jsonify({'updates': updates, 'count': len(updates)})
+
+
+@skills_bp.route('/api/skills/<skill_id>/updates/status')
+def api_get_skill_update_status(skill_id):
+    """Get update status for a specific skill."""
+    status = skill_update_manager.get_skill_update_status(skill_id)
+    if 'error' in status:
+        return jsonify(status), 404
+    return jsonify(status)

--- a/unit_tests/test_plugin_update_manager.py
+++ b/unit_tests/test_plugin_update_manager.py
@@ -1,0 +1,366 @@
+"""
+Unit tests for plugin and skill update manager.
+
+Tests version comparison logic, update checking, and status retrieval.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from backend.plugin_update_manager import (
+    _parse_version,
+    compare_versions,
+    PluginUpdateManager,
+    SkillUpdateManager,
+    plugin_update_manager,
+    skill_update_manager,
+)
+
+
+class TestVersionParsing:
+    """Test version string parsing."""
+    
+    def test_parse_standard_semver(self):
+        """Test parsing standard semantic versions."""
+        assert _parse_version("1.0.0") == (1, 0, 0, 0)
+        assert _parse_version("2.1.3") == (2, 1, 3, 0)
+        assert _parse_version("10.20.30") == (10, 20, 30, 0)
+    
+    def test_parse_short_versions(self):
+        """Test parsing versions with fewer than 3 parts."""
+        assert _parse_version("1.0") == (1, 0, 0, 0)
+        assert _parse_version("2") == (2, 0, 0, 0)
+        assert _parse_version("3.5") == (3, 5, 0, 0)
+    
+    def test_parse_with_v_prefix(self):
+        """Test parsing versions with 'v' prefix."""
+        assert _parse_version("v1.0.0") == (1, 0, 0, 0)
+        assert _parse_version("V2.1.3") == (2, 1, 3, 0)
+        assert _parse_version("v3.5") == (3, 5, 0, 0)
+    
+    def test_parse_prerelease_versions(self):
+        """Test parsing pre-release versions."""
+        assert _parse_version("1.0.0-beta") == (1, 0, 0, -1)
+        assert _parse_version("2.1.0-alpha") == (2, 1, 0, -1)
+        assert _parse_version("1.0.0-rc.1") == (1, 0, 0, -1)
+    
+    def test_parse_invalid_versions(self):
+        """Test parsing invalid version strings."""
+        assert _parse_version("") == (0, 0, 0, 0)
+        assert _parse_version(None) == (0, 0, 0, 0)
+        assert _parse_version("invalid") == (0, 0, 0, 0)
+        assert _parse_version("abc.def.ghi") == (0, 0, 0, 0)
+    
+    def test_parse_with_whitespace(self):
+        """Test parsing versions with whitespace."""
+        assert _parse_version("  1.0.0  ") == (1, 0, 0, 0)
+        assert _parse_version("\t2.1.3\n") == (2, 1, 3, 0)
+
+
+class TestVersionComparison:
+    """Test version comparison logic."""
+    
+    def test_compare_equal_versions(self):
+        """Test comparing equal versions."""
+        assert compare_versions("1.0.0", "1.0.0") == 0
+        assert compare_versions("2.1.3", "2.1.3") == 0
+        assert compare_versions("v1.0.0", "1.0.0") == 0
+    
+    def test_compare_newer_version_available(self):
+        """Test when update is available (latest > current)."""
+        assert compare_versions("1.0.0", "1.0.1") == 1
+        assert compare_versions("1.0.0", "1.1.0") == 1
+        assert compare_versions("1.0.0", "2.0.0") == 1
+        assert compare_versions("1.9.9", "2.0.0") == 1
+    
+    def test_compare_current_is_newer(self):
+        """Test when current version is newer than latest."""
+        assert compare_versions("1.0.1", "1.0.0") == -1
+        assert compare_versions("2.0.0", "1.9.9") == -1
+        assert compare_versions("1.1.0", "1.0.5") == -1
+    
+    def test_compare_prerelease_versions(self):
+        """Test comparing pre-release versions."""
+        # Pre-release should be less than stable (so stable is an "update")
+        assert compare_versions("1.0.0-beta", "1.0.0") == 1  # beta -> stable is an update
+        assert compare_versions("1.0.0", "1.0.0-beta") == -1  # stable -> beta is downgrade
+        
+        # Pre-release versions are equal to each other (we don't parse the suffix detail)
+        assert compare_versions("1.0.0-alpha", "1.0.0-beta") == 0
+    
+    def test_compare_short_versions(self):
+        """Test comparing versions with different lengths."""
+        assert compare_versions("1.0", "1.0.0") == 0
+        assert compare_versions("1", "1.0.0") == 0
+        assert compare_versions("2.1", "2.1.3") == 1
+    
+    def test_compare_with_v_prefix(self):
+        """Test comparing versions with 'v' prefix."""
+        assert compare_versions("v1.0.0", "v1.0.1") == 1
+        assert compare_versions("1.0.0", "v1.0.0") == 0
+
+
+class TestPluginUpdateManager:
+    """Test PluginUpdateManager functionality."""
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_check_plugin_updates_no_updates(self, mock_pm_class):
+        """Test checking for updates when none are available."""
+        mock_pm = Mock()
+        mock_pm.list_plugins.return_value = [
+            {
+                'id': 'test-plugin',
+                'name': 'Test Plugin',
+                'version': '1.0.0',
+                'category': 'general',
+            }
+        ]
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        updates = manager.check_plugin_updates()
+        
+        assert updates == []
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_check_plugin_updates_with_updates(self, mock_pm_class):
+        """Test checking for updates when updates are available."""
+        mock_pm = Mock()
+        mock_pm.list_plugins.return_value = [
+            {
+                'id': 'test-plugin',
+                'name': 'Test Plugin',
+                'version': '1.0.0',
+                'category': 'general',
+                'update': {
+                    'latest_version': '1.1.0',
+                    'url': 'https://example.com/update.zip',
+                }
+            }
+        ]
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        updates = manager.check_plugin_updates()
+        
+        assert len(updates) == 1
+        assert updates[0]['id'] == 'test-plugin'
+        assert updates[0]['current_version'] == '1.0.0'
+        assert updates[0]['latest_version'] == '1.1.0'
+        assert updates[0]['update_available'] is True
+        assert updates[0]['update_url'] == 'https://example.com/update.zip'
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_check_plugin_updates_current_is_newer(self, mock_pm_class):
+        """Test when current version is newer than 'latest'."""
+        mock_pm = Mock()
+        mock_pm.list_plugins.return_value = [
+            {
+                'id': 'test-plugin',
+                'name': 'Test Plugin',
+                'version': '2.0.0',
+                'category': 'general',
+                'update': {
+                    'latest_version': '1.5.0',
+                    'url': 'https://example.com/update.zip',
+                }
+            }
+        ]
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        updates = manager.check_plugin_updates()
+        
+        # Should not include plugins where current > latest
+        assert updates == []
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_check_plugin_updates_multiple_plugins(self, mock_pm_class):
+        """Test checking updates for multiple plugins."""
+        mock_pm = Mock()
+        mock_pm.list_plugins.return_value = [
+            {
+                'id': 'plugin-1',
+                'name': 'Plugin 1',
+                'version': '1.0.0',
+                'category': 'general',
+                'update': {
+                    'latest_version': '1.1.0',
+                    'url': 'https://example.com/p1.zip',
+                }
+            },
+            {
+                'id': 'plugin-2',
+                'name': 'Plugin 2',
+                'version': '2.0.0',
+                'category': 'tools',
+                # No update info
+            },
+            {
+                'id': 'plugin-3',
+                'name': 'Plugin 3',
+                'version': '1.5.0',
+                'category': 'general',
+                'update': {
+                    'latest_version': '2.0.0',
+                    'url': 'https://example.com/p3.zip',
+                }
+            },
+        ]
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        updates = manager.check_plugin_updates()
+        
+        assert len(updates) == 2
+        assert updates[0]['id'] == 'plugin-1'
+        assert updates[1]['id'] == 'plugin-3'
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_get_plugin_update_status_not_found(self, mock_pm_class):
+        """Test getting update status for non-existent plugin."""
+        mock_pm = Mock()
+        mock_pm.get_plugin.return_value = None
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        status = manager.get_plugin_update_status('nonexistent')
+        
+        assert 'error' in status
+        assert 'not found' in status['error'].lower()
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_get_plugin_update_status_no_update_info(self, mock_pm_class):
+        """Test getting update status when no update info is available."""
+        mock_pm = Mock()
+        mock_pm.get_plugin.return_value = {
+            'id': 'test-plugin',
+            'name': 'Test Plugin',
+            'version': '1.0.0',
+        }
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        status = manager.get_plugin_update_status('test-plugin')
+        
+        assert status['id'] == 'test-plugin'
+        assert status['current_version'] == '1.0.0'
+        assert status['update_available'] is False
+        assert 'No update information' in status['message']
+    
+    @patch('backend.plugin_lifecycle.PluginManager')
+    def test_get_plugin_update_status_with_update(self, mock_pm_class):
+        """Test getting update status when update is available."""
+        mock_pm = Mock()
+        mock_pm.get_plugin.return_value = {
+            'id': 'test-plugin',
+            'name': 'Test Plugin',
+            'version': '1.0.0',
+            'update': {
+                'latest_version': '1.1.0',
+                'url': 'https://example.com/update.zip',
+                'changelog': 'Bug fixes and improvements',
+            }
+        }
+        mock_pm_class.return_value = mock_pm
+        
+        manager = PluginUpdateManager()
+        status = manager.get_plugin_update_status('test-plugin')
+        
+        assert status['id'] == 'test-plugin'
+        assert status['current_version'] == '1.0.0'
+        assert status['latest_version'] == '1.1.0'
+        assert status['update_available'] is True
+        assert status['update_url'] == 'https://example.com/update.zip'
+        assert status['changelog'] == 'Bug fixes and improvements'
+
+
+class TestSkillUpdateManager:
+    """Test SkillUpdateManager functionality."""
+    
+    def test_check_skill_updates_no_updates(self):
+        """Test checking for skill updates when none are available."""
+        with patch('backend.skills_manager.skills_manager') as mock_sm:
+            mock_sm.list_skills.return_value = [
+                {
+                    'id': 'test-skill',
+                    'name': 'Test Skill',
+                    'version': '1.0.0',
+                }
+            ]
+            
+            manager = SkillUpdateManager()
+            updates = manager.check_skill_updates()
+            
+            assert updates == []
+    
+    def test_check_skill_updates_with_updates(self):
+        """Test checking for skill updates when updates are available."""
+        with patch('backend.skills_manager.skills_manager') as mock_sm:
+            mock_sm.list_skills.return_value = [
+                {
+                    'id': 'test-skill',
+                    'name': 'Test Skill',
+                    'version': '1.0.0',
+                    'update': {
+                        'latest_version': '1.2.0',
+                        'url': 'https://example.com/skill-update.zip',
+                    }
+                }
+            ]
+            
+            manager = SkillUpdateManager()
+            updates = manager.check_skill_updates()
+            
+            assert len(updates) == 1
+            assert updates[0]['id'] == 'test-skill'
+            assert updates[0]['current_version'] == '1.0.0'
+            assert updates[0]['latest_version'] == '1.2.0'
+            assert updates[0]['update_available'] is True
+    
+    def test_get_skill_update_status_not_found(self):
+        """Test getting update status for non-existent skill."""
+        with patch('backend.skills_manager.skills_manager') as mock_sm:
+            mock_sm.get_skill.return_value = None
+            
+            manager = SkillUpdateManager()
+            status = manager.get_skill_update_status('nonexistent')
+            
+            assert 'error' in status
+            assert 'not found' in status['error'].lower()
+    
+    def test_get_skill_update_status_with_update(self):
+        """Test getting update status when update is available."""
+        with patch('backend.skills_manager.skills_manager') as mock_sm:
+            mock_sm.get_skill.return_value = {
+                'id': 'test-skill',
+                'name': 'Test Skill',
+                'version': '1.0.0',
+                'update': {
+                    'latest_version': '1.5.0',
+                    'url': 'https://example.com/skill.zip',
+                    'changelog': 'New features added',
+                }
+            }
+            
+            manager = SkillUpdateManager()
+            status = manager.get_skill_update_status('test-skill')
+            
+            assert status['id'] == 'test-skill'
+            assert status['current_version'] == '1.0.0'
+            assert status['latest_version'] == '1.5.0'
+            assert status['update_available'] is True
+            assert status['changelog'] == 'New features added'
+
+
+class TestSingletonInstances:
+    """Test that singleton instances are properly initialized."""
+    
+    def test_plugin_update_manager_singleton(self):
+        """Test plugin_update_manager singleton exists."""
+        assert plugin_update_manager is not None
+        assert isinstance(plugin_update_manager, PluginUpdateManager)
+    
+    def test_skill_update_manager_singleton(self):
+        """Test skill_update_manager singleton exists."""
+        assert skill_update_manager is not None
+        assert isinstance(skill_update_manager, SkillUpdateManager)


### PR DESCRIPTION
## Problem

Right now there's no way to check if plugins or skills have updates available. Users have to manually track versions or check external sources to know when new versions are released. This makes it hard to keep plugins and skills up to date.

## What This PR Does

This adds version checking infrastructure for both plugins and skills. The system can now:
- Parse and compare semantic versions
- Check if updates are available for installed plugins/skills
- Provide update information through REST API endpoints

## Implementation Details

### New Module: `plugin_update_manager.py`

Created a new module that handles all version comparison logic:

**Version Parsing:**
- Supports standard semver: `1.0.0`, `2.1.3`, `10.20.30`
- Handles short versions: `1.0` → `1.0.0`, `2` → `2.0.0`
- Strips v-prefix: `v1.0.0` → `1.0.0`
- Recognizes pre-release tags: `1.0.0-beta`, `2.1.0-alpha`, `1.0.0-rc.1`
- Pre-release versions correctly sort before stable: `1.0.0-beta < 1.0.0`

**Version Comparison:**
- Returns `1` if update available (latest > current)
- Returns `0` if up to date (latest == current)
- Returns `-1` if current is newer (latest < current)

**Manager Classes:**
- `PluginUpdateManager` - checks plugin updates via `plugin_lifecycle.PluginManager`
- `SkillUpdateManager` - checks skill updates via `skills_manager`
- Both expose singleton instances: `plugin_update_manager` and `skill_update_manager`

### New API Endpoints

Added four new REST endpoints:

**Plugin Endpoints:**
- `GET /api/plugins/updates/check`
  - Lists all plugins with available updates
  - Returns: `{updates: [...], count: N}`
  - Each update includes: id, name, current_version, latest_version, update_url, category

- `GET /api/plugins/<plugin_id>/updates/status`
  - Checks update status for a specific plugin
  - Returns: current_version, latest_version, update_available (bool), update_url, changelog
  - Returns 404 if plugin not found

**Skill Endpoints:**
- `GET /api/skills/updates/check`
  - Lists all skills with available updates
  - Returns: `{updates: [...], count: N}`
  - Each update includes: id, name, current_version, latest_version, update_url

- `GET /api/skills/<skill_id>/updates/status`
  - Checks update status for a specific skill
  - Returns: current_version, latest_version, update_available (bool), update_url, changelog
  - Returns 404 if skill not found

### How It Works

The update manager reads the `update` field from plugin/skill manifests:

```json
{
  "id": "my-plugin",
  "version": "1.0.0",
  "update": {
    "latest_version": "1.1.0",
    "url": "https://example.com/my-plugin-v1.1.0.zip",
    "changelog": "Bug fixes and improvements"
  }
}
```

When checking for updates:
1. Reads current version from manifest
2. Reads latest_version from update field
3. Compares versions using semantic versioning rules
4. Returns update info if latest > current

## Testing

Added comprehensive unit tests in `unit_tests/test_plugin_update_manager.py`:

**Test Coverage (25 tests total):**
- ✅ Version parsing (6 tests)
  - Standard semver, short versions, v-prefix, pre-release, invalid versions, whitespace handling
- ✅ Version comparison (6 tests)
  - Equal versions, newer available, current is newer, pre-release handling, short versions, v-prefix
- ✅ Plugin update checking (7 tests)
  - No updates, updates available, current newer than latest, multiple plugins, not found, no update info, with update
- ✅ Skill update checking (4 tests)
  - No updates, updates available, not found, with update
- ✅ Singleton instances (2 tests)

All 25 tests passing.

**Test Examples:**
```python
# Version parsing
assert _parse_version("1.0.0") == (1, 0, 0, 0)
assert _parse_version("v2.1.3") == (2, 1, 3, 0)
assert _parse_version("1.0.0-beta") == (1, 0, 0, -1)

# Version comparison
assert compare_versions("1.0.0", "1.0.1") == 1  # update available
assert compare_versions("1.0.0", "1.0.0") == 0  # up to date
assert compare_versions("2.0.0", "1.9.9") == -1  # current is newer
```

## What's NOT Included

This PR focuses on the core checking logic only. The following are intentionally left for future PRs:

- ❌ UI components to display update notifications in the frontend
- ❌ Actual download and installation of updates
- ❌ Background scheduler to check for updates periodically
- ❌ Update notification system (email, in-app alerts, etc.)
- ❌ Auto-update functionality

These can be added incrementally once the core version checking logic is reviewed and merged.

## Files Changed

- `backend/plugin_update_manager.py` - 277 lines (new file)
- `routes/plugins.py` - 17 lines added (2 new endpoints)
- `routes/skills.py` - 17 lines added (2 new endpoints)
- `unit_tests/test_plugin_update_manager.py` - 366 lines (new file)

**Total:** 677 lines added across 4 files

## How to Test Manually

1. Start the evonic server
2. Install a plugin/skill with an `update` field in its manifest
3. Call the update check endpoints:

```bash
# Check all plugin updates
curl http://localhost:5000/api/plugins/updates/check

# Check specific plugin
curl http://localhost:5000/api/plugins/my-plugin/updates/status

# Check all skill updates
curl http://localhost:5000/api/skills/updates/check

# Check specific skill
curl http://localhost:5000/api/skills/my-skill/updates/status
```

## Future Work

After this PR is merged, follow-up PRs could add:
1. Frontend UI to display update notifications
2. One-click update installation
3. Background update checker (runs every 24h)
4. Update history/changelog viewer
5. Rollback functionality for failed updates
