### PR TITLE
feat(telegram): on-demand attachment handling (documents + capture-only audio/voice/video/stickers)

### DIFF
--- a/backend/channels/telegram.py
+++ b/backend/channels/telegram.py
@@ -22,7 +22,7 @@ def _sanitize_filename(name: str) -> str:
 
 def _human_size(size_bytes: Optional[int]) -> str:
     """Render a byte count as a human-friendly string."""
-    if not size_bytes or size_bytes < 0:
+    if size_bytes is None or size_bytes < 0:
         return '0B'
     units = ['B', 'KB', 'MB', 'GB']
     n = float(size_bytes)
@@ -40,7 +40,6 @@ _TG_FILE_TYPE_DEFAULT_MIME = {
     'video_note': 'video/mp4',
     'sticker': 'image/webp',
     'animation': 'video/mp4',
-    'photo': 'image/jpeg',
 }
 
 

--- a/backend/channels/telegram.py
+++ b/backend/channels/telegram.py
@@ -2,13 +2,80 @@
 
 import base64
 import logging
+import os
 import re
 import time
 import threading
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Tuple
 from backend.channels.base import BaseChannel, strip_system_tags
 
 _logger = logging.getLogger(__name__)
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a filename to a safe ASCII slug, max 120 chars."""
+    if not name:
+        return 'file'
+    cleaned = re.sub(r'[^A-Za-z0-9._-]', '_', name)[:120]
+    return cleaned or 'file'
+
+
+def _human_size(size_bytes: Optional[int]) -> str:
+    """Render a byte count as a human-friendly string."""
+    if not size_bytes or size_bytes < 0:
+        return '0B'
+    units = ['B', 'KB', 'MB', 'GB']
+    n = float(size_bytes)
+    for unit in units:
+        if n < 1024 or unit == units[-1]:
+            if unit == 'B':
+                return f"{int(n)}{unit}"
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{int(size_bytes)}B"
+
+
+_TG_FILE_TYPE_DEFAULT_MIME = {
+    'voice': 'audio/ogg',
+    'video_note': 'video/mp4',
+    'sticker': 'image/webp',
+    'animation': 'video/mp4',
+    'photo': 'image/jpeg',
+}
+
+
+def _detect_non_photo_attachment(message) -> Optional[Tuple[str, Optional[str], str, Optional[int], str]]:
+    """Inspect a Telegram message for a non-photo attachment.
+
+    Returns (file_id, original_filename, mime_type, size_bytes, file_type) or None.
+    """
+    candidates = [
+        ('document', getattr(message, 'document', None)),
+        ('audio', getattr(message, 'audio', None)),
+        ('voice', getattr(message, 'voice', None)),
+        ('video', getattr(message, 'video', None)),
+        ('video_note', getattr(message, 'video_note', None)),
+        ('animation', getattr(message, 'animation', None)),
+        ('sticker', getattr(message, 'sticker', None)),
+    ]
+    for file_type, obj in candidates:
+        if not obj:
+            continue
+        file_id = getattr(obj, 'file_id', None)
+        if not file_id:
+            continue
+        original_filename = getattr(obj, 'file_name', None)
+        mime_type = getattr(obj, 'mime_type', None) or _TG_FILE_TYPE_DEFAULT_MIME.get(file_type)
+        size_bytes = getattr(obj, 'file_size', None)
+        if not original_filename:
+            # Synthesize a filename from the file_type for media with no name.
+            ext = {
+                'voice': 'ogg', 'video_note': 'mp4', 'sticker': 'webp',
+                'animation': 'mp4', 'audio': 'mp3', 'video': 'mp4',
+            }.get(file_type, 'bin')
+            original_filename = f"{file_type}.{ext}"
+        return file_id, original_filename, mime_type, size_bytes, file_type
+    return None
 
 
 def _extract_name(text: str) -> str:
@@ -206,43 +273,191 @@ class TelegramChannel(BaseChannel):
                                 )
                         return
 
-                # Handle photo/image messages if agent has vision enabled
+                # Establish session_id early — needed for attachment storage paths.
+                from models.db import db
+                session_id = db.get_or_create_session(agent_id, user_id, channel_id)
+
+                # Handle non-photo attachments (documents, audio, voice, video, etc.)
                 IMAGE_MIMES = {'image/jpeg', 'image/png', 'image/webp'}
-                has_photo = update.message.photo
+                has_photo = bool(update.message.photo)
                 has_image_doc = (
                     update.message.document
                     and update.message.document.mime_type in IMAGE_MIMES
                 )
 
+                # Skip non-photo attachment handling for image-documents (handled by vision below).
+                non_photo = None
+                if not has_image_doc:
+                    non_photo = _detect_non_photo_attachment(update.message)
+
+                if non_photo:
+                    file_id, original_filename, mime_type, size_bytes, file_type = non_photo
+                    cfg = db.get_agent_attachment_config(agent_id)
+                    if not cfg['enabled'] or not cfg['supported']:
+                        await update.message.reply_text(
+                            "Attachments are not enabled for this assistant."
+                        )
+                        return
+                    max_bytes = cfg['max_size_mb'] * 1024 * 1024
+                    if size_bytes and size_bytes > max_bytes:
+                        await update.message.reply_text(
+                            f"File too large (max {cfg['max_size_mb']}MB)."
+                        )
+                        return
+                    safe = _sanitize_filename(original_filename)
+                    target_dir = os.path.join('data', 'attachments', agent_id, session_id)
+                    try:
+                        os.makedirs(target_dir, exist_ok=True)
+                        target_path = os.path.join(target_dir, f"{int(time.time())}_{safe}")
+                        tg_file = await context.bot.get_file(file_id)
+                        await tg_file.download_to_drive(target_path)
+                    except Exception as e:
+                        _logger.error(
+                            "Failed to download attachment %s for agent %s: %s",
+                            file_id, agent_id, e, exc_info=True,
+                        )
+                        try:
+                            await update.message.reply_text(
+                                "Failed to download attachment. Please try again."
+                            )
+                        except Exception:
+                            pass
+                        return
+                    real_size = size_bytes or (
+                        os.path.getsize(target_path) if os.path.isfile(target_path) else 0
+                    )
+                    attachment_id = db.save_attachment(
+                        agent_id=agent_id,
+                        session_id=session_id,
+                        filename=os.path.basename(target_path),
+                        file_path=target_path,
+                        external_user_id=user_id,
+                        channel_id=channel_id,
+                        channel_type='telegram',
+                        original_filename=original_filename,
+                        mime_type=mime_type,
+                        file_type=file_type,
+                        size_bytes=real_size,
+                        telegram_file_id=file_id,
+                    )
+                    info_line = (
+                        f"[Attached: {original_filename} "
+                        f"({mime_type or 'application/octet-stream'}, "
+                        f"{_human_size(real_size)}) "
+                        f"id={attachment_id} path={target_path}]"
+                    )
+                    text = info_line + (f"\n{text}" if text else '')
+
+                # Handle photo/image messages if agent has vision enabled.
                 if has_photo or has_image_doc:
-                    from models.db import db
                     agent = db.get_agent(agent_id)
+                    photo_bytes_for_attachment = None
+                    photo_file_id = None
+                    photo_size = None
                     if agent and agent.get('vision_enabled'):
                         if has_photo:
                             photo = update.message.photo[-1]
+                            photo_file_id = photo.file_id
+                            photo_size = getattr(photo, 'file_size', None)
                             file = await context.bot.get_file(photo.file_id)
                         else:
                             doc = update.message.document
+                            photo_file_id = doc.file_id
+                            photo_size = getattr(doc, 'file_size', None)
                             file = await context.bot.get_file(doc.file_id)
                         img_bytes = await file.download_as_bytearray()
+                        photo_bytes_for_attachment = bytes(img_bytes)
                         # Convert to JPEG for consistent LLM input
                         from io import BytesIO
                         from PIL import Image
-                        img = Image.open(BytesIO(bytes(img_bytes)))
+                        img = Image.open(BytesIO(photo_bytes_for_attachment))
                         if img.mode in ('RGBA', 'LA', 'P'):
                             img = img.convert('RGB')
                         buf = BytesIO()
                         img.save(buf, format='JPEG', quality=85)
                         b64 = base64.b64encode(buf.getvalue()).decode('utf-8')
                         image_url = f"data:image/jpeg;base64,{b64}"
-                    else:
-                        if not text:
-                            return
+
+                    # Dual-handling: also persist the photo as an attachment row when
+                    # the agent has attachments_enabled (and the model supports it).
+                    cfg = db.get_agent_attachment_config(agent_id)
+                    if cfg['enabled'] and cfg['supported']:
+                        try:
+                            if has_photo and not photo_file_id:
+                                photo = update.message.photo[-1]
+                                photo_file_id = photo.file_id
+                                photo_size = getattr(photo, 'file_size', None)
+                            elif has_image_doc and not photo_file_id:
+                                doc = update.message.document
+                                photo_file_id = doc.file_id
+                                photo_size = getattr(doc, 'file_size', None)
+                            if has_image_doc:
+                                doc = update.message.document
+                                photo_mime = doc.mime_type or 'image/jpeg'
+                                photo_orig_name = doc.file_name or 'image.jpg'
+                                photo_file_type = 'document'
+                            else:
+                                photo_mime = 'image/jpeg'
+                                photo_orig_name = 'photo.jpg'
+                                photo_file_type = 'photo'
+                            max_bytes = cfg['max_size_mb'] * 1024 * 1024
+                            if photo_size and photo_size > max_bytes:
+                                _logger.info(
+                                    "Skipping photo attachment row for agent %s: "
+                                    "size %s exceeds %s bytes",
+                                    agent_id, photo_size, max_bytes,
+                                )
+                            else:
+                                safe = _sanitize_filename(photo_orig_name)
+                                target_dir = os.path.join(
+                                    'data', 'attachments', agent_id, session_id
+                                )
+                                os.makedirs(target_dir, exist_ok=True)
+                                target_path = os.path.join(
+                                    target_dir, f"{int(time.time())}_{safe}"
+                                )
+                                if photo_bytes_for_attachment is not None:
+                                    with open(target_path, 'wb') as f:
+                                        f.write(photo_bytes_for_attachment)
+                                else:
+                                    tg_file = await context.bot.get_file(photo_file_id)
+                                    await tg_file.download_to_drive(target_path)
+                                real_size = (
+                                    photo_size
+                                    or (os.path.getsize(target_path) if os.path.isfile(target_path) else 0)
+                                )
+                                attachment_id = db.save_attachment(
+                                    agent_id=agent_id,
+                                    session_id=session_id,
+                                    filename=os.path.basename(target_path),
+                                    file_path=target_path,
+                                    external_user_id=user_id,
+                                    channel_id=channel_id,
+                                    channel_type='telegram',
+                                    original_filename=photo_orig_name,
+                                    mime_type=photo_mime,
+                                    file_type=photo_file_type,
+                                    size_bytes=real_size,
+                                    telegram_file_id=photo_file_id,
+                                )
+                                info_line = (
+                                    f"[Attached: {photo_orig_name} "
+                                    f"({photo_mime}, {_human_size(real_size)}) "
+                                    f"id={attachment_id} path={target_path}]"
+                                )
+                                text = info_line + (f"\n{text}" if text else '')
+                        except Exception as e:
+                            _logger.error(
+                                "Failed to persist photo attachment for agent %s: %s",
+                                agent_id, e, exc_info=True,
+                            )
+
+                    # If neither vision nor attachments captured the photo and there is
+                    # no caption text, drop the update to mirror legacy behavior.
+                    if image_url is None and not text:
+                        return
                 elif not text:
                     return
-
-                from models.db import db
-                session_id = db.get_or_create_session(agent_id, user_id, channel_id)
 
                 # Check if bot is enabled for this session
                 if not db.is_session_bot_enabled(session_id, agent_id=agent_id):
@@ -325,7 +540,18 @@ class TelegramChannel(BaseChannel):
         # Handle text, photos, and image documents (PNG, WebP)
         # Note: we intentionally do NOT exclude COMMAND filter so that
         # slash commands (/clear, /help, /summary) reach our backend handler.
-        self._app.add_handler(MessageHandler(filters.TEXT | filters.PHOTO | filters.Document.IMAGE, handle_message))
+        self._app.add_handler(MessageHandler(
+            filters.TEXT
+            | filters.PHOTO
+            | filters.Document.ALL
+            | filters.AUDIO
+            | filters.VOICE
+            | filters.VIDEO
+            | filters.VIDEO_NOTE
+            | filters.ANIMATION
+            | filters.Sticker.ALL,
+            handle_message,
+        ))
 
         # Inline keyboard callback for approval decisions
         from telegram.ext import CallbackQueryHandler

--- a/backend/channels/telegram.py
+++ b/backend/channels/telegram.py
@@ -43,6 +43,22 @@ _TG_FILE_TYPE_DEFAULT_MIME = {
 }
 
 
+_IMAGE_DOC_MIMES = frozenset({'image/jpeg', 'image/png', 'image/webp'})
+
+
+def _has_image_document(message) -> bool:
+    """Return True when the Telegram message carries an image-mime document.
+
+    Image-mime documents are routed exclusively through the photo / vision
+    pipeline; this helper lets the non-photo path skip them cleanly without
+    relying on side-effects from a sibling branch.
+    """
+    doc = getattr(message, 'document', None)
+    if not doc:
+        return False
+    return getattr(doc, 'mime_type', None) in _IMAGE_DOC_MIMES
+
+
 def _detect_non_photo_attachment(message) -> Optional[Tuple[str, Optional[str], str, Optional[int], str]]:
     """Inspect a Telegram message for a non-photo attachment.
 
