### PR TITLE
fix(app): limit unreplied-chat startup scan to human-facing sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -260,16 +260,18 @@ if not _reloader_active or _is_reloader_child:
     # Startup check: scan all active sessions for unreplied user messages
     # ----------------------------------------------------------------
     def _check_unreplied_chats():
-        """Scan all chat sessions on startup. Log any session where the last
-        message is from a user and no agent has replied — these users may have
-        been left hanging after a restart or deployment."""
-        
-        # @TODO(robin): Perlu pastikan bahwa chat session-nya hanya yg user sama agent saja, jangan scan session yg dari agent-to-agent atau system-to-agent. contoh user to agent itu seperti chat di halaman agent detail chat tab, atau chat melalui channel seperti telegram.
+        """Scan human-facing chat sessions on startup. Log any session where the
+        last message is from a user and no agent has replied — these users may
+        have been left hanging after a restart or deployment.
 
+        Only scans sessions between a human and an agent (web UI or channels).
+        Skips agent-to-agent, scheduler, and system notification sessions.
+        """
         import time as _time
         _time.sleep(3.0)  # brief delay for DB + agent_runtime to be ready
 
         from models.chatlog import ChatLog
+        from models.chat import is_human_facing_external_user_id
         _unreplied_types = frozenset({'user', 'final', 'intermediate', 'error'})
 
         try:
@@ -283,6 +285,8 @@ if not _reloader_active or _is_reloader_child:
         _total_sessions = 0
 
         for _agent in _enabled:
+            if _agent.get('is_subagent'):
+                continue
             _agent_id = _agent['id']
             _agent_name = _agent.get('name', _agent_id)
             try:
@@ -291,9 +295,7 @@ if not _reloader_active or _is_reloader_child:
                 continue
 
             for _sess in _sessions:
-                _euid = _sess.get('external_user_id', '')
-                # Skip agent-to-agent and system/scheduler sessions
-                if _euid.startswith('__agent__') or _euid == '__scheduler__':
+                if not is_human_facing_external_user_id(_sess.get('external_user_id', '')):
                     continue
                 _total_sessions += 1
                 _session_id = _sess['id']
@@ -326,16 +328,16 @@ if not _reloader_active or _is_reloader_child:
                     _agent_name, _session_id, _ts_str, _preview
                 )
 
-        #if _unreplied_count:
-        #    _log.warning(
-        #        "Unreplied-chat scan complete: %d/%d session(s) have no agent reply.",
-        #        _unreplied_count, _total_sessions
-        #    )
-        #else:
-        #    _log.info(
-        #        "Unreplied-chat scan complete: all %d session(s) have replies.",
-        #        _total_sessions
-        #    )
+        if _unreplied_count:
+            _log.warning(
+                "Unreplied-chat scan complete: %d/%d human session(s) have no agent reply.",
+                _unreplied_count, _total_sessions,
+            )
+        else:
+            _log.info(
+                "Unreplied-chat scan complete: all %d human session(s) have replies.",
+                _total_sessions,
+            )
 
     import threading as _threading
     _threading.Thread(target=_check_unreplied_chats, daemon=True).start()

--- a/models/chat.py
+++ b/models/chat.py
@@ -7,6 +7,24 @@ from typing import Any, Dict, List, Optional, Generator
 
 AGENTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'agents')
 
+# Non-human session identifiers (agent-to-agent, scheduler, system notifications).
+_SYSTEM_EXTERNAL_USER_IDS = frozenset({'__scheduler__'})
+_SYSTEM_EXTERNAL_USER_PREFIXES = ('__agent__', '__system__')
+
+
+def is_human_facing_external_user_id(external_user_id: str) -> bool:
+    """Return True when external_user_id denotes a human user session.
+
+    Human sessions include web UI chats and channel users (Telegram, WhatsApp, etc.).
+    Excludes agent-to-agent, scheduler, and system notification sessions.
+    """
+    euid = (external_user_id or '').strip()
+    if not euid:
+        return False
+    if euid in _SYSTEM_EXTERNAL_USER_IDS:
+        return False
+    return not any(euid.startswith(prefix) for prefix in _SYSTEM_EXTERNAL_USER_PREFIXES)
+
 
 def _migrate_session_id(cursor, old_id: str, new_id: str) -> None:
     """Rename a session ID and update all referencing tables."""

