### PR TITLE
security(plugins): add cryptographic signature verification

### DIFF
--- a/backend/plugin_lifecycle.py
+++ b/backend/plugin_lifecycle.py
@@ -437,6 +437,13 @@ class PluginManager:
         """Install a plugin from a zip file."""
         if not zipfile.is_zipfile(zip_path):
             return {'error': 'Not a valid zip file'}
+        
+        # Validate zip file including signature verification
+        from backend.zip_validator import validate_upload_zip
+        ok, error_msg = validate_upload_zip(zip_path, verify_signature=True)
+        if not ok:
+            _logger.error("Plugin zip validation failed: %s", error_msg)
+            return {'error': error_msg}
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             with zipfile.ZipFile(zip_path, 'r') as zf:

--- a/backend/plugin_signer.py
+++ b/backend/plugin_signer.py
@@ -1,0 +1,344 @@
+"""
+Plugin Code Signing — cryptographic signature verification for plugins.
+
+Provides GPG-based signature verification to ensure plugins are from trusted
+sources and haven't been tampered with. This prevents supply chain attacks
+and malicious plugin installation.
+
+Signature Format:
+- Plugins must include a `plugin.sig` file containing a detached GPG signature
+- The signature covers the entire plugin.zip file (excluding the signature itself)
+- Signatures are verified against a trusted keyring
+
+Setup:
+1. Generate a GPG key pair for plugin signing:
+   gpg --gen-key
+
+2. Export the public key to the trusted keyring:
+   gpg --export --armor <key-id> > plugins/trusted_keys.asc
+
+3. Sign a plugin:
+   gpg --detach-sign --armor -o plugin.sig plugin.zip
+
+4. Include plugin.sig in the plugin distribution
+"""
+
+import os
+import subprocess
+import tempfile
+import logging
+from typing import Tuple, Optional
+
+_logger = logging.getLogger(__name__)
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLUGINS_DIR = os.path.join(BASE_DIR, 'plugins')
+TRUSTED_KEYS_FILE = os.path.join(PLUGINS_DIR, 'trusted_keys.asc')
+
+
+class SignatureVerificationError(Exception):
+    """Raised when signature verification fails."""
+    pass
+
+
+def is_gpg_available() -> bool:
+    """
+    Check if GPG is available on the system.
+    
+    Returns:
+        bool: True if gpg command is available, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            ['gpg', '--version'],
+            capture_output=True,
+            timeout=5,
+            check=False
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def has_trusted_keys() -> bool:
+    """
+    Check if trusted keys file exists.
+    
+    Returns:
+        bool: True if trusted_keys.asc exists and is non-empty
+    """
+    if not os.path.isfile(TRUSTED_KEYS_FILE):
+        return False
+    
+    try:
+        stat = os.stat(TRUSTED_KEYS_FILE)
+        return stat.st_size > 0
+    except OSError:
+        return False
+
+
+def is_signature_verification_enabled() -> bool:
+    """
+    Check if signature verification is enabled.
+    
+    Verification is enabled when:
+    1. GPG is available on the system
+    2. Trusted keys file exists
+    3. PLUGIN_SIGNATURE_REQUIRED setting is not explicitly disabled
+    
+    Returns:
+        bool: True if verification should be enforced
+    """
+    # Check if explicitly disabled via environment variable
+    import os as env_os
+    if env_os.environ.get('PLUGIN_SIGNATURE_REQUIRED', '').lower() == 'false':
+        return False
+    
+    # Check database setting
+    try:
+        from models.db import db
+        setting = db.get_setting('plugin_signature_required')
+        if setting == '0':
+            return False
+        elif setting == '1':
+            # Explicitly enabled, check prerequisites
+            if not is_gpg_available():
+                _logger.warning("Plugin signature verification enabled but GPG not available")
+                return False
+            if not has_trusted_keys():
+                _logger.warning("Plugin signature verification enabled but no trusted keys found")
+                return False
+            return True
+    except Exception as e:
+        _logger.debug("Could not check plugin_signature_required setting: %s", e)
+    
+    # Default: enable if GPG and keys are available
+    return is_gpg_available() and has_trusted_keys()
+
+
+def verify_plugin_signature(plugin_zip_path: str, signature_path: Optional[str] = None) -> Tuple[bool, str]:
+    """
+    Verify the GPG signature of a plugin zip file.
+    
+    Args:
+        plugin_zip_path: Path to the plugin zip file
+        signature_path: Optional path to signature file. If None, looks for
+                       plugin_zip_path + '.sig' or plugin_zip_path + '.asc'
+    
+    Returns:
+        Tuple of (success: bool, message: str)
+        - (True, "Signature valid") if verification succeeds
+        - (False, error_message) if verification fails
+    
+    Raises:
+        SignatureVerificationError: If verification is required but fails
+    """
+    # Check if verification is enabled
+    if not is_signature_verification_enabled():
+        _logger.debug("Plugin signature verification is disabled")
+        return True, "Signature verification disabled"
+    
+    # Check if GPG is available
+    if not is_gpg_available():
+        msg = "GPG not available for signature verification"
+        _logger.error(msg)
+        return False, msg
+    
+    # Check if trusted keys exist
+    if not has_trusted_keys():
+        msg = f"No trusted keys found at {TRUSTED_KEYS_FILE}"
+        _logger.error(msg)
+        return False, msg
+    
+    # Find signature file
+    if signature_path is None:
+        # Try common signature file extensions
+        for ext in ['.sig', '.asc']:
+            candidate = plugin_zip_path + ext
+            if os.path.isfile(candidate):
+                signature_path = candidate
+                break
+    
+    if signature_path is None or not os.path.isfile(signature_path):
+        msg = f"No signature file found for {plugin_zip_path}"
+        _logger.error(msg)
+        return False, msg
+    
+    # Create temporary GPG home directory for isolated verification
+    with tempfile.TemporaryDirectory(prefix='gpg_verify_') as temp_gnupg:
+        try:
+            # Import trusted keys into temporary keyring
+            import_result = subprocess.run(
+                [
+                    'gpg',
+                    '--homedir', temp_gnupg,
+                    '--batch',
+                    '--yes',
+                    '--import',
+                    TRUSTED_KEYS_FILE
+                ],
+                capture_output=True,
+                timeout=30,
+                check=False
+            )
+            
+            if import_result.returncode != 0:
+                msg = f"Failed to import trusted keys: {import_result.stderr.decode('utf-8', errors='replace')}"
+                _logger.error(msg)
+                return False, msg
+            
+            # Verify signature
+            verify_result = subprocess.run(
+                [
+                    'gpg',
+                    '--homedir', temp_gnupg,
+                    '--batch',
+                    '--status-fd', '1',
+                    '--verify',
+                    signature_path,
+                    plugin_zip_path
+                ],
+                capture_output=True,
+                timeout=30,
+                check=False
+            )
+            
+            stdout = verify_result.stdout.decode('utf-8', errors='replace')
+            stderr = verify_result.stderr.decode('utf-8', errors='replace')
+            
+            # Check for GOODSIG in status output
+            if verify_result.returncode == 0 and '[GNUPG:] GOODSIG' in stdout:
+                # Extract signer info
+                signer = "unknown"
+                for line in stdout.split('\n'):
+                    if '[GNUPG:] GOODSIG' in line:
+                        parts = line.split('[GNUPG:] GOODSIG', 1)
+                        if len(parts) > 1:
+                            signer = parts[1].strip()
+                        break
+                
+                msg = f"Signature valid (signed by: {signer})"
+                _logger.info(msg)
+                return True, msg
+            else:
+                # Signature verification failed
+                msg = f"Signature verification failed: {stderr}"
+                _logger.error(msg)
+                return False, msg
+        
+        except subprocess.TimeoutExpired:
+            msg = "GPG verification timed out"
+            _logger.error(msg)
+            return False, msg
+        
+        except Exception as e:
+            msg = f"Signature verification error: {e}"
+            _logger.error(msg, exc_info=True)
+            return False, msg
+
+
+def create_plugin_signature(plugin_zip_path: str, key_id: Optional[str] = None, output_path: Optional[str] = None) -> Tuple[bool, str]:
+    """
+    Create a detached GPG signature for a plugin zip file.
+    
+    This is a helper function for plugin developers to sign their plugins.
+    
+    Args:
+        plugin_zip_path: Path to the plugin zip file to sign
+        key_id: Optional GPG key ID to use for signing. If None, uses default key
+        output_path: Optional output path for signature. If None, uses plugin_zip_path + '.sig'
+    
+    Returns:
+        Tuple of (success: bool, message: str)
+    """
+    if not is_gpg_available():
+        return False, "GPG not available"
+    
+    if not os.path.isfile(plugin_zip_path):
+        return False, f"Plugin file not found: {plugin_zip_path}"
+    
+    if output_path is None:
+        output_path = plugin_zip_path + '.sig'
+    
+    try:
+        cmd = ['gpg', '--detach-sign', '--armor', '-o', output_path]
+        
+        if key_id:
+            cmd.extend(['--local-user', key_id])
+        
+        cmd.append(plugin_zip_path)
+        
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=60,
+            check=False
+        )
+        
+        if result.returncode == 0:
+            msg = f"Signature created: {output_path}"
+            _logger.info(msg)
+            return True, msg
+        else:
+            msg = f"Failed to create signature: {result.stderr.decode('utf-8', errors='replace')}"
+            _logger.error(msg)
+            return False, msg
+    
+    except subprocess.TimeoutExpired:
+        return False, "GPG signing timed out"
+    
+    except Exception as e:
+        msg = f"Signature creation error: {e}"
+        _logger.error(msg, exc_info=True)
+        return False, msg
+
+
+def get_signature_status() -> dict:
+    """
+    Get the current status of signature verification system.
+    
+    Returns:
+        dict with keys:
+        - enabled: bool, whether verification is enabled
+        - gpg_available: bool, whether GPG is installed
+        - has_trusted_keys: bool, whether trusted keys are configured
+        - trusted_keys_path: str, path to trusted keys file
+        - key_count: int, number of trusted keys (if available)
+    """
+    status = {
+        'enabled': is_signature_verification_enabled(),
+        'gpg_available': is_gpg_available(),
+        'has_trusted_keys': has_trusted_keys(),
+        'trusted_keys_path': TRUSTED_KEYS_FILE,
+        'key_count': 0
+    }
+    
+    # Try to count keys in trusted keyring
+    if status['gpg_available'] and status['has_trusted_keys']:
+        try:
+            with tempfile.TemporaryDirectory(prefix='gpg_status_') as temp_gnupg:
+                # Import keys
+                subprocess.run(
+                    ['gpg', '--homedir', temp_gnupg, '--batch', '--yes', '--import', TRUSTED_KEYS_FILE],
+                    capture_output=True,
+                    timeout=10,
+                    check=False
+                )
+                
+                # List keys
+                result = subprocess.run(
+                    ['gpg', '--homedir', temp_gnupg, '--batch', '--list-keys', '--with-colons'],
+                    capture_output=True,
+                    timeout=10,
+                    check=False
+                )
+                
+                if result.returncode == 0:
+                    # Count 'pub' lines (public keys)
+                    output = result.stdout.decode('utf-8', errors='replace')
+                    status['key_count'] = output.count('\npub:')
+        
+        except Exception as e:
+            _logger.debug("Could not count trusted keys: %s", e)
+    
+    return status

--- a/backend/zip_validator.py
+++ b/backend/zip_validator.py
@@ -1,11 +1,15 @@
 """
 Shared zip upload validation — enforces size limits, zip bomb protection,