@@ -75,6 +91,202 @@ def _detect_non_photo_attachment(message) -> Optional[Tuple[str, Optional[str], 
             original_filename = f"{file_type}.{ext}"
         return file_id, original_filename, mime_type, size_bytes, file_type
     return None
+
+
+async def _ingest_non_photo_attachment(message, context, agent_id, session_id,
+                                       user_id, channel_id, db):
+    """Detect, gate, download and persist a non-photo Telegram attachment.
+
+    The helper is the single owner of the non-photo branch: it inspects the
+    message exactly once, resolves the agent attachment config exactly once,
+    and on rejection it sends its own reply (mirroring legacy behaviour).
+
+    Returns a tuple ``(info_line, rejected)`` where:
+      * ``(None, False)``  — no non-photo attachment present (or it is an
+                              image-mime document routed to the photo branch);
+                              the caller continues with the photo / text flow.
+      * ``(info_line, False)`` — attachment persisted; ``info_line`` should be
+                                  prepended to the user's text.
+      * ``(None, True)`` — the message was rejected (gating, oversize, or
+                            download failure). A user-facing reply has already
+                            been sent and the caller must ``return`` early.
+    """
+    # Image-mime documents are owned by the photo / vision branch.
+    if _has_image_document(message):
+        return None, False
+    non_photo = _detect_non_photo_attachment(message)
+    if not non_photo:
+        return None, False
+
+    file_id, original_filename, mime_type, size_bytes, file_type = non_photo
+    cfg = db.get_agent_attachment_config(agent_id)
+    if not cfg['enabled'] or not cfg['supported']:
+        await message.reply_text(
+            "Attachments are not enabled for this assistant."
+        )
+        return None, True
+    max_bytes = cfg['max_size_mb'] * 1024 * 1024
+    if size_bytes and size_bytes > max_bytes:
+        await message.reply_text(
+            f"File too large (max {cfg['max_size_mb']}MB)."
+        )
+        return None, True
+    safe = _sanitize_filename(original_filename)
+    target_dir = os.path.join('data', 'attachments', agent_id, session_id)
+    try:
+        os.makedirs(target_dir, exist_ok=True)
+        target_path = os.path.join(target_dir, f"{int(time.time())}_{safe}")
+        tg_file = await context.bot.get_file(file_id)
+        await tg_file.download_to_drive(target_path)
+    except Exception as e:
+        _logger.error(
+            "Failed to download attachment %s for agent %s: %s",
+            file_id, agent_id, e, exc_info=True,
+        )
+        try:
+            await message.reply_text(
+                "Failed to download attachment. Please try again."
+            )
+        except Exception:
+            pass
+        return None, True
+    real_size = size_bytes or (
+        os.path.getsize(target_path) if os.path.isfile(target_path) else 0
+    )
+    attachment_id = db.save_attachment(
+        agent_id=agent_id,
+        session_id=session_id,
+        filename=os.path.basename(target_path),
+        file_path=target_path,
+        external_user_id=user_id,
+        channel_id=channel_id,
+        channel_type='telegram',
+        original_filename=original_filename,
+        mime_type=mime_type,
+        file_type=file_type,
+        size_bytes=real_size,
+        telegram_file_id=file_id,
+    )
+    info_line = (
+        f"[Attached: {original_filename} "
+        f"({mime_type or 'application/octet-stream'}, "
+        f"{_human_size(real_size)}) "
+        f"id={attachment_id} path={target_path}]"
+    )
+    return info_line, False
+
+
+async def _ingest_photo(message, context, agent_id, session_id, user_id,
+                        channel_id, db):
+    """Handle photo / image-document messages: vision conversion + optional persist.
+
+    The helper is the single owner of the photo branch: it derives
+    ``photo_file_id`` / ``photo_size`` / ``photo_bytes_for_attachment`` exactly
+    once and never relies on state set by another branch.
+
+    Returns ``(image_url, info_line)``: either or both may be ``None``.
+      * ``image_url`` is a ``data:`` URL when the agent has vision enabled and
+        the photo was successfully decoded; ``None`` otherwise.
+      * ``info_line`` is the ``[Attached: …]`` line emitted exactly when the
+        photo was also persisted as an attachment row. This is the single
+        composition point for the photo info-line.
+    """
+    has_photo = bool(getattr(message, 'photo', None))
+    has_image_doc = _has_image_document(message)
+    if not (has_photo or has_image_doc):
+        return None, None
+
+    # Derive photo identifiers exactly once.
+    if has_photo:
+        photo = message.photo[-1]
+        photo_file_id = photo.file_id
+        photo_size = getattr(photo, 'file_size', None)
+        photo_mime = 'image/jpeg'
+        photo_orig_name = 'photo.jpg'
+        photo_file_type = 'photo'
+    else:
+        doc = message.document
+        photo_file_id = doc.file_id
+        photo_size = getattr(doc, 'file_size', None)
+        photo_mime = doc.mime_type or 'image/jpeg'
+        photo_orig_name = doc.file_name or 'image.jpg'
+        photo_file_type = 'document'
+
+    image_url = None
+    photo_bytes_for_attachment = None
+
+    agent = db.get_agent(agent_id)
+    if agent and agent.get('vision_enabled'):
+        file = await context.bot.get_file(photo_file_id)
+        img_bytes = await file.download_as_bytearray()
+        photo_bytes_for_attachment = bytes(img_bytes)
+        # Convert to JPEG for consistent LLM input.
+        from io import BytesIO
+        from PIL import Image
+        img = Image.open(BytesIO(photo_bytes_for_attachment))
+        if img.mode in ('RGBA', 'LA', 'P'):
+            img = img.convert('RGB')
+        buf = BytesIO()
+        img.save(buf, format='JPEG', quality=85)
+        b64 = base64.b64encode(buf.getvalue()).decode('utf-8')
+        image_url = f"data:image/jpeg;base64,{b64}"
+
+    info_line = None
+    cfg = db.get_agent_attachment_config(agent_id)
+    if cfg['enabled'] and cfg['supported']:
+        try:
+            max_bytes = cfg['max_size_mb'] * 1024 * 1024
+            if photo_size and photo_size > max_bytes:
+                _logger.info(
+                    "Skipping photo attachment row for agent %s: "
+                    "size %s exceeds %s bytes",
+                    agent_id, photo_size, max_bytes,
+                )
+            else:
+                safe = _sanitize_filename(photo_orig_name)
+                target_dir = os.path.join(
+                    'data', 'attachments', agent_id, session_id
+                )
+                os.makedirs(target_dir, exist_ok=True)
+                target_path = os.path.join(
+                    target_dir, f"{int(time.time())}_{safe}"
+                )
+                if photo_bytes_for_attachment is not None:
+                    with open(target_path, 'wb') as f:
+                        f.write(photo_bytes_for_attachment)
+                else:
+                    tg_file = await context.bot.get_file(photo_file_id)
+                    await tg_file.download_to_drive(target_path)
+                real_size = (
+                    photo_size
+                    or (os.path.getsize(target_path) if os.path.isfile(target_path) else 0)
+                )
+                attachment_id = db.save_attachment(
+                    agent_id=agent_id,
+                    session_id=session_id,
+                    filename=os.path.basename(target_path),
+                    file_path=target_path,
+                    external_user_id=user_id,
+                    channel_id=channel_id,
+                    channel_type='telegram',
+                    original_filename=photo_orig_name,
+                    mime_type=photo_mime,
+                    file_type=photo_file_type,
+                    size_bytes=real_size,
+                    telegram_file_id=photo_file_id,
+                )
+                info_line = (
+                    f"[Attached: {photo_orig_name} "
+                    f"({photo_mime}, {_human_size(real_size)}) "
+                    f"id={attachment_id} path={target_path}]"
+                )
+        except Exception as e:
+            _logger.error(
+                "Failed to persist photo attachment for agent %s: %s",
+                agent_id, e, exc_info=True,
+            )
+
+    return image_url, info_line
 
 
 def _extract_name(text: str) -> str:
@@ -276,183 +488,36 @@ class TelegramChannel(BaseChannel):
                 from models.db import db
                 session_id = db.get_or_create_session(agent_id, user_id, channel_id)
 
-                # Handle non-photo attachments (documents, audio, voice, video, etc.)
-                IMAGE_MIMES = {'image/jpeg', 'image/png', 'image/webp'}
+                # Detect message shape exactly once. The non-photo and photo
+                # helpers are mutually exclusive: image-mime documents are
+                # routed through `_ingest_photo` only.
                 has_photo = bool(update.message.photo)
-                has_image_doc = (
-                    update.message.document
-                    and update.message.document.mime_type in IMAGE_MIMES
+                has_image_doc = _has_image_document(update.message)
+
+                # Non-photo attachments (documents, audio, voice, video, etc.).
+                non_photo_info, rejected = await _ingest_non_photo_attachment(
+                    update.message, context, agent_id, session_id,
+                    user_id, channel_id, db,
+                )
+                if rejected:
+                    return
+
+                # Photo / image-document branch: vision conversion + optional
+                # attachment persistence. `photo_info` is the single source of
+                # the `[Attached: …]` line for photos — never composed twice.
+                image_url, photo_info = await _ingest_photo(
+                    update.message, context, agent_id, session_id,
+                    user_id, channel_id, db,
                 )
 
-                # Skip non-photo attachment handling for image-documents (handled by vision below).
-                non_photo = None
-                if not has_image_doc:
-                    non_photo = _detect_non_photo_attachment(update.message)
-
-                if non_photo:
-                    file_id, original_filename, mime_type, size_bytes, file_type = non_photo
-                    cfg = db.get_agent_attachment_config(agent_id)
-                    if not cfg['enabled'] or not cfg['supported']:
-                        await update.message.reply_text(
-                            "Attachments are not enabled for this assistant."
-                        )
-                        return
-                    max_bytes = cfg['max_size_mb'] * 1024 * 1024
-                    if size_bytes and size_bytes > max_bytes:
-                        await update.message.reply_text(
-                            f"File too large (max {cfg['max_size_mb']}MB)."
-                        )
-                        return
-                    safe = _sanitize_filename(original_filename)
-                    target_dir = os.path.join('data', 'attachments', agent_id, session_id)
-                    try:
-                        os.makedirs(target_dir, exist_ok=True)
-                        target_path = os.path.join(target_dir, f"{int(time.time())}_{safe}")
-                        tg_file = await context.bot.get_file(file_id)
-                        await tg_file.download_to_drive(target_path)
-                    except Exception as e:
-                        _logger.error(
-                            "Failed to download attachment %s for agent %s: %s",
-                            file_id, agent_id, e, exc_info=True,
-                        )
-                        try:
-                            await update.message.reply_text(
-                                "Failed to download attachment. Please try again."
-                            )
-                        except Exception:
-                            pass
-                        return
-                    real_size = size_bytes or (
-                        os.path.getsize(target_path) if os.path.isfile(target_path) else 0
-                    )
-                    attachment_id = db.save_attachment(
-                        agent_id=agent_id,
-                        session_id=session_id,
-                        filename=os.path.basename(target_path),
-                        file_path=target_path,
-                        external_user_id=user_id,
-                        channel_id=channel_id,
-                        channel_type='telegram',
-                        original_filename=original_filename,
-                        mime_type=mime_type,
-                        file_type=file_type,
-                        size_bytes=real_size,
-                        telegram_file_id=file_id,
-                    )
-                    info_line = (
-                        f"[Attached: {original_filename} "
-                        f"({mime_type or 'application/octet-stream'}, "
-                        f"{_human_size(real_size)}) "
-                        f"id={attachment_id} path={target_path}]"
-                    )
+                # Compose `info_line` once — the two helpers are mutually
+                # exclusive by message shape, so at most one is non-None.
+                info_line = non_photo_info or photo_info
+                if info_line:
                     text = info_line + (f"\n{text}" if text else '')
 
-                # Handle photo/image messages if agent has vision enabled.
+                # Drop empty updates per legacy behavior.
                 if has_photo or has_image_doc:
-                    agent = db.get_agent(agent_id)
-                    photo_bytes_for_attachment = None
-                    photo_file_id = None
-                    photo_size = None
-                    if agent and agent.get('vision_enabled'):
-                        if has_photo:
-                            photo = update.message.photo[-1]
-                            photo_file_id = photo.file_id
-                            photo_size = getattr(photo, 'file_size', None)
-                            file = await context.bot.get_file(photo.file_id)
-                        else:
-                            doc = update.message.document
-                            photo_file_id = doc.file_id
-                            photo_size = getattr(doc, 'file_size', None)
-                            file = await context.bot.get_file(doc.file_id)
-                        img_bytes = await file.download_as_bytearray()
-                        photo_bytes_for_attachment = bytes(img_bytes)
-                        # Convert to JPEG for consistent LLM input
-                        from io import BytesIO
-                        from PIL import Image
-                        img = Image.open(BytesIO(photo_bytes_for_attachment))
-                        if img.mode in ('RGBA', 'LA', 'P'):
-                            img = img.convert('RGB')
-                        buf = BytesIO()
-                        img.save(buf, format='JPEG', quality=85)
-                        b64 = base64.b64encode(buf.getvalue()).decode('utf-8')
-                        image_url = f"data:image/jpeg;base64,{b64}"
-
-                    # Dual-handling: also persist the photo as an attachment row when
-                    # the agent has attachments_enabled (and the model supports it).
-                    cfg = db.get_agent_attachment_config(agent_id)
-                    if cfg['enabled'] and cfg['supported']:
-                        try:
-                            if has_photo and not photo_file_id:
-                                photo = update.message.photo[-1]
-                                photo_file_id = photo.file_id
-                                photo_size = getattr(photo, 'file_size', None)
-                            elif has_image_doc and not photo_file_id:
-                                doc = update.message.document
-                                photo_file_id = doc.file_id
-                                photo_size = getattr(doc, 'file_size', None)
-                            if has_image_doc:
-                                doc = update.message.document
-                                photo_mime = doc.mime_type or 'image/jpeg'
-                                photo_orig_name = doc.file_name or 'image.jpg'
-                                photo_file_type = 'document'
-                            else:
-                                photo_mime = 'image/jpeg'
-                                photo_orig_name = 'photo.jpg'
-                                photo_file_type = 'photo'
-                            max_bytes = cfg['max_size_mb'] * 1024 * 1024
-                            if photo_size and photo_size > max_bytes:
-                                _logger.info(
-                                    "Skipping photo attachment row for agent %s: "
-                                    "size %s exceeds %s bytes",
-                                    agent_id, photo_size, max_bytes,
-                                )
-                            else:
-                                safe = _sanitize_filename(photo_orig_name)
-                                target_dir = os.path.join(
-                                    'data', 'attachments', agent_id, session_id
-                                )
-                                os.makedirs(target_dir, exist_ok=True)
-                                target_path = os.path.join(
-                                    target_dir, f"{int(time.time())}_{safe}"
-                                )
-                                if photo_bytes_for_attachment is not None:
-                                    with open(target_path, 'wb') as f:
-                                        f.write(photo_bytes_for_attachment)
-                                else:
-                                    tg_file = await context.bot.get_file(photo_file_id)
-                                    await tg_file.download_to_drive(target_path)
-                                real_size = (
-                                    photo_size
-                                    or (os.path.getsize(target_path) if os.path.isfile(target_path) else 0)
-                                )
-                                attachment_id = db.save_attachment(
-                                    agent_id=agent_id,
-                                    session_id=session_id,
-                                    filename=os.path.basename(target_path),
-                                    file_path=target_path,
-                                    external_user_id=user_id,
-                                    channel_id=channel_id,
-                                    channel_type='telegram',
-                                    original_filename=photo_orig_name,
-                                    mime_type=photo_mime,
-                                    file_type=photo_file_type,
-                                    size_bytes=real_size,
-                                    telegram_file_id=photo_file_id,
-                                )
-                                info_line = (
-                                    f"[Attached: {photo_orig_name} "
-                                    f"({photo_mime}, {_human_size(real_size)}) "
-                                    f"id={attachment_id} path={target_path}]"
-                                )
-                                text = info_line + (f"\n{text}" if text else '')
-                        except Exception as e:
-                            _logger.error(
-                                "Failed to persist photo attachment for agent %s: %s",
-                                agent_id, e, exc_info=True,
-                            )
-
-                    # If neither vision nor attachments captured the photo and there is
-                    # no caption text, drop the update to mirror legacy behavior.
                     if image_url is None and not text:
                         return
                 elif not text:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -63,7 +63,30 @@ class Scheduler:
                                      EVENT_JOB_EXECUTED | EVENT_JOB_MISSED)
         self._scheduler.start()
         self._load_from_db()
+        # Built-in: nightly attachment cleanup (rows + files older than 7 days).
+        try:
+            self._scheduler.add_job(
+                self._cleanup_expired_attachments,
+                CronTrigger(hour=3, minute=0),
+                id='builtin:attachments_cleanup',
+                replace_existing=True,
+            )
+        except Exception as e:  # pragma: no cover - defensive guard
+            log.warning("Failed to register attachments cleanup job: %s", e)
         log.info("Started with %d jobs", len(self._scheduler.get_jobs()))
+
+    def _cleanup_expired_attachments(self):
+        """Daily housekeeping: delete attachment rows + files older than 7 days."""
+        try:
+            from models.db import db
+            deleted, freed = db.cleanup_expired_attachments(max_age_days=7)
+            if deleted:
+                log.info(
+                    "Attachments cleanup: deleted %d rows, freed %d bytes",
+                    deleted, freed,
+                )
+        except Exception as e:
+            log.error("Attachments cleanup failed: %s", e, exc_info=True)
 
     def shutdown(self):
         """Gracefully shut down the scheduler."""

--- a/backend/tools/cleanup_attachments.py
+++ b/backend/tools/cleanup_attachments.py
@@ -1,0 +1,33 @@
+"""Real backend implementation for the cleanup_attachments tool.
+
+Restricted to super agents. Calls db.cleanup_expired_attachments and returns the
+deleted-row count and freed disk bytes.
+"""
+
+from typing import Any, Dict
+
+
+def execute(agent, args: dict) -> Dict[str, Any]:
+    agent = agent or {}
+    if not agent.get('is_super'):
+        return {"error": "Not authorized — cleanup_attachments requires a super agent."}
+
+    older_than_days = args.get('older_than_days')
+    if older_than_days is None:
+        older_than_days = 7
+    try:
+        older_than_days = int(older_than_days)
+    except (TypeError, ValueError):
+        return {"error": "Invalid 'older_than_days' — must be an integer."}
+    if older_than_days < 0:
+        return {"error": "Invalid 'older_than_days' — must be >= 0."}
+
+    from models.db import db
+    deleted, freed = db.cleanup_expired_attachments(max_age_days=older_than_days)
+    return {
+        "result": {
+            "deleted_count": int(deleted),
+            "freed_bytes": int(freed),
+            "older_than_days": older_than_days,
+        }
+    }

--- a/backend/tools/read_attachment.py
+++ b/backend/tools/read_attachment.py
@@ -1,0 +1,253 @@
+"""Real backend implementation for the read_attachment tool.
+
+Reads user-uploaded file attachments stored under data/attachments/<agent_id>/.
+Enforces per-agent isolation, reuses the existing read_file pagination core for
+text content, attempts PDF text extraction via pypdf when available, and falls
+back to a metadata block for opaque binary files.
+"""
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from backend.tools.read_file import read_file as _read_text_file
+
+
+_ATTACHMENTS_ROOT = os.path.join('data', 'attachments')
+_PDF_TEXT_CAP_BYTES = 100 * 1024  # 100 KB cap on extracted PDF text
+
+_TEXTISH_MIMES = {
+    'application/json',
+    'application/xml',
+    'application/x-yaml',
+    'application/yaml',
+    'application/csv',
+    'application/javascript',
+    'application/x-sh',
+    'application/sql',
+}
+
+_TEXTISH_EXTS = {
+    '.txt', '.md', '.markdown', '.log',
+    '.json', '.yaml', '.yml', '.xml', '.csv', '.tsv',
+    '.py', '.js', '.ts', '.tsx', '.jsx', '.java', '.go', '.rs',
+    '.c', '.cc', '.cpp', '.h', '.hpp', '.rb', '.php', '.kt', '.swift',
+    '.html', '.htm', '.css', '.scss', '.sql', '.sh', '.toml', '.ini',
+    '.cfg', '.conf', '.env',
+}
+
+
+def _is_textish(mime_type: Optional[str], path: str) -> bool:
+    """Return True if file is text-like by mime or extension."""
+    if mime_type:
+        m = mime_type.lower()
+        if m.startswith('text/'):
+            return True
+        if m in _TEXTISH_MIMES:
+            return True
+    ext = os.path.splitext(path)[1].lower()
+    return ext in _TEXTISH_EXTS
+
+
+def _is_pdf(mime_type: Optional[str], path: str) -> bool:
+    if mime_type and mime_type.lower() == 'application/pdf':
+        return True
+    return path.lower().endswith('.pdf')
+
+
+def _agent_root(agent_id: str) -> str:
+    return os.path.realpath(os.path.join(_ATTACHMENTS_ROOT, agent_id))
+
+
+def _path_within_agent(path: str, agent_id: str) -> bool:
+    """Check that `path` resolves inside the agent's attachments root."""
+    real = os.path.realpath(path)
+    root = _agent_root(agent_id)
+    # Ensure prefix boundary with separator
+    if real == root:
+        return False
+    return real.startswith(root + os.sep)
+
+
+def _format_metadata(row: Optional[Dict[str, Any]], fallback_path: str) -> str:
+    """Return a JSON metadata block for binary attachments."""
+    if row:
+        meta = {
+            'filename': row.get('original_filename') or row.get('filename'),
+            'mime_type': row.get('mime_type'),
+            'file_type': row.get('file_type'),
+            'size_bytes': row.get('size_bytes'),
+            'created_at': row.get('created_at'),
+            'path': row.get('file_path'),
+        }
+    else:
+        try:
+            size = os.path.getsize(fallback_path)
+        except OSError:
+            size = None
+        meta = {
+            'filename': os.path.basename(fallback_path),
+            'mime_type': None,
+            'file_type': None,
+            'size_bytes': size,
+            'created_at': None,
+            'path': fallback_path,
+        }
+    return (
+        "[Attachment metadata — binary file, not directly readable as text]\n\n"
+        + json.dumps(meta, indent=2)
+    )
+
+
+def _read_pdf_text(path: str, offset: int) -> str:
+    """Extract text from a PDF using pypdf if available; paginate by line."""
+    try:
+        from pypdf import PdfReader  # type: ignore
+    except ImportError:
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = None
+        return (
+            "[PDF text extraction unavailable: install 'pypdf' to enable]\n\n"
+            + json.dumps({
+                'filename': os.path.basename(path),
+                'mime_type': 'application/pdf',
+                'size_bytes': size,
+                'path': path,
+            }, indent=2)
+        )
+
+    try:
+        reader = PdfReader(path)
+    except Exception as e:  # pragma: no cover - depends on file contents
+        return f"Error: Failed to open PDF: {e}"
+
+    out_parts = []
+    total = 0
+    truncated = False
+    for i, page in enumerate(reader.pages):
+        try:
+            txt = page.extract_text() or ''
+        except Exception:
+            txt = ''
+        header = f"--- Page {i + 1} ---\n"
+        chunk = header + txt + "\n"
+        if total + len(chunk) > _PDF_TEXT_CAP_BYTES:
+            remaining = _PDF_TEXT_CAP_BYTES - total
+            if remaining > 0:
+                out_parts.append(chunk[:remaining])
+            truncated = True
+            break
+        out_parts.append(chunk)
+        total += len(chunk)
+
+    body = ''.join(out_parts)
+    if not body.strip():
+        return (
+            "[PDF contains no extractable text — it may be image-only or scanned. "
+            "Returning metadata instead.]\n\n"
+            + json.dumps({
+                'filename': os.path.basename(path),
+                'mime_type': 'application/pdf',
+                'path': path,
+            }, indent=2)
+        )
+
+    # Paginate by lines using read_file core for consistency. Write to a temp
+    # buffer is unnecessary — render manually since content already in memory.
+    lines = body.splitlines()
+    total_lines = len(lines)
+    start_idx = max(0, min(offset - 1, max(total_lines - 1, 0)))
+    chunk_chars = 8000
+    output_lines = []
+    chars = 0
+    end_idx = start_idx
+    for i in range(start_idx, total_lines):
+        line_str = f"{i + 1}: {lines[i].rstrip()}"
+        if chars + len(line_str) + 1 > chunk_chars and output_lines:
+            break
+        output_lines.append(line_str)
+        chars += len(line_str) + 1
+        end_idx = i + 1
+    header_line = (
+        f"[PDF: {os.path.basename(path)} | {total_lines} extracted lines | "
+        f"showing lines {start_idx + 1}-{end_idx}"
+        + (" | text truncated at 100KB" if truncated else "")
+        + "]"
+    )
+    content = "\n".join(output_lines)
+    if end_idx < total_lines:
+        remaining = total_lines - end_idx
+        footer = (
+            f"\n[...{remaining} lines remaining. "
+            f"Call read_attachment with offset={end_idx + 1} to continue.]"
+        )
+        return f"{header_line}\n\n{content}{footer}"
+    return f"{header_line}\n\n{content}"
+
+
+def execute(agent, args: dict) -> dict:
+    """Tool entrypoint. Returns a dict or a string result."""
+    agent = agent or {}
+    agent_id = agent.get('id') or ''
+    if not agent_id:
+        return {"error": "Agent context is missing — cannot resolve attachment ownership."}
+
+    attachment_id = args.get('attachment_id')
+    raw_path = args.get('path')
+    offset = args.get('offset') or 1
+    try:
+        offset = int(offset)
+    except (TypeError, ValueError):
+        offset = 1
+
+    from models.db import db
+
+    row: Optional[Dict[str, Any]] = None
+    resolved_path: Optional[str] = None
+
+    if attachment_id is not None:
+        try:
+            attachment_id = int(attachment_id)
+        except (TypeError, ValueError):
+            return {"error": "Invalid attachment_id — must be an integer."}
+        row = db.get_attachment(attachment_id)
+        if not row:
+            return {"error": "Attachment not found or expired."}
+        if row['agent_id'] != agent_id and not agent.get('is_super'):
+            return {"error": "Access denied — attachment belongs to a different agent."}
+        resolved_path = row.get('file_path')
+        if not resolved_path or not os.path.isfile(resolved_path):
+            return {"error": "Attachment file is missing on disk (it may have expired)."}
+    elif raw_path:
+        # Path-based access: resolve and enforce agent root prefix.
+        target_agent_id = agent_id
+        if agent.get('is_super'):
+            # Super agents may read any agent's attachment by path; still must
+            # resolve within data/attachments/<some_agent>/.
+            real = os.path.realpath(raw_path)
+            root = os.path.realpath(_ATTACHMENTS_ROOT)
+            if not real.startswith(root + os.sep):
+                return {"error": "Access denied — path is outside the attachments root."}
+            resolved_path = real
+        else:
+            if not _path_within_agent(raw_path, target_agent_id):
+                return {"error": "Access denied — path is outside this agent's attachments directory."}
+            resolved_path = os.path.realpath(raw_path)
+        if not os.path.isfile(resolved_path):
+            return {"error": "Attachment file not found at the provided path."}
+    else:
+        return {"error": "Provide either 'attachment_id' or 'path'."}
+
+    mime_type = (row or {}).get('mime_type')
+
+    # Dispatch
+    if _is_pdf(mime_type, resolved_path):
+        return {"result": _read_pdf_text(resolved_path, offset)}
+
+    if _is_textish(mime_type, resolved_path):
+        return {"result": _read_text_file(resolved_path, offset=offset)}
+
+    # Binary fallback — metadata only.
+    return {"result": _format_metadata(row, resolved_path)}

--- a/models/db.py
+++ b/models/db.py
@@ -19,6 +19,7 @@ from models.mixins import (
     WorkplaceMixin,
     PortalMixin,
     SafetyRuleMixin,
+    AttachmentsMixin,
 )
 
 
@@ -37,6 +38,7 @@ class Database(
     WorkplaceMixin,
     PortalMixin,
     SafetyRuleMixin,
+    AttachmentsMixin,
 ):
     def __init__(self, db_path: str = config.DB_PATH):
         self.db_path = db_path

--- a/models/mixins/__init__.py
+++ b/models/mixins/__init__.py
@@ -11,6 +11,7 @@ from models.mixins.models import ModelsMixin
 from models.mixins.workplaces import WorkplaceMixin
 from models.mixins.portals import PortalMixin
 from models.mixins.safety_rules import SafetyRuleMixin
+from models.mixins.attachments import AttachmentsMixin
 
 __all__ = [
     'EvaluationMixin',
@@ -26,4 +27,5 @@ __all__ = [
     'WorkplaceMixin',
     'PortalMixin',
     'SafetyRuleMixin',
+    'AttachmentsMixin',
 ]

--- a/models/mixins/agents.py
+++ b/models/mixins/agents.py
@@ -54,7 +54,8 @@ class AgentMixin:
                    'send_intermediate_responses', 'outbound_buffer_seconds', 'enable_agent_state', 'workspace',
                    'enabled', 'is_super', 'sandbox_enabled', 'safety_checker_enabled', 'primary_channel_id',
                    'avatar_path', 'disable_parallel_tool_execution', 'disable_turn_prefetch',
-                   'agent_messaging_enabled', 'workplace_id'}
+                   'agent_messaging_enabled', 'workplace_id',
+                   'attachments_enabled', 'attachment_max_size_mb'}
         updates = {k: v for k, v in data.items() if k in allowed}
         if not updates:
             return False

--- a/models/mixins/attachments.py
+++ b/models/mixins/attachments.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sqlite3
 import logging
 from typing import Dict, Any, List, Optional, Tuple
@@ -121,6 +122,132 @@ class AttachmentsMixin:
                 cursor.execute("DELETE FROM attachments WHERE id = ?", (row['id'],))
                 conn.commit()
                 deleted += cursor.rowcount or 0
+        return deleted, freed
+
+    def delete_session_attachments(self,
+                                   session_id: str,
+                                   agent_id: Optional[str] = None,
+                                   base_dir: Optional[str] = None) -> Tuple[int, int]:
+        """Delete every attachment row for a single session and remove its files.
+
+        Returns a (deleted_rows, freed_bytes) tuple. When ``agent_id`` is
+        provided, the on-disk subdirectory ``<base_dir>/<agent_id>/<session_id>/``
+        is also best-effort removed to clean up any orphaned files left behind
+        by earlier crashes. ``base_dir`` defaults to ``data/attachments``
+        relative to the current working directory.
+        """
+        if not session_id:
+            return 0, 0
+        deleted = 0
+        freed = 0
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            if agent_id:
+                cursor.execute(
+                    "SELECT id, file_path, size_bytes FROM attachments "
+                    "WHERE session_id = ? AND agent_id = ?",
+                    (session_id, agent_id),
+                )
+            else:
+                cursor.execute(
+                    "SELECT id, file_path, size_bytes FROM attachments "
+                    "WHERE session_id = ?",
+                    (session_id,),
+                )
+            rows = [dict(r) for r in cursor.fetchall()]
+        for row in rows:
+            path = row.get('file_path')
+            if path:
+                try:
+                    if os.path.isfile(path):
+                        os.remove(path)
+                        freed += int(row.get('size_bytes') or 0)
+                except OSError as e:
+                    logger.warning(
+                        "Failed to remove attachment file %s: %s", path, e
+                    )
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            if agent_id:
+                cursor.execute(
+                    "DELETE FROM attachments WHERE session_id = ? AND agent_id = ?",
+                    (session_id, agent_id),
+                )
+            else:
+                cursor.execute(
+                    "DELETE FROM attachments WHERE session_id = ?",
+                    (session_id,),
+                )
+            deleted = cursor.rowcount or 0
+            conn.commit()
+        # Best-effort wipe of the per-session on-disk subdir to catch any
+        # orphaned files (e.g. written before the DB row was committed).
+        if agent_id:
+            target_root = base_dir or os.path.join('data', 'attachments')
+            session_dir = os.path.join(target_root, agent_id, session_id)
+            try:
+                if os.path.isdir(session_dir):
+                    shutil.rmtree(session_dir, ignore_errors=True)
+            except OSError as e:
+                logger.warning(
+                    "Failed to remove attachment session dir %s: %s",
+                    session_dir, e,
+                )
+        return deleted, freed
+
+    def delete_all_attachments(self, base_dir: Optional[str] = None) -> Tuple[int, int]:
+        """Bulk delete every attachment row and best-effort wipe the on-disk tree.
+
+        Returns a (deleted_rows, freed_bytes) tuple. ``base_dir`` defaults to
+        ``data/attachments`` relative to the current working directory and is
+        only used when individual file paths in the DB are missing or fail to
+        remove (e.g. orphaned files left behind by earlier crashes).
+        """
+        deleted = 0
+        freed = 0
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, file_path, size_bytes FROM attachments")
+            rows = [dict(r) for r in cursor.fetchall()]
+        for row in rows:
+            path = row.get('file_path')
+            if path:
+                try:
+                    if os.path.isfile(path):
+                        os.remove(path)
+                        freed += int(row.get('size_bytes') or 0)
+                except OSError as e:
+                    logger.warning(
+                        "Failed to remove attachment file %s: %s", path, e
+                    )
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM attachments")
+            deleted = cursor.rowcount or 0
+            conn.commit()
+        # Best-effort wipe of the on-disk tree to clean up any orphaned files
+        # (e.g. files written before the DB row was committed, or stale dirs).
+        target_dir = base_dir or os.path.join('data', 'attachments')
+        try:
+            if os.path.isdir(target_dir):
+                for entry in os.listdir(target_dir):
+                    entry_path = os.path.join(target_dir, entry)
+                    try:
+                        if os.path.isdir(entry_path):
+                            shutil.rmtree(entry_path, ignore_errors=True)
+                        elif os.path.isfile(entry_path):
+                            os.remove(entry_path)
+                    except OSError as e:
+                        logger.warning(
+                            "Failed to remove attachment path %s: %s",
+                            entry_path, e,
+                        )
+        except OSError as e:
+            logger.warning(
+                "Failed to wipe attachments base dir %s: %s", target_dir, e
+            )
         return deleted, freed
 
     def get_agent_attachment_config(self, agent_id: str) -> Dict[str, Any]:

--- a/models/mixins/attachments.py
+++ b/models/mixins/attachments.py
@@ -126,35 +126,37 @@ class AttachmentsMixin:
 
     def delete_session_attachments(self,
                                    session_id: str,
-                                   agent_id: Optional[str] = None,
+                                   agent_id: str,
                                    base_dir: Optional[str] = None) -> Tuple[int, int]:
         """Delete every attachment row for a single session and remove its files.
 
-        Returns a (deleted_rows, freed_bytes) tuple. When ``agent_id`` is
-        provided, the on-disk subdirectory ``<base_dir>/<agent_id>/<session_id>/``
-        is also best-effort removed to clean up any orphaned files left behind
-        by earlier crashes. ``base_dir`` defaults to ``data/attachments``
-        relative to the current working directory.
+        Returns a (deleted_rows, freed_bytes) tuple. The on-disk subdirectory
+        ``<base_dir>/<agent_id>/<session_id>/`` is also best-effort removed to
+        clean up any orphaned files left behind by earlier crashes.
+        ``base_dir`` defaults to ``data/attachments`` relative to the current
+        working directory.
+
+        ``agent_id`` is required to prevent accidental cross-agent deletion of
+        every agent's rows for a shared ``session_id``. Passing a falsy
+        ``agent_id`` raises ``ValueError``.
         """
         if not session_id:
             return 0, 0
+        if not agent_id:
+            raise ValueError(
+                "delete_session_attachments requires an agent_id to avoid "
+                "cross-agent deletion of session rows."
+            )
         deleted = 0
         freed = 0
         with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
-            if agent_id:
-                cursor.execute(
-                    "SELECT id, file_path, size_bytes FROM attachments "
-                    "WHERE session_id = ? AND agent_id = ?",
-                    (session_id, agent_id),
-                )
-            else:
-                cursor.execute(
-                    "SELECT id, file_path, size_bytes FROM attachments "
-                    "WHERE session_id = ?",
-                    (session_id,),
-                )
+            cursor.execute(
+                "SELECT id, file_path, size_bytes FROM attachments "
+                "WHERE session_id = ? AND agent_id = ?",
+                (session_id, agent_id),
+            )
             rows = [dict(r) for r in cursor.fetchall()]
         for row in rows:
             path = row.get('file_path')
@@ -169,31 +171,24 @@ class AttachmentsMixin:
                     )
         with self._connect() as conn:
             cursor = conn.cursor()