--- a/unit_tests/test_human_facing_session.py
+++ b/unit_tests/test_human_facing_session.py
@@ -1,0 +1,38 @@
+"""Tests for human-facing session identification (unreplied-chat scan, messaging)."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.chat import is_human_facing_external_user_id
+
+
+class TestIsHumanFacingExternalUserId:
+    def test_web_user_allowed(self):
+        assert is_human_facing_external_user_id('user_123') is True
+
+    def test_web_test_allowed(self):
+        assert is_human_facing_external_user_id('web_test') is True
+
+    def test_telegram_user_allowed(self):
+        assert is_human_facing_external_user_id('76639539') is True
+
+    def test_agent_to_agent_rejected(self):
+        assert is_human_facing_external_user_id('__agent__parent_bot') is False
+
+    def test_scheduler_rejected(self):
+        assert is_human_facing_external_user_id('__scheduler__') is False
+
+    def test_system_exact_rejected(self):
+        assert is_human_facing_external_user_id('__system__') is False
+
+    def test_system_prefixed_rejected(self):
+        assert is_human_facing_external_user_id('__system__my_agent') is False
+
+    def test_empty_rejected(self):
+        assert is_human_facing_external_user_id('') is False
+        assert is_human_facing_external_user_id('   ') is False
+
+    def test_none_coerced_rejected(self):
+        assert is_human_facing_external_user_id(None) is False


### PR DESCRIPTION
## Summary

On startup, Evonic scans chat sessions for user messages that never got an agent reply (for example after a restart or deploy). That scan was treating **every** session the same, including agent-to-agent, scheduler, and system notification traffic. Those are not real “user waiting for a reply” cases, so they could produce noisy or misleading warnings in the logs.

This PR tightens the scan so it only considers **human-facing** sessions: web UI chats and channel users (Telegram, WhatsApp, etc.).

## Motivation

There was an open TODO in `app.py` asking to limit the unreplied-chat check to true human↔agent conversations. The previous filter only skipped `__agent__*` and `__scheduler__`, but still included:

- `__system__` / `__system__<agent_id>` (internal notifications)
- Empty or invalid `external_user_id` values
- Sub-agent rows if they appear in the enabled agent list

That made the startup warning less trustworthy for operators debugging real user issues.

## What changed

- Added `is_human_facing_external_user_id()` in `models/chat.py` as a single source of truth for “is this a human session?”
- Updated `_check_unreplied_chats()` in `app.py` to:
  - Skip non-human sessions via the helper
  - Skip `is_subagent` agents
  - Re-enable the end-of-scan summary log (now labeled “human session(s)”)
- Added `unit_tests/test_human_facing_session.py` with 9 cases covering web users, channels, agent/system IDs, and edge cases

## Behavior

| Session type | Scanned? |
|--------------|----------|
| Web UI user (`user_123`, `web_test`) | Yes |
| Channel user (e.g. Telegram ID) | Yes |
| `__agent__*` (agent-to-agent) | No |
| `__scheduler__` | No |
| `__system__` / `__system__*` | No |
| Empty `external_user_id` | No |

`web_test` is intentionally **included** — it represents browser testing in the web UI, consistent with `get_web_fallback_session()`.

## Testing

```bash
python -m pytest unit_tests/test_human_facing_session.py -v
```

All 9 tests pass.

No manual app run required for this change; it is log-only at startup and covered by unit tests. Optional sanity check: start Evonic with a mix of human Telegram/web sessions and an active __agent__ session — only human sessions should appear in unreplied-chat warnings.

Risk
Low. The scan is diagnostic logging only; it does not change message routing, agent replies, or session creation.