-path traversal checks, and allowed file types for plugin/skill uploads.
+path traversal checks, allowed file types, and optional signature verification
+for plugin/skill uploads.
 """
 
 import os
 import zipfile
 from typing import Dict, Optional, Tuple
+import logging
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -28,12 +32,35 @@ ALLOWED_EXTENSIONS = {
 }
 
 
-def validate_upload_zip(file_path: str, expected_filename: Optional[str] = None) -> Tuple[bool, str]:
+def validate_upload_zip(file_path: str, expected_filename: Optional[str] = None, verify_signature: bool = False) -> Tuple[bool, str]:
     """
     Validate a zip file before extraction for plugin/skill uploads.
-
+    
+    Args:
+        file_path: Path to the zip file to validate
+        expected_filename: Optional expected filename (unused, for future use)
+        verify_signature: If True, verify GPG signature for plugins
+    
     Returns (ok, error_message).  ok=True means the zip is safe to extract.
     """
+    # --- 0. Signature verification (if requested) ---------------------------
+    if verify_signature:
+        try:
+            from backend.plugin_signer import verify_plugin_signature, is_signature_verification_enabled
+            
+            if is_signature_verification_enabled():
+                sig_ok, sig_msg = verify_plugin_signature(file_path)
+                if not sig_ok:
+                    _logger.error("Signature verification failed for %s: %s", file_path, sig_msg)
+                    return False, f"Signature verification failed: {sig_msg}"
+                else:
+                    _logger.info("Signature verified for %s: %s", file_path, sig_msg)
+        except ImportError:
+            _logger.warning("plugin_signer module not available, skipping signature verification")
+        except Exception as e:
+            _logger.error("Signature verification error for %s: %s", file_path, e, exc_info=True)
+            return False, f"Signature verification error: {e}"
+    
     # --- 1. File exists + size check ----------------------------------------
     try:
         stat = os.stat(file_path)

--- a/unit_tests/test_plugin_signer.py
+++ b/unit_tests/test_plugin_signer.py
@@ -1,0 +1,296 @@
+"""
+Unit tests for plugin signature verification.
+"""
+
+import os
+import tempfile
+import zipfile
+import pytest
+from unittest.mock import patch, MagicMock
+from backend.plugin_signer import (
+    is_gpg_available,
+    has_trusted_keys,
+    is_signature_verification_enabled,
+    verify_plugin_signature,
+    get_signature_status,
+    SignatureVerificationError,
+    TRUSTED_KEYS_FILE
+)
+
+
+class TestGPGAvailability:
+    """Test GPG availability detection."""
+    
+    def test_is_gpg_available_when_installed(self):
+        """Test GPG detection when gpg is installed."""
+        # This test will pass or fail based on actual system state
+        # We just verify the function returns a boolean
+        result = is_gpg_available()
+        assert isinstance(result, bool)
+    
+    @patch('subprocess.run')
+    def test_is_gpg_available_when_not_installed(self, mock_run):
+        """Test GPG detection when gpg is not installed."""
+        mock_run.side_effect = FileNotFoundError()
+        result = is_gpg_available()
+        assert result is False
+    
+    @patch('subprocess.run')
+    def test_is_gpg_available_when_timeout(self, mock_run):
+        """Test GPG detection when command times out."""
+        import subprocess
+        mock_run.side_effect = subprocess.TimeoutExpired('gpg', 5)
+        result = is_gpg_available()
+        assert result is False
+
+
+class TestTrustedKeys:
+    """Test trusted keys detection."""
+    
+    def test_has_trusted_keys_when_missing(self):
+        """Test trusted keys detection when file doesn't exist."""
+        # Temporarily patch TRUSTED_KEYS_FILE to non-existent path
+        with patch('backend.plugin_signer.TRUSTED_KEYS_FILE', '/nonexistent/path/trusted_keys.asc'):
+            result = has_trusted_keys()
+            assert result is False
+    
+    def test_has_trusted_keys_when_empty(self):
+        """Test trusted keys detection when file is empty."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.asc') as f:
+            temp_path = f.name
+        
+        try:
+            with patch('backend.plugin_signer.TRUSTED_KEYS_FILE', temp_path):
+                result = has_trusted_keys()
+                assert result is False
+        finally:
+            os.unlink(temp_path)
+    
+    def test_has_trusted_keys_when_exists(self):
+        """Test trusted keys detection when file exists with content."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.asc') as f:
+            f.write("-----BEGIN PGP PUBLIC KEY BLOCK-----\ntest\n-----END PGP PUBLIC KEY BLOCK-----\n")
+            temp_path = f.name
+        
+        try:
+            with patch('backend.plugin_signer.TRUSTED_KEYS_FILE', temp_path):
+                result = has_trusted_keys()
+                assert result is True
+        finally:
+            os.unlink(temp_path)
+
+
+class TestSignatureVerificationEnabled:
+    """Test signature verification enabled detection."""
+    
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_enabled_when_prerequisites_met(self, mock_has_keys, mock_gpg):
+        """Test verification enabled when GPG and keys are available."""
+        mock_gpg.return_value = True
+        mock_has_keys.return_value = True
+        
+        # Mock database to return no explicit setting
+        with patch('models.db.db') as mock_db:
+            mock_db.get_setting.return_value = None
+            result = is_signature_verification_enabled()
+            assert result is True
+    
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_disabled_when_gpg_missing(self, mock_has_keys, mock_gpg):
+        """Test verification disabled when GPG is not available."""
+        mock_gpg.return_value = False
+        mock_has_keys.return_value = True
+        
+        result = is_signature_verification_enabled()
+        assert result is False
+    
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_disabled_when_keys_missing(self, mock_has_keys, mock_gpg):
+        """Test verification disabled when trusted keys are missing."""
+        mock_gpg.return_value = True
+        mock_has_keys.return_value = False
+        
+        result = is_signature_verification_enabled()
+        assert result is False
+    
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_disabled_by_env_variable(self, mock_has_keys, mock_gpg):
+        """Test verification disabled by environment variable."""
+        mock_gpg.return_value = True
+        mock_has_keys.return_value = True
+        
+        with patch.dict(os.environ, {'PLUGIN_SIGNATURE_REQUIRED': 'false'}):
+            result = is_signature_verification_enabled()
+            assert result is False
+    
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_disabled_by_database_setting(self, mock_has_keys, mock_gpg):
+        """Test verification disabled by database setting."""
+        mock_gpg.return_value = True
+        mock_has_keys.return_value = True
+        
+        with patch('models.db.db') as mock_db:
+            mock_db.get_setting.return_value = '0'
+            result = is_signature_verification_enabled()
+            assert result is False
+
+
+class TestVerifyPluginSignature:
+    """Test plugin signature verification."""
+    
+    def test_verify_when_disabled(self):
+        """Test verification passes when disabled."""
+        with patch('backend.plugin_signer.is_signature_verification_enabled', return_value=False):
+            success, msg = verify_plugin_signature('/fake/path.zip')
+            assert success is True
+            assert 'disabled' in msg.lower()
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    def test_verify_fails_when_gpg_missing(self, mock_gpg, mock_enabled):
+        """Test verification fails when GPG is not available."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = False
+        
+        success, msg = verify_plugin_signature('/fake/path.zip')
+        assert success is False
+        assert 'GPG not available' in msg
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_verify_fails_when_keys_missing(self, mock_keys, mock_gpg, mock_enabled):
+        """Test verification fails when trusted keys are missing."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = True
+        mock_keys.return_value = False
+        
+        success, msg = verify_plugin_signature('/fake/path.zip')
+        assert success is False
+        assert 'No trusted keys' in msg
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_verify_fails_when_signature_missing(self, mock_keys, mock_gpg, mock_enabled):
+        """Test verification fails when signature file is missing."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = True
+        mock_keys.return_value = True
+        
+        with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as f:
+            zip_path = f.name
+        
+        try:
+            success, msg = verify_plugin_signature(zip_path)
+            assert success is False
+            assert 'No signature file' in msg
+        finally:
+            os.unlink(zip_path)
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    @patch('subprocess.run')
+    def test_verify_success_with_good_signature(self, mock_run, mock_keys, mock_gpg, mock_enabled):
+        """Test verification succeeds with valid signature."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = True
+        mock_keys.return_value = True
+        
+        # Mock GPG import and verify commands
+        mock_import = MagicMock()
+        mock_import.returncode = 0
+        mock_import.stderr = b''
+        
+        mock_verify = MagicMock()
+        mock_verify.returncode = 0
+        mock_verify.stdout = b'[GNUPG:] GOODSIG ABC123 Test Signer <test@example.com>'
+        mock_verify.stderr = b''
+        
+        mock_run.side_effect = [mock_import, mock_verify]
+        
+        with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as f:
+            zip_path = f.name
+        
+        with tempfile.NamedTemporaryFile(suffix='.sig', delete=False) as f:
+            sig_path = f.name
+        
+        try:
+            success, msg = verify_plugin_signature(zip_path, sig_path)
+            assert success is True
+            assert 'Signature valid' in msg
+        finally:
+            os.unlink(zip_path)
+            os.unlink(sig_path)
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    @patch('subprocess.run')
+    def test_verify_fails_with_bad_signature(self, mock_run, mock_keys, mock_gpg, mock_enabled):
+        """Test verification fails with invalid signature."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = True
+        mock_keys.return_value = True
+        
+        # Mock GPG import success but verify failure
+        mock_import = MagicMock()
+        mock_import.returncode = 0
+        mock_import.stderr = b''
+        
+        mock_verify = MagicMock()
+        mock_verify.returncode = 1
+        mock_verify.stdout = b''
+        mock_verify.stderr = b'gpg: BAD signature from "Test Signer <test@example.com>"'
+        
+        mock_run.side_effect = [mock_import, mock_verify]
+        
+        with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as f:
+            zip_path = f.name
+        
+        with tempfile.NamedTemporaryFile(suffix='.sig', delete=False) as f:
+            sig_path = f.name
+        
+        try:
+            success, msg = verify_plugin_signature(zip_path, sig_path)
+            assert success is False
+            assert 'verification failed' in msg.lower()
+        finally:
+            os.unlink(zip_path)
+            os.unlink(sig_path)
+
+
+class TestGetSignatureStatus:
+    """Test signature status reporting."""
+    
+    @patch('backend.plugin_signer.is_signature_verification_enabled')
+    @patch('backend.plugin_signer.is_gpg_available')
+    @patch('backend.plugin_signer.has_trusted_keys')
+    def test_get_status(self, mock_keys, mock_gpg, mock_enabled):
+        """Test getting signature verification status."""
+        mock_enabled.return_value = True
+        mock_gpg.return_value = True
+        mock_keys.return_value = True
+        
+        status = get_signature_status()
+        
+        assert isinstance(status, dict)
+        assert 'enabled' in status
+        assert 'gpg_available' in status
+        assert 'has_trusted_keys' in status
+        assert 'trusted_keys_path' in status
+        assert 'key_count' in status
+        
+        assert status['enabled'] is True
+        assert status['gpg_available'] is True
+        assert status['has_trusted_keys'] is True
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Context

Plugins run arbitrary Python code via `setup.py` with full system privileges. Right now, any zip file that passes basic validation (size limits, path traversal checks, file type whitelist) can be installed. There's no cryptographic verification that the plugin came from a trusted source or hasn't been tampered with.

This is the highest-risk attack surface I found during the security audit. A malicious plugin could exfiltrate data, backdoor the system, or escalate privileges. Supply chain attacks are real—we've seen them with npm, PyPI, and other package ecosystems.

## What This PR Does

Adds GPG-based signature verification for plugins. When signature verification is enabled, plugins must include a detached GPG signature (`.sig` or `.asc` file) that's verified against a trusted keyring before installation.

**New files:**
- `backend/plugin_signer.py` — Signature verification logic using GPG subprocess calls
- `unit_tests/test_plugin_signer.py` — 18 test cases covering verification, key management, and edge cases

**Modified files:**
- `backend/zip_validator.py` — Added optional signature verification step
- `backend/plugin_lifecycle.py` — Integrated verification into `install_plugin()` workflow

## How It Works

**Setup (one-time):**
1. Generate a GPG key pair for plugin signing (or use an existing one)
2. Export the public key to `plugins/trusted_keys.asc`
3. Optionally set `PLUGIN_SIGNATURE_REQUIRED=true` in environment or database

**Plugin installation:**
1. Developer signs their plugin: `gpg --detach-sign --armor -o plugin.sig plugin.zip`
2. User installs plugin with signature file alongside the zip
3. Evonic verifies the signature against the trusted keyring
4. If verification passes, installation proceeds normally
5. If verification fails, installation is blocked with a clear error message

**Graceful fallback:**
- If GPG isn't installed, verification is skipped (logged as warning)
- If no trusted keys are configured, verification is skipped
- If `PLUGIN_SIGNATURE_REQUIRED=false`, verification is disabled
- This means existing setups won't break, but new deployments can opt into stricter security

## Why GPG?

GPG is widely available, well-understood, and already used by many package managers (apt, yum, Homebrew). It's not perfect, but it's a reasonable choice for this use case. The implementation is isolated enough that we could swap in a different signing mechanism later if needed.

## Testing

All 18 unit tests pass. The tests mock GPG subprocess calls to avoid requiring GPG during CI, but I also manually tested with real GPG:

1. Generated a test key pair
2. Signed a dummy plugin zip
3. Verified installation succeeds with valid signature
4. Verified installation fails with tampered signature
5. Verified installation fails with signature from untrusted key

## What This Doesn't Do

- Doesn't enforce signature verification by default (opt-in for now)
- Doesn't provide a plugin marketplace or curated repository
- Doesn't sandbox plugin execution (that's a separate, much larger problem)
- Doesn't verify plugin dependencies or transitive trust

This PR is focused on one thing: preventing unsigned or tampered plugins from being installed when verification is enabled.

## Migration Path

For existing deployments:
1. No action required—verification is disabled by default
2. To enable: install GPG, configure trusted keys, set `PLUGIN_SIGNATURE_REQUIRED=true`

For plugin developers:
1. Sign your plugin zip with GPG
2. Distribute the `.sig` file alongside the zip
3. Document your public key fingerprint so users can verify it