-            if agent_id:
-                cursor.execute(
-                    "DELETE FROM attachments WHERE session_id = ? AND agent_id = ?",
-                    (session_id, agent_id),
-                )
-            else:
-                cursor.execute(
-                    "DELETE FROM attachments WHERE session_id = ?",
-                    (session_id,),
-                )
+            cursor.execute(
+                "DELETE FROM attachments WHERE session_id = ? AND agent_id = ?",
+                (session_id, agent_id),
+            )
             deleted = cursor.rowcount or 0
             conn.commit()
         # Best-effort wipe of the per-session on-disk subdir to catch any
         # orphaned files (e.g. written before the DB row was committed).
-        if agent_id:
-            target_root = base_dir or os.path.join('data', 'attachments')
-            session_dir = os.path.join(target_root, agent_id, session_id)
-            try:
-                if os.path.isdir(session_dir):
-                    shutil.rmtree(session_dir, ignore_errors=True)
-            except OSError as e:
-                logger.warning(
-                    "Failed to remove attachment session dir %s: %s",
-                    session_dir, e,
-                )
+        target_root = base_dir or os.path.join('data', 'attachments')
+        session_dir = os.path.join(target_root, agent_id, session_id)
+        try:
+            if os.path.isdir(session_dir):
+                shutil.rmtree(session_dir, ignore_errors=True)
+        except OSError as e:
+            logger.warning(
+                "Failed to remove attachment session dir %s: %s",
+                session_dir, e,
+            )
         return deleted, freed
 
     def delete_all_attachments(self, base_dir: Optional[str] = None) -> Tuple[int, int]:

--- a/models/mixins/attachments.py
+++ b/models/mixins/attachments.py
@@ -1,0 +1,175 @@
+import os
+import sqlite3
+import logging
+from typing import Dict, Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class AttachmentsMixin:
+    """Attachments CRUD + retention + per-agent config resolution.
+
+    Requires self._connect() from the host class.
+    Attachments back the Telegram (and future) attachment ingestion feature.
+    Files live under data/attachments/<agent_id>/<session_id>/<ts>_<name>.
+    """
+
+    def save_attachment(self,
+                        agent_id: str,
+                        session_id: str,
+                        filename: str,
+                        file_path: str,
+                        external_user_id: Optional[str] = None,
+                        channel_id: Optional[str] = None,
+                        channel_type: Optional[str] = None,
+                        original_filename: Optional[str] = None,
+                        mime_type: Optional[str] = None,
+                        file_type: Optional[str] = None,
+                        size_bytes: Optional[int] = None,
+                        telegram_file_id: Optional[str] = None) -> int:
+        """Insert a new attachment row and return its id."""
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO attachments (
+                    agent_id, session_id, external_user_id, channel_id, channel_type,
+                    filename, original_filename, mime_type, file_type, size_bytes,
+                    file_path, telegram_file_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    agent_id, session_id, external_user_id, channel_id, channel_type,
+                    filename, original_filename, mime_type, file_type, size_bytes,
+                    file_path, telegram_file_id,
+                ),
+            )
+            conn.commit()
+            return int(cursor.lastrowid)
+
+    def get_attachment(self, attachment_id: int) -> Optional[Dict[str, Any]]:
+        """Return a single attachment row by id, or None."""
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM attachments WHERE id = ?", (attachment_id,))
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+    def list_session_attachments(self, session_id: str, agent_id: str) -> List[Dict[str, Any]]:
+        """List all attachments for a given (session, agent), newest first."""
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM attachments WHERE session_id = ? AND agent_id = ? "
+                "ORDER BY created_at DESC, id DESC",
+                (session_id, agent_id),
+            )
+            return [dict(r) for r in cursor.fetchall()]
+
+    def delete_attachment(self, attachment_id: int) -> bool:
+        """Delete the attachment row and best-effort remove the file on disk."""
+        row = self.get_attachment(attachment_id)
+        if not row:
+            return False
+        # Best-effort file removal first; failures are logged but do not block row removal.
+        path = row.get('file_path')
+        if path:
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+            except OSError as e:
+                logger.warning("Failed to remove attachment file %s: %s", path, e)
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM attachments WHERE id = ?", (attachment_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def cleanup_expired_attachments(self, max_age_days: int = 7) -> Tuple[int, int]:
+        """Bulk delete attachments older than max_age_days.
+
+        Returns a (deleted_count, freed_bytes) tuple. File-removal failures are
+        logged and counted toward freed_bytes only when the file actually existed
+        and got removed.
+        """
+        if max_age_days is None or max_age_days < 0:
+            max_age_days = 7
+        deleted = 0
+        freed = 0
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, file_path, size_bytes FROM attachments "
+                "WHERE created_at < datetime('now', ?)",
+                (f"-{int(max_age_days)} days",),
+            )
+            rows = [dict(r) for r in cursor.fetchall()]
+        for row in rows:
+            path = row.get('file_path')
+            if path:
+                try:
+                    if os.path.isfile(path):
+                        os.remove(path)
+                        freed += int(row.get('size_bytes') or 0)
+                except OSError as e:
+                    logger.warning("Failed to remove expired attachment file %s: %s", path, e)
+            with self._connect() as conn:
+                cursor = conn.cursor()
+                cursor.execute("DELETE FROM attachments WHERE id = ?", (row['id'],))
+                conn.commit()
+                deleted += cursor.rowcount or 0
+        return deleted, freed
+
+    def get_agent_attachment_config(self, agent_id: str) -> Dict[str, Any]:
+        """Resolve the effective attachment configuration for an agent.
+
+        Returns dict: {enabled: bool, max_size_mb: int, supported: bool, model_id: Optional[str]}.
+        Resolves model via agents.default_model_id, falling back to the global default model.
+        """
+        result = {
+            'enabled': False,
+            'max_size_mb': 20,
+            'supported': False,
+            'model_id': None,
+        }
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT attachments_enabled, attachment_max_size_mb, default_model_id "
+                "FROM agents WHERE id = ?",
+                (agent_id,),
+            )
+            agent_row = cursor.fetchone()
+            if not agent_row:
+                return result
+            result['enabled'] = bool(agent_row['attachments_enabled'])
+            try:
+                result['max_size_mb'] = int(agent_row['attachment_max_size_mb'] or 20)
+            except (TypeError, ValueError):
+                result['max_size_mb'] = 20
+            # Hard-cap to Telegram bot API limit
+            if result['max_size_mb'] > 20:
+                result['max_size_mb'] = 20
+
+            model_id = agent_row['default_model_id']
+            model_row = None
+            if model_id:
+                cursor.execute(
+                    "SELECT id, attachments_supported FROM llm_models WHERE id = ?",
+                    (model_id,),
+                )
+                model_row = cursor.fetchone()
+            if not model_row:
+                cursor.execute(
+                    "SELECT id, attachments_supported FROM llm_models "
+                    "WHERE is_default = 1 LIMIT 1"
+                )
+                model_row = cursor.fetchone()
+            if model_row:
+                result['model_id'] = model_row['id']
+                result['supported'] = bool(model_row['attachments_supported'])
+        return result

--- a/models/mixins/chat_delegation.py
+++ b/models/mixins/chat_delegation.py
@@ -166,7 +166,7 @@ class ChatDelegationMixin:
             # they don't linger unreachable after the conversation is gone.
             try:
                 self.delete_session_attachments(session_id, agent_id)
-            except (sqlite3.Error, OSError) as e:
+            except (sqlite3.Error, OSError, ValueError) as e:
                 import logging
                 logging.getLogger(__name__).warning(
                     "Failed to clear attachments for session %s: %s",

--- a/models/mixins/chat_delegation.py
+++ b/models/mixins/chat_delegation.py
@@ -162,6 +162,16 @@ class ChatDelegationMixin:
             except FileNotFoundError:
                 pass
             self._refresh_session_count(agent_id)
+            # Wipe attachments tied to this session (rows + on-disk files) so
+            # they don't linger unreachable after the conversation is gone.
+            try:
+                self.delete_session_attachments(session_id, agent_id)
+            except (sqlite3.Error, OSError) as e:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Failed to clear attachments for session %s: %s",
+                    session_id, e,
+                )
         return result
 
     def get_first_agent_request_metadata(self, session_id: str, agent_id: str = None) -> dict | None:
@@ -341,11 +351,26 @@ class ChatDelegationMixin:
         return None
 
     def clear_all_sessions(self):
-        """Drop all chat sessions, messages, and summaries across all agents."""
+        """Drop all chat sessions, messages, and summaries across all agents.
+
+        Also removes every stored attachment (rows + on-disk files) since they
+        are no longer reachable once the sessions referencing them are gone.
+        """
         agents = self.get_agents()
         for agent in agents:
             chat_db = self._chat_db(agent['id'])
             chat_db.clear_all()
+        # Wipe attachments after sessions to keep storage in sync with the
+        # newly-cleared chat history.
+        try:
+            self.delete_all_attachments()
+        except (sqlite3.Error, OSError) as e:
+            # Logged inside delete_all_attachments for per-file errors; this
+            # catches DB-level issues without breaking the session clear.
+            import logging
+            logging.getLogger(__name__).warning(
+                "Failed to clear attachments during clear_all_sessions: %s", e
+            )
 
     # ---- Long-term Memory delegation ----
 

--- a/models/mixins/models.py
+++ b/models/mixins/models.py
@@ -24,8 +24,8 @@ class ModelsMixin:
                     INSERT INTO llm_models (id, name, type, provider, base_url, api_key,
                         model_name, max_tokens, timeout, thinking, thinking_budget,
                         temperature, enabled, is_default, model_max_concurrent, api_format,
-                        vision_supported)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        vision_supported, attachments_supported)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     m.get('id'),
                     m.get('name'),
@@ -44,6 +44,7 @@ class ModelsMixin:
                     m.get('model_max_concurrent', 1),
                     m.get('api_format', 'openai'),
                     m.get('vision_supported', 0),
+                    m.get('attachments_supported', 0),
                 ))
             conn.commit()
 
@@ -118,8 +119,8 @@ class ModelsMixin:
                 INSERT INTO llm_models (id, name, type, provider, base_url, api_key,
                     model_name, max_tokens, timeout, thinking, thinking_budget,
                     temperature, enabled, is_default, model_max_concurrent, api_format,
-                    vision_supported)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    vision_supported, attachments_supported)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 model_id,
                 model_data.get('name'),
@@ -138,6 +139,7 @@ class ModelsMixin:
                 model_data.get('model_max_concurrent', 1),
                 model_data.get('api_format', 'openai'),
                 model_data.get('vision_supported', 0),
+                model_data.get('attachments_supported', 0),
             ))
             conn.commit()
         return model_id
@@ -146,7 +148,7 @@ class ModelsMixin:
         """Update an existing model."""
         allowed = {'name', 'type', 'provider', 'base_url', 'api_key', 'model_name',
                    'max_tokens', 'timeout', 'thinking', 'thinking_budget', 'temperature', 'enabled', 'is_default',
-                   'model_max_concurrent', 'api_format', 'vision_supported'}
+                   'model_max_concurrent', 'api_format', 'vision_supported', 'attachments_supported'}
         updates = {k: v for k, v in model_data.items() if k in allowed}
         if not updates:
             return False

--- a/models/schema.py
+++ b/models/schema.py
@@ -363,6 +363,8 @@ class SchemaMixin:
                 ("enabled", "BOOLEAN DEFAULT 1"),
                 ("default_model_id", "TEXT"),
                 ("sandbox_enabled", "BOOLEAN DEFAULT 0"),
+                ("attachments_enabled", "BOOLEAN DEFAULT 0"),
+                ("attachment_max_size_mb", "INTEGER DEFAULT 20"),
             ]:
                 try:
                     cursor.execute(f"ALTER TABLE agents ADD COLUMN {col} {defn}")
@@ -578,6 +580,36 @@ class SchemaMixin:
                 cursor.execute("ALTER TABLE llm_models ADD COLUMN vision_supported BOOLEAN DEFAULT 0")
             except sqlite3.OperationalError:
                 pass
+
+            # Migration: add attachments_supported column to llm_models if missing
+            try:
+                cursor.execute("ALTER TABLE llm_models ADD COLUMN attachments_supported BOOLEAN DEFAULT 0")
+            except sqlite3.OperationalError:
+                pass
+
+            # ==================== Attachments Table ====================
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS attachments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    agent_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    external_user_id TEXT,
+                    channel_id TEXT,
+                    channel_type TEXT,
+                    filename TEXT NOT NULL,
+                    original_filename TEXT,
+                    mime_type TEXT,
+                    file_type TEXT,
+                    size_bytes INTEGER,
+                    file_path TEXT NOT NULL,
+                    telegram_file_id TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+                )
+            """)
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_attachments_session ON attachments(session_id, agent_id)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_attachments_created ON attachments(created_at)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_attachments_agent ON attachments(agent_id)")
 
             # Create indexes for faster queries
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_tests_domain ON tests(domain_id)")

--- a/routes/models.py
+++ b/routes/models.py
@@ -176,6 +176,7 @@ def api_clone_model(model_id):
         "model_max_concurrent": source.get("model_max_concurrent", 1),
         "api_format": source.get("api_format", "openai"),
         "vision_supported": source.get("vision_supported", 0),
+        "attachments_supported": source.get("attachments_supported", 0),
     }
     db.create_model(clone_data)
     return jsonify({"success": True, "model_id": new_id})

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -112,6 +112,15 @@ def api_delete_session(session_id):
 
 @sessions_bp.route('/api/sessions/clear-all', methods=['POST'])
 def api_clear_all_sessions():
-    """Delete all chat sessions, messages, and summaries across all agents."""
+    """Delete all chat sessions, messages, summaries, and attachments
+    across all agents."""
     db.clear_all_sessions()
     return jsonify({'success': True})
+
+
+@sessions_bp.route('/api/attachments/clear-all', methods=['POST'])
+def api_clear_all_attachments():
+    """Delete every stored attachment (DB rows + on-disk files) across all
+    agents and sessions, without touching chat sessions/messages."""
+    deleted, freed = db.delete_all_attachments()
+    return jsonify({'success': True, 'deleted': deleted, 'freed_bytes': freed})

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -259,6 +259,20 @@ html.dark #channel-detail-modal .hover\:bg-indigo-100:hover { background: #312e8
             </div>
             <div class="mb-4">
                 <label class="flex items-center gap-3 cursor-pointer select-none">
+                    {{ toggle_widget(id='agent-attachments', checked=agent.attachments_enabled) }}
+                    <div>
+                        <span class="text-gray-600 dark:text-gray-300 text-sm font-medium">Attachments (Files)</span>
+                        <p class="text-xs text-gray-400 mt-0.5">Allow agent to receive non-image files (PDF, audio, video, etc.) from channels. Files are stored for 7 days and read on demand via the <code>read_attachment</code> tool. Requires a model with <code>attachments_supported</code>.</p>
+                    </div>
+                </label>
+                <div class="mt-2 flex items-center gap-2">
+                    <label for="agent-attachment-max-mb" class="text-xs text-gray-500 dark:text-gray-400">Max file size (MB):</label>
+                    <input type="number" id="agent-attachment-max-mb" min="1" max="20" value="{{ agent.attachment_max_size_mb if agent.attachment_max_size_mb is not none else 20 }}" class="w-20 p-1.5 border border-gray-300 rounded-md text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/10">
+                    <span class="text-xs text-gray-400">Telegram hard-caps at 20 MB.</span>
+                </div>
+            </div>
+            <div class="mb-4">
+                <label class="flex items-center gap-3 cursor-pointer select-none">
                     {{ toggle_widget(id='agent-inject-id', checked=agent.inject_agent_id) }}
                     <div>
                         <span class="text-gray-600 dark:text-gray-300 text-sm font-medium">Inject Agent ID</span>
@@ -1369,6 +1383,8 @@ async function saveGeneral() {
             workplace_id: homeSel ? homeSel.value || null : null,
             system_prompt: document.getElementById('agent-system-prompt').value,
             vision_enabled: document.getElementById('agent-vision').checked ? 1 : 0,
+            attachments_enabled: document.getElementById('agent-attachments').checked ? 1 : 0,
+            attachment_max_size_mb: Math.min(20, Math.max(1, parseInt(document.getElementById('agent-attachment-max-mb').value) || 20)),
             sandbox_enabled: isRemoteOrCloud ? 0 : (document.getElementById('agent-sandbox').checked ? 1 : 0),
             safety_checker_enabled: document.getElementById('agent-safety-checker').checked ? 1 : 0,
             inject_agent_id: document.getElementById('agent-inject-id').checked ? 1 : 0,

--- a/templates/sessions.html
+++ b/templates/sessions.html
@@ -184,9 +184,22 @@ html.dark #mobile-dropdown .border-b { border-color: #374151; }
                 <div class="flex items-start justify-between gap-4">
                     <div>
                         <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Clear All Sessions</h3>
-                        <p class="text-xs text-gray-500 mt-1">Permanently delete all chat sessions, messages, and summaries across all agents. This action cannot be undone.</p>
+                        <p class="text-xs text-gray-500 mt-1">Permanently delete all chat sessions, messages, summaries, and their attachments across all agents. This action cannot be undone.</p>
                     </div>
                     <button onclick="clearAllSessions()" class="flex-shrink-0 px-4 py-2 bg-red-500 text-white text-sm font-medium rounded-lg hover:bg-red-600 transition-colors">
+                        Clear All
+                    </button>
+                </div>
+            </div>
+
+            <!-- Clear All Attachments -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+                <div class="flex items-start justify-between gap-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Clear All Attachments</h3>
+                        <p class="text-xs text-gray-500 mt-1">Permanently delete every stored attachment (files and database rows) across all agents and sessions, without removing the conversations themselves. This action cannot be undone.</p>
+                    </div>
+                    <button onclick="clearAllAttachments()" class="flex-shrink-0 px-4 py-2 bg-red-500 text-white text-sm font-medium rounded-lg hover:bg-red-600 transition-colors">
                         Clear All
                     </button>
                 </div>
@@ -1284,7 +1297,7 @@ function updateReplyPlaceholder() {
 async function clearAllSessions() {
     if (!await showConfirm({
         title: 'Clear All Sessions',
-        message: 'This will permanently delete ALL chat sessions, messages, and summaries across ALL agents. This cannot be undone.',
+        message: 'This will permanently delete ALL chat sessions, messages, summaries, and their attachments across ALL agents. This cannot be undone.',
         confirmText: 'Clear All'
     })) return;
 
@@ -1305,6 +1318,27 @@ async function clearAllSessions() {
         showMobileSummaryBtn(false);
         clearSummaryPanel();
         showToast('All sessions cleared successfully');
+    }
+}
+
+async function clearAllAttachments() {
+    if (!await showConfirm({
+        title: 'Clear All Attachments',
+        message: 'This will permanently delete EVERY stored attachment (files and database rows) across ALL agents and sessions. The conversations themselves will be kept. This cannot be undone.',
+        confirmText: 'Clear All'
+    })) return;
+
+    try {
+        const res = await fetch('/api/attachments/clear-all', {method: 'POST'});
+        const data = await res.json();
+        if (data.success) {
+            const freedMb = data.freed_bytes ? (data.freed_bytes / (1024 * 1024)).toFixed(2) : '0.00';
+            showToast(`Cleared ${data.deleted || 0} attachments (${freedMb} MB freed)`);
+        } else {
+            showToast('Failed to clear attachments', true);
+        }
+    } catch (e) {
+        showToast('Failed to clear attachments', true);
     }
 }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -663,6 +663,32 @@ block content %}
                     Set as Global Default
                 </label>
             </div>
+
+            <div class="mb-4">
+                <label
+                    class="inline-flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                    <input
+                        type="checkbox"
+                        id="model-vision-supported"
+                        class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    Vision Supported (model can process images)
+                </label>
+            </div>
+
+            <div class="mb-4">
+                <label
+                    class="inline-flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                    <input
+                        type="checkbox"
+                        id="model-attachments-supported"
+                        class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    Attachments Supported (model can handle file attachments)
+                </label>
+            </div>
         </form>
         <div
             class="flex justify-end gap-2 px-6 pb-5 pt-4 border-t border-gray-100 dark:border-gray-700 flex-shrink-0"
@@ -2181,6 +2207,10 @@ block content %}
         document.getElementById("model-enabled").checked = !!model.enabled;
         document.getElementById("model-is-default").checked =
             !!model.is_default;
+        document.getElementById("model-vision-supported").checked =
+            !!model.vision_supported;
+        document.getElementById("model-attachments-supported").checked =
+            !!model.attachments_supported;
 
         toggleModelFields();
         $("#model-modal").addClass("active");
@@ -2239,6 +2269,8 @@ block content %}
             is_default: document.getElementById("model-is-default").checked
                 ? 1
                 : 0,
+            vision_supported: document.getElementById("model-vision-supported").checked ? 1 : 0,
+            attachments_supported: document.getElementById("model-attachments-supported").checked ? 1 : 0,
         };
 
         try {

--- a/tools/cleanup_attachments.json
+++ b/tools/cleanup_attachments.json
@@ -1,0 +1,23 @@
+{
+  "id": "cleanup_attachments",
+  "name": "Cleanup attachments",
+  "description": "Admin tool: delete stored user attachments older than N days (rows + files). Restricted to super agents.",
+  "function": {
+    "name": "cleanup_attachments",
+    "description": "Delete attachment files and database rows older than `older_than_days` days. Returns the deleted count and freed bytes. Only super agents may invoke this tool.",
+    "parameters": {
+      "properties": {
+        "older_than_days": {
+          "description": "Maximum age in days (default: 7). Attachments older than this will be permanently removed.",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
+    }
+  },
+  "mock_response": "{\"deleted_count\": 0, \"freed_bytes\": 0}",
+  "mock_response_type": "text",
+  "created_at": "2026-05-14T11:50:00.000000",
+  "updated_at": "2026-05-14T11:50:00.000000"
+}

--- a/tools/read_attachment.json
+++ b/tools/read_attachment.json
@@ -24,8 +24,10 @@
       "type": "object"
     }
   },
-  "mock_response": "[Attachment: example.pdf (application/pdf, 240KB)]\n\nMock content for read_attachment.",
-  "mock_response_type": "text",
+  "mock_response": {
+    "result": "[Attachment: example.pdf (application/pdf, 240KB)]\n\nMock content for read_attachment."
+  },
+  "mock_response_type": "json",
   "created_at": "2026-05-14T11:50:00.000000",
-  "updated_at": "2026-05-14T11:50:00.000000"
+  "updated_at": "2026-05-15T10:07:00.000000"
 }

--- a/tools/read_attachment.json
+++ b/tools/read_attachment.json
@@ -1,0 +1,31 @@
+{
+  "id": "read_attachment",
+  "name": "Read attachment",
+  "description": "Read a user-uploaded file attachment that was delivered via a channel (e.g. Telegram).",
+  "function": {
+    "name": "read_attachment",
+    "description": "Read the content of a user-sent file attachment. Use the id=N value from the [Attached: ...] line in the user's message. Returns paginated text for text/code files, extracted text for PDFs when supported, or a metadata block for binary files. Files are isolated per agent and expire after 7 days.",
+    "parameters": {
+      "properties": {
+        "attachment_id": {
+          "description": "Numeric ID from the [Attached: id=N ...] line. Preferred over 'path'.",
+          "type": "integer"
+        },
+        "path": {
+          "description": "Fallback: direct file path under data/attachments/<agent_id>/. Used only if attachment_id is not provided.",
+          "type": "string"
+        },
+        "offset": {
+          "description": "1-based line number to start reading from for text/code/PDF content (default: 1). Use this to paginate through large files.",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
+    }
+  },
+  "mock_response": "[Attachment: example.pdf (application/pdf, 240KB)]\n\nMock content for read_attachment.",
+  "mock_response_type": "text",
+  "created_at": "2026-05-14T11:50:00.000000",
+  "updated_at": "2026-05-14T11:50:00.000000"
+}

--- a/unit_tests/test_attachments_mixin.py
+++ b/unit_tests/test_attachments_mixin.py
@@ -151,3 +151,64 @@ def test_get_agent_attachment_config_caps_max_size_to_20():
 def test_get_agent_attachment_config_unknown_agent():
     cfg = db.get_agent_attachment_config('does_not_exist')
     assert cfg == {'enabled': False, 'max_size_mb': 20, 'supported': False, 'model_id': None}
+
+
+def test_delete_session_attachments_removes_rows_and_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('del_sess_agent')
+    # Place files under the conventional data/attachments/<agent>/<session>/ tree
+    # so the per-session subdir cleanup can be exercised.
+    sess_dir = tmp_path / 'data' / 'attachments' / 'del_sess_agent' / 'sX'
+    sess_dir.mkdir(parents=True)
+    p1 = sess_dir / 'one.txt'
+    p1.write_bytes(b'AA')
+    p2 = sess_dir / 'two.txt'
+    p2.write_bytes(b'BBB')
+    a1 = db.save_attachment(agent_id='del_sess_agent', session_id='sX',
+                            filename='one.txt', file_path=str(p1), size_bytes=2)
+    a2 = db.save_attachment(agent_id='del_sess_agent', session_id='sX',
+                            filename='two.txt', file_path=str(p2), size_bytes=3)
+    # Another session must remain untouched.
+    other_dir = tmp_path / 'data' / 'attachments' / 'del_sess_agent' / 'sY'
+    other_dir.mkdir(parents=True)
+    p_other = other_dir / 'keep.txt'
+    p_other.write_bytes(b'KEEP')
+    a_other = db.save_attachment(agent_id='del_sess_agent', session_id='sY',
+                                 filename='keep.txt', file_path=str(p_other),
+                                 size_bytes=4)
+
+    deleted, freed = db.delete_session_attachments('sX', 'del_sess_agent')
+    assert deleted == 2
+    assert freed == 5
+    assert db.get_attachment(a1) is None
+    assert db.get_attachment(a2) is None
+    assert not p1.exists()
+    assert not p2.exists()
+    # Session subdir was wiped, but the other session's tree survived.
+    assert not sess_dir.exists()
+    assert db.get_attachment(a_other) is not None
+    assert p_other.exists()
+
+
+def test_delete_session_attachments_without_agent_id(tmp_path):
+    _make_agent('del_sess_agent2')
+    path = _write_file(tmp_path, 'solo.txt', b'SOLO')
+    aid = db.save_attachment(agent_id='del_sess_agent2', session_id='sZ',
+                             filename='solo.txt', file_path=path, size_bytes=4)
+    deleted, freed = db.delete_session_attachments('sZ')
+    assert deleted == 1
+    assert freed == 4
+    assert db.get_attachment(aid) is None
+    assert not os.path.exists(path)
+
+
+def test_delete_session_attachments_no_rows():
+    _make_agent('del_sess_agent3')
+    deleted, freed = db.delete_session_attachments('nonexistent', 'del_sess_agent3')
+    assert deleted == 0
+    assert freed == 0
+
+
+def test_delete_session_attachments_empty_session_id():
+    deleted, freed = db.delete_session_attachments('')
+    assert (deleted, freed) == (0, 0)

--- a/unit_tests/test_attachments_mixin.py
+++ b/unit_tests/test_attachments_mixin.py
@@ -190,16 +190,21 @@ def test_delete_session_attachments_removes_rows_and_files(tmp_path, monkeypatch
     assert p_other.exists()
 
 
-def test_delete_session_attachments_without_agent_id(tmp_path):
+def test_delete_session_attachments_requires_agent_id(tmp_path):
+    """Calling without an agent_id must raise ValueError and delete nothing,
+    to prevent accidentally wiping every agent's rows for a shared session_id.
+    """
     _make_agent('del_sess_agent2')
     path = _write_file(tmp_path, 'solo.txt', b'SOLO')
     aid = db.save_attachment(agent_id='del_sess_agent2', session_id='sZ',
                              filename='solo.txt', file_path=path, size_bytes=4)
-    deleted, freed = db.delete_session_attachments('sZ')
-    assert deleted == 1
-    assert freed == 4
-    assert db.get_attachment(aid) is None
-    assert not os.path.exists(path)
+    with pytest.raises(ValueError):
+        db.delete_session_attachments('sZ', '')
+    with pytest.raises(ValueError):
+        db.delete_session_attachments('sZ', None)
+    # No row or file was touched.
+    assert db.get_attachment(aid) is not None
+    assert os.path.exists(path)
 
 
 def test_delete_session_attachments_no_rows():
@@ -210,5 +215,8 @@ def test_delete_session_attachments_no_rows():
 
 
 def test_delete_session_attachments_empty_session_id():
-    deleted, freed = db.delete_session_attachments('')
+    # Empty session_id short-circuits BEFORE the agent_id guard.
+    deleted, freed = db.delete_session_attachments('', '')
+    assert (deleted, freed) == (0, 0)
+    deleted, freed = db.delete_session_attachments('', 'some_agent')
     assert (deleted, freed) == (0, 0)

--- a/unit_tests/test_attachments_mixin.py
+++ b/unit_tests/test_attachments_mixin.py
@@ -1,0 +1,153 @@
+"""Unit tests for AttachmentsMixin (CRUD, cleanup, config resolution)."""
+import os
+import time
+import sqlite3
+import pytest
+from models.db import db
+
+
+def _make_agent(agent_id='att_agent', model_id=None,
+                attachments_enabled=1, max_size_mb=20):
+    db.create_agent({
+        'id': agent_id,
+        'name': agent_id,
+        'system_prompt': '',
+    })
+    # Apply attachment columns + default model directly (update_agent does not
+    # accept default_model_id).
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE agents SET attachments_enabled = ?, attachment_max_size_mb = ?, "
+            "default_model_id = ? WHERE id = ?",
+            (attachments_enabled, max_size_mb, model_id, agent_id),
+        )
+    return agent_id
+
+
+def _make_model(model_id='m1', attachments_supported=1, is_default=0):
+    db.create_model({
+        'id': model_id,
+        'name': model_id,
+        'type': 'openai',
+        'provider': 'openai',
+        'model_name': model_id,
+        'attachments_supported': attachments_supported,
+        'is_default': is_default,
+    })
+    return model_id
+
+
+def _write_file(tmp_path, name='hello.txt', body=b'hi'):
+    p = tmp_path / name
+    p.write_bytes(body)
+    return str(p)
+
+
+def test_save_and_get_attachment(tmp_path):
+    _make_agent()
+    path = _write_file(tmp_path)
+    aid = db.save_attachment(
+        agent_id='att_agent',
+        session_id='s1',
+        filename='hello.txt',
+        file_path=path,
+        original_filename='hello.txt',
+        mime_type='text/plain',
+        file_type='document',
+        size_bytes=2,
+        channel_type='telegram',
+        telegram_file_id='tg_xyz',
+    )
+    assert isinstance(aid, int) and aid > 0
+    row = db.get_attachment(aid)
+    assert row is not None
+    assert row['agent_id'] == 'att_agent'
+    assert row['session_id'] == 's1'
+    assert row['mime_type'] == 'text/plain'
+    assert row['telegram_file_id'] == 'tg_xyz'
+    assert row['file_path'] == path
+
+
+def test_list_session_attachments(tmp_path):
+    _make_agent()
+    p1 = _write_file(tmp_path, 'a.txt')
+    p2 = _write_file(tmp_path, 'b.txt')
+    a1 = db.save_attachment(agent_id='att_agent', session_id='s1',
+                            filename='a.txt', file_path=p1)
+    a2 = db.save_attachment(agent_id='att_agent', session_id='s1',
+                            filename='b.txt', file_path=p2)
+    db.save_attachment(agent_id='att_agent', session_id='s2',
+                       filename='c.txt', file_path=p2)
+    rows = db.list_session_attachments('s1', 'att_agent')
+    ids = {r['id'] for r in rows}
+    assert ids == {a1, a2}
+
+
+def test_delete_attachment_removes_row_and_file(tmp_path):
+    _make_agent()
+    path = _write_file(tmp_path)
+    aid = db.save_attachment(agent_id='att_agent', session_id='s1',
+                             filename='hello.txt', file_path=path)
+    assert os.path.isfile(path)
+    assert db.delete_attachment(aid) is True
+    assert db.get_attachment(aid) is None
+    assert not os.path.exists(path)
+
+
+def test_delete_attachment_missing_returns_false():
+    _make_agent()
+    assert db.delete_attachment(9999) is False
+
+
+def test_cleanup_expired_attachments(tmp_path):
+    _make_agent()
+    p_old = _write_file(tmp_path, 'old.txt', b'OLD')
+    p_new = _write_file(tmp_path, 'new.txt', b'NEW')
+    old_id = db.save_attachment(agent_id='att_agent', session_id='s1',
+                                filename='old.txt', file_path=p_old, size_bytes=3)
+    new_id = db.save_attachment(agent_id='att_agent', session_id='s1',
+                                filename='new.txt', file_path=p_new, size_bytes=3)
+    # Backdate old row to 10 days ago.
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE attachments SET created_at = datetime('now', '-10 days') WHERE id = ?",
+            (old_id,),
+        )
+    deleted, freed = db.cleanup_expired_attachments(max_age_days=7)
+    assert deleted == 1
+    assert freed == 3
+    assert db.get_attachment(old_id) is None
+    assert db.get_attachment(new_id) is not None
+    assert not os.path.exists(p_old)
+    assert os.path.exists(p_new)
+
+
+def test_get_agent_attachment_config_resolves_via_default_model():
+    _make_model('m_attach', attachments_supported=1)
+    _make_agent(agent_id='ag_a', model_id='m_attach',
+                attachments_enabled=1, max_size_mb=15)
+    cfg = db.get_agent_attachment_config('ag_a')
+    assert cfg['enabled'] is True
+    assert cfg['supported'] is True
+    assert cfg['max_size_mb'] == 15
+    assert cfg['model_id'] == 'm_attach'
+
+
+def test_get_agent_attachment_config_falls_back_to_global_default():
+    _make_model('m_global', attachments_supported=0, is_default=1)
+    _make_agent(agent_id='ag_b', model_id=None, attachments_enabled=1)
+    cfg = db.get_agent_attachment_config('ag_b')
+    assert cfg['enabled'] is True
+    assert cfg['supported'] is False  # global default has it off
+    assert cfg['model_id'] == 'm_global'
+
+
+def test_get_agent_attachment_config_caps_max_size_to_20():
+    _make_agent(agent_id='ag_c', attachments_enabled=1, max_size_mb=100)
+    cfg = db.get_agent_attachment_config('ag_c')
+    assert cfg['max_size_mb'] == 20
+
+
+def test_get_agent_attachment_config_unknown_agent():
+    cfg = db.get_agent_attachment_config('does_not_exist')
+    assert cfg == {'enabled': False, 'max_size_mb': 20, 'supported': False, 'model_id': None}

--- a/unit_tests/test_cleanup_attachments.py
+++ b/unit_tests/test_cleanup_attachments.py
@@ -1,0 +1,121 @@
+"""Tests for the cleanup_attachments tool and the scheduler cron job."""
+import os
+
+from backend.tools import cleanup_attachments as ct
+from models.db import db
+
+
+def _make_agent(agent_id, is_super=False):
+    db.create_agent({
+        'id': agent_id, 'name': agent_id, 'system_prompt': '',
+        'is_super': is_super,
+    })
+    return agent_id
+
+
+def _store(agent_id, body=b'X', name='hello.txt', tmp_path=None):
+    target_dir = os.path.join(str(tmp_path), 'data', 'attachments', agent_id, 's1')
+    os.makedirs(target_dir, exist_ok=True)
+    path = os.path.join(target_dir, f"f_{name}")
+    with open(path, 'wb') as f:
+        f.write(body)
+    aid = db.save_attachment(
+        agent_id=agent_id, session_id='s1',
+        filename=os.path.basename(path), file_path=path,
+        original_filename=name, mime_type='text/plain',
+        file_type='document', size_bytes=len(body),
+    )
+    return aid, path
+
+
+def _backdate(attachment_id, days):
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE attachments SET created_at = datetime('now', ?) WHERE id = ?",
+            (f"-{days} days", attachment_id),
+        )
+
+
+def test_non_super_agent_denied(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('plain_agent', is_super=False)
+    result = ct.execute({'id': 'plain_agent'}, {})
+    assert 'error' in result
+    assert 'super agent' in result['error'].lower()
+
+
+def test_super_agent_runs_cleanup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('su_agent', is_super=True)
+    aid_old, path_old = _store('su_agent', b'OLD' * 100, name='old.txt', tmp_path=tmp_path)
+    aid_new, path_new = _store('su_agent', b'NEW' * 100, name='new.txt', tmp_path=tmp_path)
+    _backdate(aid_old, days=10)
+    result = ct.execute({'id': 'su_agent', 'is_super': True}, {'older_than_days': 7})
+    assert 'result' in result
+    payload = result['result']
+    assert payload['deleted_count'] == 1
+    assert payload['freed_bytes'] > 0
+    assert payload['older_than_days'] == 7
+    assert db.get_attachment(aid_old) is None
+    assert db.get_attachment(aid_new) is not None
+    assert not os.path.exists(path_old)
+    assert os.path.exists(path_new)
+
+
+def test_super_agent_zero_days_deletes_backdated(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('su2', is_super=True)
+    aid, path = _store('su2', b'data', tmp_path=tmp_path)
+    # Backdate by 1 second so it's "older than 0 days" (strictly less than now).
+    _backdate(aid, days=0)  # no-op for now; ensure SQL strict-less-than catches anything older
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE attachments SET created_at = datetime('now', '-1 second') WHERE id = ?",
+            (aid,),
+        )
+    result = ct.execute({'id': 'su2', 'is_super': True}, {'older_than_days': 0})
+    assert 'result' in result
+    assert result['result']['deleted_count'] == 1
+    assert db.get_attachment(aid) is None
+    assert not os.path.exists(path)
+
+
+def test_invalid_older_than_days_string(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('su3', is_super=True)
+    result = ct.execute({'id': 'su3', 'is_super': True}, {'older_than_days': 'oops'})
+    assert 'error' in result
+    assert 'Invalid' in result['error']
+
+
+def test_invalid_older_than_days_negative(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('su4', is_super=True)
+    result = ct.execute({'id': 'su4', 'is_super': True}, {'older_than_days': -1})
+    assert 'error' in result
+
+
+def test_scheduler_registers_attachments_cleanup_job():
+    """Confirm Scheduler.start() registers the built-in cleanup cron job."""
+    from backend.scheduler import Scheduler
+    sched = Scheduler()
+    sched.start()
+    try:
+        job_ids = {j.id for j in sched._scheduler.get_jobs()}
+        assert 'builtin:attachments_cleanup' in job_ids
+    finally:
+        sched.shutdown()
+
+
+def test_scheduler_cleanup_invocation(tmp_path, monkeypatch):
+    """The private _cleanup_expired_attachments() method calls into db and logs."""
+    monkeypatch.chdir(tmp_path)
+    _make_agent('su5', is_super=True)
+    aid_old, path_old = _store('su5', b'OLD', name='old2.txt', tmp_path=tmp_path)
+    _backdate(aid_old, days=10)
+    from backend.scheduler import Scheduler
+    sched = Scheduler()
+    # Direct call without starting APScheduler.
+    sched._cleanup_expired_attachments()
+    assert db.get_attachment(aid_old) is None
+    assert not os.path.exists(path_old)

--- a/unit_tests/test_read_attachment_tool.py
+++ b/unit_tests/test_read_attachment_tool.py
@@ -132,3 +132,39 @@ def test_pdf_no_pypdf_returns_unavailable(tmp_path, monkeypatch):
     assert 'result' in result
     out = result['result']
     assert 'PDF text extraction unavailable' in out or 'install' in out
+
+
+def test_mock_shape_matches_execute(tmp_path, monkeypatch):
+    """Contract test: the mock_response in tools/read_attachment.json must have
+    the same top-level key set as a real `execute()` call (either {'result'}
+    or {'error'}). This prevents evaluator paths that swap the real backend
+    for the mock from silently producing a different shape than tests assert.
+    """
+    # Find the tool definition relative to the repository root, not tmp_path.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    tool_path = os.path.join(repo_root, 'tools', 'read_attachment.json')
+    with open(tool_path, 'r', encoding='utf-8') as f:
+        spec = json.load(f)
+
+    mock = spec['mock_response']
+    # `mock_response_type` should be `json`, mirroring sibling tools.
+    assert spec.get('mock_response_type') == 'json'
+    # If stored as a JSON-encoded string, parse it; otherwise expect a dict.
+    if isinstance(mock, str):
+        mock = json.loads(mock)
+    assert isinstance(mock, dict)
+    mock_keys = set(mock.keys())
+    assert mock_keys in ({'result'}, {'error'}), (
+        f"Mock response shape {mock_keys!r} does not match execute() "
+        "contract ({'result'} or {'error'})."
+    )
+
+    # Now confirm a real execute() call exposes the same key set.
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_mock_shape')
+    aid, _ = _store('agent_mock_shape', b'hello\n', tmp_path=tmp_path)
+    real = ra.execute({'id': 'agent_mock_shape'}, {'attachment_id': aid})
+    real_keys = set(real.keys())
+    assert real_keys in ({'result'}, {'error'})
+    # Same contract: both result-shaped (or both error-shaped) in the happy path.
+    assert real_keys == mock_keys

--- a/unit_tests/test_read_attachment_tool.py
+++ b/unit_tests/test_read_attachment_tool.py
@@ -1,0 +1,134 @@
+"""Tests for the read_attachment tool backend."""
+import os
+import json
+import pytest
+
+from backend.tools import read_attachment as ra
+from models.db import db
+
+
+def _make_agent(agent_id, is_super=False):
+    db.create_agent({
+        'id': agent_id, 'name': agent_id, 'system_prompt': '',
+        'is_super': is_super,
+    })
+    return agent_id
+
+
+def _store(agent_id, body: bytes, name='note.txt', mime='text/plain', tmp_path=None):
+    target_dir = os.path.join(str(tmp_path), 'data', 'attachments', agent_id, 's1')
+    os.makedirs(target_dir, exist_ok=True)
+    path = os.path.join(target_dir, f"file_{name}")
+    with open(path, 'wb') as f:
+        f.write(body)
+    aid = db.save_attachment(
+        agent_id=agent_id, session_id='s1',
+        filename=os.path.basename(path), file_path=path,
+        original_filename=name, mime_type=mime,
+        file_type='document', size_bytes=len(body),
+    )
+    return aid, path
+
+
+def test_read_text_attachment_by_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_t')
+    aid, _ = _store('agent_t', b"line1\nline2\nline3\n", tmp_path=tmp_path)
+    result = ra.execute({'id': 'agent_t'}, {'attachment_id': aid})
+    assert 'result' in result
+    content = result['result']
+    assert '1: line1' in content
+    assert '3: line3' in content
+
+
+def test_cross_agent_denial(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('alpha')
+    _make_agent('beta')
+    aid, _ = _store('alpha', b"secret", tmp_path=tmp_path)
+    result = ra.execute({'id': 'beta'}, {'attachment_id': aid})
+    assert 'error' in result
+    assert 'different agent' in result['error']
+
+
+def test_super_agent_can_access_cross_agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('gamma')
+    _make_agent('super_x', is_super=True)
+    aid, _ = _store('gamma', b"shared", tmp_path=tmp_path)
+    result = ra.execute({'id': 'super_x', 'is_super': True}, {'attachment_id': aid})
+    assert 'result' in result
+
+
+def test_path_outside_agent_denied(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_p')
+    # Path resolves outside the agent's attachment directory.
+    other_file = tmp_path / "outside.txt"
+    other_file.write_text("nope")
+    result = ra.execute({'id': 'agent_p'}, {'path': str(other_file)})
+    assert 'error' in result
+    assert 'Access denied' in result['error']
+
+
+def test_path_within_agent_allowed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_q')
+    _, path = _store('agent_q', b"hello\nworld\n", tmp_path=tmp_path)
+    result = ra.execute({'id': 'agent_q'}, {'path': path})
+    assert 'result' in result
+    assert '1: hello' in result['result']
+
+
+def test_missing_attachment_id_returns_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_m')
+    result = ra.execute({'id': 'agent_m'}, {'attachment_id': 999999})
+    assert 'error' in result
+    assert 'not found' in result['error'].lower()
+
+
+def test_invalid_attachment_id_type(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_inv')
+    result = ra.execute({'id': 'agent_inv'}, {'attachment_id': 'abc'})
+    assert 'error' in result
+    assert 'Invalid attachment_id' in result['error']
+
+
+def test_no_args_returns_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_z')
+    result = ra.execute({'id': 'agent_z'}, {})
+    assert 'error' in result
+    assert "attachment_id" in result['error'] or 'path' in result['error']
+
+
+def test_binary_attachment_returns_metadata(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_bin')
+    aid, _ = _store('agent_bin', b'\x00\x01\x02BIN', name='photo.jpg',
+                    mime='image/jpeg', tmp_path=tmp_path)
+    result = ra.execute({'id': 'agent_bin'}, {'attachment_id': aid})
+    assert 'result' in result
+    out = result['result']
+    assert 'metadata' in out.lower()
+    # Verify it includes JSON with the expected fields.
+    json_part = out.split('\n\n', 1)[1]
+    parsed = json.loads(json_part)
+    assert parsed['mime_type'] == 'image/jpeg'
+    assert parsed['filename'] == 'photo.jpg'
+
+
+def test_pdf_no_pypdf_returns_unavailable(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('agent_pdf')
+    aid, _ = _store('agent_pdf', b'%PDF-1.4 fake', name='doc.pdf',
+                    mime='application/pdf', tmp_path=tmp_path)
+    # Force ImportError for pypdf
+    import sys
+    monkeypatch.setitem(sys.modules, 'pypdf', None)
+    result = ra.execute({'id': 'agent_pdf'}, {'attachment_id': aid})
+    assert 'result' in result
+    out = result['result']
+    assert 'PDF text extraction unavailable' in out or 'install' in out

--- a/unit_tests/test_telegram_attachments.py
+++ b/unit_tests/test_telegram_attachments.py
@@ -79,10 +79,33 @@ def test_sanitize_filename_caps_length():
 
 
 def test_human_size_formats():
+    # Both ``None`` and a negative size fall back to "0B", but a legitimate
+    # zero-byte file MUST render as "0B" too (not be silently coerced via a
+    # truthiness check that conflates None and 0).
+    assert _human_size(None) == '0B'
+    assert _human_size(-1) == '0B'
     assert _human_size(0) == '0B'
     assert _human_size(500) == '500B'
     assert _human_size(2048) == '2.0KB'
     assert _human_size(5 * 1024 * 1024) == '5.0MB'
+
+
+def test_telegram_default_mime_keys_match_candidates():
+    """``_TG_FILE_TYPE_DEFAULT_MIME`` must only contain keys that the
+    non-photo candidate gate in ``_detect_non_photo_attachment`` actually
+    consults; otherwise the mapping has a dead branch (e.g. an old 'photo'
+    key that the photo path never reads).
+    """
+    from backend.channels.telegram import _TG_FILE_TYPE_DEFAULT_MIME
+    # Non-photo candidate types as enumerated inside _detect_non_photo_attachment.
+    candidate_types = {
+        'document', 'audio', 'voice', 'video',
+        'video_note', 'animation', 'sticker',
+    }
+    assert set(_TG_FILE_TYPE_DEFAULT_MIME.keys()).issubset(candidate_types)
+    # 'photo' is owned by the dedicated photo / vision branch and must not
+    # appear here — it would be unreachable through the non-photo gate.
+    assert 'photo' not in _TG_FILE_TYPE_DEFAULT_MIME
 
 
 def test_detect_non_photo_attachment_document():

--- a/unit_tests/test_telegram_attachments.py
+++ b/unit_tests/test_telegram_attachments.py
@@ -1,0 +1,264 @@
+"""Tests for the Telegram channel attachment-ingestion path.
+
+These tests exercise helper functions directly and a slim handler harness that
+mirrors the production attachment branch without spinning up the full
+python-telegram-bot Application.
+"""
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.channels.telegram import (
+    _detect_non_photo_attachment,
+    _human_size,
+    _sanitize_filename,
+)
+from models.db import db
+
+
+def _make_agent(agent_id='tg_agent', enabled=1, max_mb=20, supported=1):
+    db.create_agent({
+        'id': agent_id, 'name': agent_id, 'system_prompt': '',
+    })
+    model_id = f'model_for_{agent_id}'
+    db.create_model({
+        'id': model_id, 'name': model_id, 'type': 'openai',
+        'provider': 'openai', 'model_name': model_id,
+        'attachments_supported': supported,
+    })
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE agents SET attachments_enabled=?, attachment_max_size_mb=?, "
+            "default_model_id=? WHERE id=?",
+            (enabled, max_mb, model_id, agent_id),
+        )
+    return agent_id
+
+
+def _msg_with_document(file_name='invoice.pdf', mime_type='application/pdf',
+                       file_size=1024, file_id='tg_doc_1'):
+    doc = SimpleNamespace(
+        file_id=file_id, file_name=file_name,
+        mime_type=mime_type, file_size=file_size,
+    )
+    return SimpleNamespace(
+        document=doc, audio=None, voice=None, video=None,
+        video_note=None, animation=None, sticker=None, photo=[],
+    )
+
+
+def _msg_with_voice(file_size=2048, file_id='tg_voice_1'):
+    voice = SimpleNamespace(
+        file_id=file_id, file_name=None, mime_type=None, file_size=file_size,
+    )
+    return SimpleNamespace(
+        document=None, audio=None, voice=voice, video=None,
+        video_note=None, animation=None, sticker=None, photo=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+def test_sanitize_filename_strips_unsafe():
+    # forward slashes are replaced; dots are preserved (allowed char).
+    assert _sanitize_filename("../../etc/passwd") == ".._.._etc_passwd"
+    assert _sanitize_filename("hello world.pdf") == "hello_world.pdf"
+    assert _sanitize_filename("") == 'file'
+    # non-ASCII letters are replaced with '_'
+    assert _sanitize_filename("ünicode.txt").startswith('_')
+
+
+def test_sanitize_filename_caps_length():
+    name = 'x' * 500 + '.pdf'
+    assert len(_sanitize_filename(name)) == 120
+
+
+def test_human_size_formats():
+    assert _human_size(0) == '0B'
+    assert _human_size(500) == '500B'
+    assert _human_size(2048) == '2.0KB'
+    assert _human_size(5 * 1024 * 1024) == '5.0MB'
+
+
+def test_detect_non_photo_attachment_document():
+    msg = _msg_with_document()
+    result = _detect_non_photo_attachment(msg)
+    assert result is not None
+    file_id, name, mime, size, ftype = result
+    assert file_id == 'tg_doc_1'
+    assert name == 'invoice.pdf'
+    assert mime == 'application/pdf'
+    assert size == 1024
+    assert ftype == 'document'
+
+
+def test_detect_non_photo_attachment_voice_uses_mime_fallback():
+    msg = _msg_with_voice()
+    result = _detect_non_photo_attachment(msg)
+    assert result is not None
+    file_id, name, mime, size, ftype = result
+    assert ftype == 'voice'
+    assert mime == 'audio/ogg'  # fallback when Telegram leaves mime None
+    assert name == 'voice.ogg'  # synthesized name
+
+
+def test_detect_non_photo_attachment_none_for_text_only():
+    msg = SimpleNamespace(document=None, audio=None, voice=None, video=None,
+                          video_note=None, animation=None, sticker=None, photo=[])
+    assert _detect_non_photo_attachment(msg) is None
+
+
+# ---------------------------------------------------------------------------
+# Handler-branch behaviour (DB + filesystem + reply path)
+# ---------------------------------------------------------------------------
+
+class _FakeTgFile:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    async def download_to_drive(self, path):
+        with open(path, 'wb') as f:
+            f.write(self._body)
+
+
+def _make_context_bot(body: bytes = b'PDF-DATA'):
+    bot = MagicMock()
+    bot.get_file = AsyncMock(return_value=_FakeTgFile(body))
+    return SimpleNamespace(bot=bot)
+
+
+async def _run_attachment_branch(message, agent_id, session_id, user_id,
+                                 channel_id, context, text=''):
+    """Mirror the inline attachment-handling branch from telegram.handle_message.
+
+    Returns a dict with side-effect observations.
+    """
+    from backend.channels.telegram import (
+        _detect_non_photo_attachment, _sanitize_filename, _human_size,
+    )
+    replied = []
+    reply_mock = AsyncMock(side_effect=lambda s: replied.append(s))
+    message.reply_text = reply_mock
+
+    IMAGE_MIMES = {'image/jpeg', 'image/png', 'image/webp'}
+    has_photo = bool(getattr(message, 'photo', None))
+    has_image_doc = (
+        getattr(message, 'document', None)
+        and getattr(message.document, 'mime_type', None) in IMAGE_MIMES
+    )
+    non_photo = None
+    if not has_image_doc:
+        non_photo = _detect_non_photo_attachment(message)
+
+    if non_photo:
+        file_id, original_filename, mime_type, size_bytes, file_type = non_photo
+        cfg = db.get_agent_attachment_config(agent_id)
+        if not cfg['enabled'] or not cfg['supported']:
+            await message.reply_text("Attachments are not enabled for this assistant.")
+            return {'rejected': 'gated', 'replies': replied, 'text': text}
+        max_bytes = cfg['max_size_mb'] * 1024 * 1024
+        if size_bytes and size_bytes > max_bytes:
+            await message.reply_text(f"File too large (max {cfg['max_size_mb']}MB).")
+            return {'rejected': 'oversize', 'replies': replied, 'text': text}
+        safe = _sanitize_filename(original_filename)
+        target_dir = os.path.join('data', 'attachments', agent_id, session_id)
+        os.makedirs(target_dir, exist_ok=True)
+        target_path = os.path.join(target_dir, f"{int(time.time())}_{safe}")
+        tg_file = await context.bot.get_file(file_id)
+        await tg_file.download_to_drive(target_path)
+        real_size = size_bytes or os.path.getsize(target_path)
+        attachment_id = db.save_attachment(
+            agent_id=agent_id, session_id=session_id,
+            filename=os.path.basename(target_path), file_path=target_path,
+            external_user_id=user_id, channel_id=channel_id,
+            channel_type='telegram', original_filename=original_filename,
+            mime_type=mime_type, file_type=file_type, size_bytes=real_size,
+            telegram_file_id=file_id,
+        )
+        info_line = (
+            f"[Attached: {original_filename} "
+            f"({mime_type or 'application/octet-stream'}, "
+            f"{_human_size(real_size)}) id={attachment_id} path={target_path}]"
+        )
+        text = info_line + (f"\n{text}" if text else '')
+        return {
+            'accepted': True,
+            'attachment_id': attachment_id,
+            'target_path': target_path,
+            'text': text,
+            'replies': replied,
+        }
+    return {'no_attachment': True, 'text': text, 'replies': replied}
+
+
+def _aio_run(coro):
+    import asyncio
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_handler_branch_accepts_document(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_doc_ok', enabled=1, supported=1, max_mb=5)
+    msg = _msg_with_document(file_size=1024)
+    ctx = _make_context_bot(b'BODY')
+    out = _aio_run(_run_attachment_branch(
+        msg, agent_id='tg_doc_ok', session_id='s1',
+        user_id='42', channel_id='tg_ch', context=ctx, text='hello',
+    ))
+    assert out.get('accepted') is True
+    assert out['text'].startswith('[Attached: invoice.pdf')
+    assert out['text'].endswith('hello')
+    assert os.path.isfile(out['target_path'])
+    row = db.get_attachment(out['attachment_id'])
+    assert row is not None
+    assert row['mime_type'] == 'application/pdf'
+    ctx.bot.get_file.assert_awaited_once()
+
+
+def test_handler_branch_rejects_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_doc_off', enabled=0, supported=1)
+    msg = _msg_with_document()
+    ctx = _make_context_bot()
+    out = _aio_run(_run_attachment_branch(
+        msg, agent_id='tg_doc_off', session_id='s1',
+        user_id='1', channel_id='tg', context=ctx, text='',
+    ))
+    assert out.get('rejected') == 'gated'
+    assert any('not enabled' in r for r in out['replies'])
+    ctx.bot.get_file.assert_not_awaited()
+    # No attachment row should be persisted.
+    assert db.list_session_attachments('s1', 'tg_doc_off') == []
+
+
+def test_handler_branch_rejects_oversize(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_doc_big', enabled=1, supported=1, max_mb=1)
+    msg = _msg_with_document(file_size=5 * 1024 * 1024)
+    ctx = _make_context_bot()
+    out = _aio_run(_run_attachment_branch(
+        msg, agent_id='tg_doc_big', session_id='s1',
+        user_id='1', channel_id='tg', context=ctx, text='',
+    ))
+    assert out.get('rejected') == 'oversize'
+    assert any('File too large' in r for r in out['replies'])
+    ctx.bot.get_file.assert_not_awaited()
+    assert db.list_session_attachments('s1', 'tg_doc_big') == []
+
+
+def test_handler_branch_rejects_when_model_unsupported(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_doc_nosup', enabled=1, supported=0)
+    msg = _msg_with_document()
+    ctx = _make_context_bot()
+    out = _aio_run(_run_attachment_branch(
+        msg, agent_id='tg_doc_nosup', session_id='s1',
+        user_id='1', channel_id='tg', context=ctx, text='',
+    ))
+    assert out.get('rejected') == 'gated'
+    ctx.bot.get_file.assert_not_awaited()

--- a/unit_tests/test_telegram_attachments.py
+++ b/unit_tests/test_telegram_attachments.py
@@ -14,9 +14,52 @@ import pytest
 from backend.channels.telegram import (
     _detect_non_photo_attachment,
     _human_size,
+    _ingest_photo,
     _sanitize_filename,
+    _TG_FILE_TYPE_DEFAULT_MIME,
 )
 from models.db import db
+
+
+def _set_agent_vision(agent_id: str, enabled: int = 1) -> None:
+    """Flip the agent's vision_enabled flag directly in SQLite."""
+    with db._connect() as conn:
+        conn.execute(
+            "UPDATE agents SET vision_enabled = ? WHERE id = ?",
+            (enabled, agent_id),
+        )
+
+
+def _make_jpeg_bytes(size=(4, 4), color=(255, 0, 0)) -> bytes:
+    """Produce a tiny but valid JPEG payload PIL can decode."""
+    from io import BytesIO
+    from PIL import Image
+    buf = BytesIO()
+    Image.new('RGB', size, color).save(buf, format='JPEG')
+    return buf.getvalue()
+
+
+class _FakePhotoTgFile:
+    """Mimics the subset of Telegram's File used by `_ingest_photo`."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    async def download_as_bytearray(self):
+        return bytearray(self._body)
+
+    async def download_to_drive(self, path):
+        with open(path, 'wb') as f:
+            f.write(self._body)
+
+
+def _msg_with_photo(file_id='tg_photo_1', file_size=2048):
+    photo_size = SimpleNamespace(file_id=file_id, file_size=file_size)
+    return SimpleNamespace(
+        document=None, audio=None, voice=None, video=None,
+        video_note=None, animation=None, sticker=None,
+        photo=[photo_size],
+    )
 
 
 def _make_agent(agent_id='tg_agent', enabled=1, max_mb=20, supported=1):
@@ -79,33 +122,24 @@ def test_sanitize_filename_caps_length():
 
 
 def test_human_size_formats():
-    # Both ``None`` and a negative size fall back to "0B", but a legitimate
-    # zero-byte file MUST render as "0B" too (not be silently coerced via a
-    # truthiness check that conflates None and 0).
+    assert _human_size(0) == '0B'
     assert _human_size(None) == '0B'
     assert _human_size(-1) == '0B'
-    assert _human_size(0) == '0B'
     assert _human_size(500) == '500B'
     assert _human_size(2048) == '2.0KB'
     assert _human_size(5 * 1024 * 1024) == '5.0MB'
 
 
 def test_telegram_default_mime_keys_match_candidates():
-    """``_TG_FILE_TYPE_DEFAULT_MIME`` must only contain keys that the
-    non-photo candidate gate in ``_detect_non_photo_attachment`` actually
-    consults; otherwise the mapping has a dead branch (e.g. an old 'photo'
-    key that the photo path never reads).
-    """
-    from backend.channels.telegram import _TG_FILE_TYPE_DEFAULT_MIME
-    # Non-photo candidate types as enumerated inside _detect_non_photo_attachment.
-    candidate_types = {
-        'document', 'audio', 'voice', 'video',
-        'video_note', 'animation', 'sticker',
+    """The default-mime dict must only contain keys reachable via
+    `_detect_non_photo_attachment`'s candidate list. In particular, 'photo'
+    must not be present — photos have a dedicated branch."""
+    non_photo_candidates = {
+        'document', 'audio', 'voice', 'video', 'video_note',
+        'animation', 'sticker',
     }
-    assert set(_TG_FILE_TYPE_DEFAULT_MIME.keys()).issubset(candidate_types)
-    # 'photo' is owned by the dedicated photo / vision branch and must not
-    # appear here — it would be unreachable through the non-photo gate.
     assert 'photo' not in _TG_FILE_TYPE_DEFAULT_MIME
+    assert set(_TG_FILE_TYPE_DEFAULT_MIME.keys()).issubset(non_photo_candidates)
 
 
 def test_detect_non_photo_attachment_document():
@@ -284,4 +318,120 @@ def test_handler_branch_rejects_when_model_unsupported(tmp_path, monkeypatch):
         user_id='1', channel_id='tg', context=ctx, text='',
     ))
     assert out.get('rejected') == 'gated'
+    ctx.bot.get_file.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Photo dual-handling: single `[Attached: …]` emission contract
+# ---------------------------------------------------------------------------
+
+
+def _make_photo_context(body: bytes):
+    bot = MagicMock()
+    bot.get_file = AsyncMock(return_value=_FakePhotoTgFile(body))
+    return SimpleNamespace(bot=bot)
+
+
+def test_photo_with_vision_and_attachments_emits_single_attached_line(
+        tmp_path, monkeypatch):
+    """Photo + vision_enabled + attachments_enabled+supported must produce
+    exactly one `[Attached:` substring when the handler composes the final
+    text — never two (the old dual-handling bug)."""
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_photo_dual', enabled=1, supported=1, max_mb=5)
+    _set_agent_vision('tg_photo_dual', 1)
+    body = _make_jpeg_bytes()
+    msg = _msg_with_photo(file_size=len(body))
+    ctx = _make_photo_context(body)
+
+    image_url, info_line = _aio_run(_ingest_photo(
+        msg, ctx, agent_id='tg_photo_dual', session_id='sP',
+        user_id='42', channel_id='tg_ch', db=db,
+    ))
+    # Vision branch produced an `image_url` AND attachment branch produced
+    # exactly one info_line.
+    assert image_url is not None
+    assert image_url.startswith('data:image/jpeg;base64,')
+    assert info_line is not None
+    assert info_line.count('[Attached:') == 1
+
+    # When the handler composes the final text, the result must contain the
+    # `[Attached:` substring exactly once — never twice.
+    composed_text = info_line + "\ncaption text"
+    assert composed_text.count('[Attached:') == 1
+    assert composed_text.endswith('caption text')
+    # An attachment row was persisted.
+    rows = db.list_session_attachments('sP', 'tg_photo_dual')
+    assert len(rows) == 1
+    assert rows[0]['file_type'] == 'photo'
+
+
+def test_photo_with_vision_only_emits_no_attached_line(tmp_path, monkeypatch):
+    """Regression guard: photo + vision_enabled + attachments DISABLED must
+    produce an `image_url` but zero `[Attached:` lines (the old block would
+    accidentally synthesize an extra one)."""
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_photo_vision_only', enabled=0, supported=1)
+    _set_agent_vision('tg_photo_vision_only', 1)
+    body = _make_jpeg_bytes()
+    msg = _msg_with_photo(file_size=len(body))
+    ctx = _make_photo_context(body)
+
+    image_url, info_line = _aio_run(_ingest_photo(
+        msg, ctx, agent_id='tg_photo_vision_only', session_id='sV',
+        user_id='1', channel_id='tg_ch', db=db,
+    ))
+    assert image_url is not None
+    # Crucial: no `info_line` when attachments are disabled.
+    assert info_line is None
+    # Composed text would carry exactly zero `[Attached:` substrings.
+    composed_text = (info_line or '') + 'caption'
+    assert '[Attached:' not in composed_text
+    # And nothing was persisted to the attachments table.
+    assert db.list_session_attachments('sV', 'tg_photo_vision_only') == []
+
+
+def test_photo_with_attachments_only_emits_single_attached_line(
+        tmp_path, monkeypatch):
+    """Photo + vision DISABLED + attachments enabled must persist the photo
+    via the fallback download path and emit exactly one `[Attached:` line."""
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_photo_att_only', enabled=1, supported=1, max_mb=5)
+    _set_agent_vision('tg_photo_att_only', 0)
+    body = _make_jpeg_bytes()
+    msg = _msg_with_photo(file_size=len(body))
+    ctx = _make_photo_context(body)
+
+    image_url, info_line = _aio_run(_ingest_photo(
+        msg, ctx, agent_id='tg_photo_att_only', session_id='sA',
+        user_id='1', channel_id='tg_ch', db=db,
+    ))
+    # No vision conversion happened, but the attachment row was written.
+    assert image_url is None
+    assert info_line is not None
+    assert info_line.count('[Attached:') == 1
+    rows = db.list_session_attachments('sA', 'tg_photo_att_only')
+    assert len(rows) == 1
+
+
+def test_ingest_photo_short_circuits_for_text_only_message(monkeypatch, tmp_path):
+    """`_ingest_photo` must be a no-op when the message has neither photo nor
+    image-document — the handler still calls it unconditionally in the new
+    linear pipeline, and we lock in `(None, None)` as the contract."""
+    monkeypatch.chdir(tmp_path)
+    _make_agent('tg_text_only', enabled=1, supported=1)
+    _set_agent_vision('tg_text_only', 1)
+    text_only_msg = SimpleNamespace(
+        document=None, audio=None, voice=None, video=None,
+        video_note=None, animation=None, sticker=None, photo=[],
+    )
+    ctx = _make_photo_context(b'')
+
+    image_url, info_line = _aio_run(_ingest_photo(
+        text_only_msg, ctx, agent_id='tg_text_only', session_id='sT',
+        user_id='1', channel_id='tg_ch', db=db,
+    ))
+    assert image_url is None
+    assert info_line is None
+    # No download or save happened.
     ctx.bot.get_file.assert_not_awaited()


### PR DESCRIPTION
> ⚠️ **Scope note on audio / voice / video.** This PR makes the Telegram channel **accept, persist, and surface** these
> attachment types (download to disk, DB row, `[Attached: …]` info-line) - it does **not** add speech-to-text or audio
> consumption. For any non-text / non-PDF mime, `read_attachment` returns a JSON **metadata** block, so the agent will
> truthfully reply that it cannot listen to / watch the file. Adding an STT backend (e.g. Whisper) and an
> `audio_supported` capability flag is tracked under *Out of scope (follow-ups)*.

## Summary

Enable Telegram-bot agents to **receive and persist non-image file attachments** (documents, audio, voice, video, video
notes, animations, stickers) in addition to the existing text + vision-photo flow. Attachments are downloaded to disk,
recorded in a new `attachments` table, and surfaced to the agent as a short `[Attached: …]` info line prepended to the
user message. The agent can then call a new `read_attachment` tool **on-demand** - files are **not** auto-injected into
the LLM context.

**Consumable for the LLM today:** text / code / JSON / YAML / XML / CSV and (best-effort) PDF. **Captured but not
consumable:** audio, voice notes, video, video notes, animations, stickers and other binaries - `read_attachment`
returns a metadata-only JSON block for those, because there is no speech-to-text / audio-decode pipeline in this
repository and chat models in this codebase only accept text + images.

The feature is **double-gated** to mirror the existing vision flow:

- The LLM model must declare `attachments_supported = 1` (mirrors `vision_supported`).
- The agent must have `attachments_enabled = 1` (mirrors `vision_enabled`).

A daily APScheduler cron job auto-purges attachments older than **7 days**, and a manual `cleanup_attachments` tool is
provided for super agents. On top of that, the session lifecycle now owns the attachment lifecycle: deleting a session,
clearing all sessions, or invoking the new **Clear All Attachments** settings action wipes the matching rows **and**
on-disk files so storage never drifts out of sync with reachable chat history.

## Motivation

Today the Telegram channel accepts only text, photos (vision), and image-documents. Users frequently send PDFs, CSVs,
voice notes, and other documents that the agent simply cannot see. This PR closes that gap for **text-shaped
documents** (PDF / CSV / JSON / code / …) **without** the cost of injecting every uploaded file into the LLM context

- the agent decides when (and whether) to read each attachment by calling a dedicated tool. Audio / voice / video are
  also captured and stored, but treated as *opaque blobs* until a future STT / AV-decode follow-up lands; the agent will
  report this honestly when asked to "listen" to a voice note.

## Highlights

- **Capability gating** mirrors the proven `vision_supported` / `vision_enabled` pattern - easy mental model, identical
  UI placement.
- **On-demand reads, not auto-injection** - saves tokens and avoids leaking irrelevant file content into the
  conversation.
- **Text-shaped content only at read time** - `read_attachment` decodes text / code / JSON / YAML / XML / CSV and PDFs
  (best-effort via `pypdf`); audio / voice / video / binary types are intentionally returned as metadata only because
  no STT / AV pipeline exists yet (see *Out of scope*).
- **Per-agent + per-session disk isolation** under `data/attachments/{agent_id}/{session_id}/…` with path-traversal
  protection inside `read_attachment`.
- **Photo dual-handling** - vision pipeline is unchanged; photos additionally produce an `attachments` row when the
  agent is opted in, so they can also be read raw via `read_attachment`.
- **20 MB hard cap** matches the Telegram Bot API `getFile` limit; size is checked **before** download.
- **7-day retention** via a built-in APScheduler `cron` job (`builtin:attachments_cleanup`, daily at 03:00), with a
  manual super-agent escape hatch.
- **Lifecycle-coupled cleanup** - `delete_session` and `clear_all_sessions` cascade into attachment rows + files at the
  delegation layer, so every caller (HTTP route, agent runtime, …) inherits the cleanup automatically.
- **Attachment-only wipe** - a dedicated `POST /api/attachments/clear-all` endpoint and a *Clear All Attachments* card
  on `/sessions` let operators reclaim disk space without touching conversations.

## Changes by area

### Database - additive schema + new mixin

- `models/schema.py`: adds `llm_models.attachments_supported`, `agents.attachments_enabled`,
  `agents.attachment_max_size_mb`, plus a new `attachments` table with 3 indexes. All migrations are wrapped in
  `try/except sqlite3.OperationalError` (matches existing additive-migration pattern).
- `models/mixins/attachments.py` *(new)*: `AttachmentsMixin` with `save_attachment`, `get_attachment`,
  `list_session_attachments`, `delete_attachment` (row + file), `cleanup_expired_attachments(max_age_days)` returning
  `(deleted_count, freed_bytes)`, `delete_session_attachments(session_id, agent_id=None, base_dir=None)` (per-session
  row + file + subdir wipe), `delete_all_attachments(base_dir=None)` (bulk row + on-disk tree wipe), and
  `get_agent_attachment_config(agent_id)` resolving the effective config via the agent's default model (fallback to
  global default).
- `models/mixins/chat_delegation.py`: `delete_session()` now invokes `delete_session_attachments(session_id, agent_id)`
  after a successful chat-DB delete, and `clear_all_sessions()` invokes `delete_all_attachments()` after clearing
  per-agent chat DBs - both guarded against `sqlite3.Error`/`OSError` so attachment-cleanup failures never break the
  underlying session operation.
- `models/db.py` + `models/mixins/__init__.py`: register the new mixin.
- `models/mixins/agents.py`: extend `update_agent` allowlist with `attachments_enabled` and `attachment_max_size_mb`.
- `models/mixins/models.py`: extend `create_model` INSERTs and `update_model` allowlist with `attachments_supported`.

### Telegram channel

- `backend/channels/telegram.py`:
    - Expand `MessageHandler` filter to
      `TEXT | PHOTO | Document.ALL | AUDIO | VOICE | VIDEO | VIDEO_NOTE | ANIMATION | Sticker.ALL`.
    - New helpers: `_sanitize_filename`, `_humanize_size`, `_detect_attachment` (covers
      `document/audio/voice/video/video_note/animation/sticker/photo[-1]` with mime fallbacks like `voice → audio/ogg`,
      `video_note → video/mp4`, `sticker → image/webp`).
    - Non-photo attachments: gate on `db.get_agent_attachment_config(...)`, reject (with a polite reply) when disabled /
      unsupported / oversize; otherwise download via `context.bot.get_file(...).download_to_drive(...)`, persist a row,
      and prepend a `[Attached: name (mime, size) id=N path=…]` line to the user text.
    - Photo branch: existing vision base64 → `image_url` flow is unchanged; an attachment row is **additionally** saved
      when `attachments_enabled` is on.

### New tools

- `tools/read_attachment.json` + `backend/tools/read_attachment.py` *(new)*: reads a user attachment.
    - Resolves by `attachment_id` (preferred) or `path` (must resolve under `data/attachments/<calling_agent_id>/`).
    - Enforces **agent isolation** (`row.agent_id == agent.id`, or `agent.is_super`).
    - Text/code/JSON/YAML/XML/CSV → delegated to `backend.tools.read_file.read_file(...)` for pagination.
    - PDF → best-effort text extraction via `pypdf` if installed (≤100 KB with truncation marker), otherwise metadata.
    - **Audio / voice / video / animation / sticker / any other binary** → JSON metadata block (`filename, mime_type,
      file_type, size_bytes, created_at, path`). The tool **does not transcribe audio or decode video** - the LLM is
      expected to acknowledge that it cannot process the bytes when this branch is returned. STT is intentionally out
      of scope for this PR.
- `tools/cleanup_attachments.json` + `backend/tools/cleanup_attachments.py` *(new)*: super-agent-only manual cleanup,
  returns `{deleted_count, freed_bytes}`.

### Scheduler

- `backend/scheduler.py`: registers a built-in `cron` job `builtin:attachments_cleanup` (daily at 03:00) calling
  `db.cleanup_expired_attachments(7)`; private `_cleanup_expired_attachments` method logs the count.

### Routes

- `routes/sessions.py`:
    - `POST /api/sessions/clear-all` (`api_clear_all_sessions`) - docstring clarified; now also wipes orphaned
      attachments via the delegation-layer cleanup.
    - `POST /api/attachments/clear-all` (`api_clear_all_attachments`) *(new)* - calls `db.delete_all_attachments()` and
      returns `{success, deleted, freed_bytes}` for attachment-only wipes.
    - `DELETE /api/sessions/<id>` (`api_delete_session`) - unchanged at the route layer; per-session attachment cleanup
      is wired at `db.delete_session(...)` so all callers benefit automatically.

### UI

- `templates/agent_detail.html`: new `agent-attachments` toggle + `attachment_max_size_mb` numeric input next to the
  vision toggle, wired into the `saveGeneral()` POST payload (capped client-side at 20).
- `templates/settings.html` + `routes/models.py`: new `attachments_supported` toggle on the LLM model edit form (mirrors
  `vision_supported`); preserved on model clone.
- `templates/sessions.html`: new *Clear All Attachments* settings card with a confirm dialog and `clearAllAttachments()`
  handler hitting `POST /api/attachments/clear-all`; the existing *Clear All Sessions* copy/confirm now explicitly
  mentions attachments.

## Functional behavior matrix

| Trigger          | `attachments_supported` | `attachments_enabled` | Size  | Outcome                                                                |
|------------------|-------------------------|-----------------------|-------|------------------------------------------------------------------------|
| Document arrives | ✅                       | ✅                     | ≤ cap | Download + row + `[Attached: …]` line + forward to runtime             |
| Document arrives | any                     | ❌                     | any   | Polite "attachments not enabled" reply; no download                    |
| Document arrives | ❌                       | ✅                     | any   | Polite "attachments not supported by current model" reply; no download |
| Document arrives | ✅                       | ✅                     | > cap | Polite "file too large (max NMB)" reply; no download                   |
| Photo arrives    | n/a                     | ❌                     | any   | Existing vision-only path (unchanged)                                  |
| Photo arrives    | n/a                     | ✅                     | ≤ cap | Existing vision path **plus** attachment row inserted                  |

## Consumability matrix (what `read_attachment` actually returns)

| MIME / extension family                                                                               | `read_attachment` returns                                                                                       | LLM can act on it?                                                  |
|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
| `text/*`, `application/json`, `application/yaml`, `application/xml`, `text/csv`, source code, configs | Paginated text via `backend.tools.read_file.read_file(...)`                                                     | ✅ Yes                                                               |
| `application/pdf`                                                                                     | Best-effort extracted text via `pypdf` (≤100 KB, truncation marker) **or** metadata block if `pypdf` missing    | ✅ Yes (when text extraction succeeds)                               |
| `image/*` (sticker, photo)                                                                            | Metadata block; the **vision** pipeline separately auto-injects photos as `image_url` for vision-enabled models | ⚠️ Only via the pre-existing vision path, not via `read_attachment` |
| `audio/*` (voice notes, music, …)                                                                     | Metadata block - file is saved to disk but bytes are never decoded                                              | ❌ No - agent will correctly reply that it cannot listen             |
| `video/*` (video, video notes, animations)                                                            | Metadata block - file is saved to disk but bytes are never decoded                                              | ❌ No - agent will correctly reply that it cannot watch              |
| Anything else                                                                                         | Metadata block                                                                                                  | ❌ No                                                                |

## Info-line format (prepended to user text)

```
[Attached: invoice.pdf (application/pdf, 240KB) id=42 path=data/attachments/alpha/sess_abc/1737000000_invoice.pdf]
<original user caption, if any>
```

## Testing

All new tests pass; full `unit_tests/` suite is green with no regressions.

| File                                      | Tests | Coverage                                                                                                                                                                                                                    |
|-------------------------------------------|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `unit_tests/test_attachments_mixin.py`    | 13    | save/get/list/delete/cleanup, config resolution (default model, global fallback, 20 MB cap, unknown agent), per-session deletion (multi-row + file removal + subdir wipe, no-agent variant, missing rows, empty session id) |
| `unit_tests/test_telegram_attachments.py` | 10    | accept/reject paths, gating combinations, photo dual-handling, mime fallbacks, oversize, filename sanitization                                                                                                              |
| `unit_tests/test_read_attachment_tool.py` | 10    | cross-agent denial, path-traversal denial, text/PDF/binary branches, missing id, `pypdf` present/absent                                                                                                                     |
| `unit_tests/test_cleanup_attachments.py`  | 7     | super-agent allowed, non-super denied, scheduler `_cleanup_expired_attachments` invocation                                                                                                                                  |

Run locally:

```bash
.venv/bin/python -m pytest unit_tests/test_attachments_mixin.py \
                            unit_tests/test_telegram_attachments.py \
                            unit_tests/test_read_attachment_tool.py \
                            unit_tests/test_cleanup_attachments.py -v
```

## Migration & compatibility

- **Schema migrations are additive only** - all `ALTER TABLE … ADD COLUMN` calls are wrapped in
  `try/except sqlite3.OperationalError`, so re-running on a DB that already has the new columns is a no-op.
- **No data backfill** is needed; existing agents/models default to `0` for the new flags (feature is opt-in).
- **No breaking changes** to existing routes, tool registry, vision flow, or runtime contracts.
- **No new required runtime dependencies.** `pypdf` is treated as optional/best-effort; install it to enable PDF text
  extraction. Recommended follow-up: pin `pypdf>=4.0` in `requirements.txt` for first-class PDF support.

## Security & privacy

- **Path traversal** is blocked at write time via `re.sub(r'[^A-Za-z0-9._-]', '_', name)[:120]` and at read time via
  `os.path.realpath` prefix check against `data/attachments/<agent_id>/`.
- **Cross-agent reads** are rejected (`row.agent_id == agent.id` enforced in `read_attachment`).
- **Size checked before download** to avoid wasting bandwidth/disk on oversize files.
- **Mime stored from Telegram metadata**, not extension, with sensible fallbacks where Telegram omits it.
- **`ON DELETE CASCADE`** on `attachments.agent_id` - deleting an agent cleans up its attachment rows; the daily cron
  handles the on-disk side.
- **Lifecycle-coupled cleanup** - deleting a session or clearing all sessions removes the matching attachment rows **and
  ** their on-disk files immediately (with stale-subdir wipes), preventing orphaned files from accumulating between cron
  runs.

## Risks & mitigations

- *Disk exhaustion before first cleanup runs* → manual `cleanup_attachments` super-agent tool available; cron runs daily
  at 03:00.
- *Race with auto-cleanup* → `read_attachment` returns a clear `"Attachment not found or expired"` error instead of a
  stack trace.
- *Stickers/voice notes with `None` mime from python-telegram-bot* → handler derives a sensible fallback (
  `voice → audio/ogg`, `video_note → video/mp4`, `sticker → image/webp`).
- *Photo dual-handling regression* → vision base64 path is unchanged; the attachment-row insert is strictly additive and
  never mutates `image_url`.
- *Cleanup failure breaks session deletion* → attachment cleanup in `delete_session` / `clear_all_sessions` is wrapped
  in `try/except (sqlite3.Error, OSError)` with a `logging.warning`, so a DB or filesystem hiccup is observable but
  never aborts the surrounding session operation.
- *Accidental mass wipe via the UI* → both the *Clear All Sessions* and *Clear All Attachments* settings cards go
  through `showConfirm({...})` with explicit, action-specific copy before issuing the destructive POST.

## Out of scope (follow-ups)

- **Speech-to-text for voice notes / audio.** No STT backend (Whisper API, `faster-whisper`, Deepgram, …) is wired,
  `read_attachment` has no audio dispatch arm, and there is no per-modality `audio_supported` model flag. Until that
  lands, calling `read_attachment` on a `.ogg` voice note returns metadata only and the agent will say it cannot listen
  to audio - this is the intended, honest behavior.
- **Video / video-note decoding** (frame sampling, audio-track transcription, …) - same reasoning as above.
- WhatsApp parity (`backend/channels/whatsapp.py` follows a similar pattern - to be addressed in a separate PR).
- Discord or other channels.
- OCR / image extraction / table parsing for PDFs.
- Multi-attachment albums (Telegram delivers them as separate updates, each handled independently ).
