### PR TITLE
fix(workplaces): delegate file I/O on LocalWorkplaceBackend

### DIFF
--- a/backend/workplaces/backends/local_workplace.py
+++ b/backend/workplaces/backends/local_workplace.py
@@ -54,3 +54,18 @@ class LocalWorkplaceBackend(ExecutionBackend):
             'workspace': self._workspace,
             'status': 'idle',
         }
+
+    def file_exists(self, path: str) -> bool:
+        return self._get_inner().file_exists(path)
+
+    def file_stat(self, path: str) -> dict:
+        return self._get_inner().file_stat(path)
+
+    def read_file(self, path: str) -> dict:
+        return self._get_inner().read_file(path)
+
+    def write_file(self, path: str, content: str, create_dirs: bool = True) -> dict:
+        return self._get_inner().write_file(path, content, create_dirs=create_dirs)
+
+    def make_dirs(self, path: str) -> dict:
+        return self._get_inner().make_dirs(path)

--- a/unit_tests/test_local_workplace_backend.py
+++ b/unit_tests/test_local_workplace_backend.py
@@ -1,0 +1,45 @@
+"""Tests for LocalWorkplaceBackend ExecutionBackend compliance."""
+
+import unittest
+from unittest import mock
+
+from backend.tools.lib.exec_backend import ExecutionBackend
+from backend.workplaces.backends.local_workplace import LocalWorkplaceBackend
+
+
+class TestLocalWorkplaceBackend(unittest.TestCase):
+    def test_is_concrete_execution_backend(self):
+        backend = LocalWorkplaceBackend(
+            config={'workspace_path': '/tmp/ws'},
+            sandbox_enabled=False,
+        )
+        self.assertIsInstance(backend, ExecutionBackend)
+
+    def test_file_methods_delegate_to_inner(self):
+        inner = mock.MagicMock()
+        inner.file_exists.return_value = True
+        inner.file_stat.return_value = {'exists': True, 'size': 1, 'is_binary': False}
+        inner.read_file.return_value = {'content': 'hi'}
+        inner.write_file.return_value = {'ok': True}
+        inner.make_dirs.return_value = {'ok': True}
+
+        backend = LocalWorkplaceBackend(
+            config={'workspace_path': '/tmp/ws'},
+            sandbox_enabled=False,
+        )
+        backend._inner = inner
+
+        self.assertTrue(backend.file_exists('/a'))
+        inner.file_exists.assert_called_once_with('/a')
+
+        self.assertEqual(backend.file_stat('/a')['size'], 1)
+        inner.file_stat.assert_called_once_with('/a')
+
+        self.assertEqual(backend.read_file('/a')['content'], 'hi')
+        inner.read_file.assert_called_once_with('/a')
+
+        self.assertEqual(backend.write_file('/a', 'x', create_dirs=False)['ok'], True)
+        inner.write_file.assert_called_once_with('/a', 'x', create_dirs=False)
+
+        self.assertEqual(backend.make_dirs('/d')['ok'], True)
+        inner.make_dirs.assert_called_once_with('/d')


### PR DESCRIPTION
## Background

[#34](https://github.com/anvie/evonic/issues/34) reports that any `bash` or `runpy` call from an agent bound to a **local workplace** dies immediately with:

```text
TypeError: Can't instantiate abstract class LocalWorkplaceBackend
without an implementation for abstract methods
'file_exists', 'file_stat', 'make_dirs', 'read_file', 'write_file'
```

File tools (`read_file`, `write_file`, etc.) can still work because they often go through other backends. Shell and Python execution go through `WorkplaceManager` → `LocalWorkplaceBackend`, so the failure is total for those tools.

The class in `backend/workplaces/backends/local_workplace.py` has looked the same since v0.2.6. What changed is that `ExecutionBackend` in `backend/tools/lib/exec_backend.py` now declares five file I/O methods as `@abstractmethod` so tools like `write_file` and `patch` target the same environment as `bash`/`runpy` (Docker, SSH, workplace, etc.). `LocalWorkplaceBackend` never caught up, so Python refuses to construct it.

## What this change does

Add five one-line delegators on `LocalWorkplaceBackend`, each forwarding to `_get_inner()`:

- `file_exists`
- `file_stat`
- `read_file`
- `write_file` (including `create_dirs`)
- `make_dirs`

`_get_inner()` already returns either `LocalBackend` or `DockerBackend` (sandbox path). Both inner classes implement the full interface, so there is no new logic, only wiring.

No change to workplace config, session routing, or sandbox defaults.

## Files touched

| File | Change |
|------|--------|
| `backend/workplaces/backends/local_workplace.py` | Implement the five abstract methods |
| `unit_tests/test_local_workplace_backend.py` | New tests |

## Tests

`unit_tests/test_local_workplace_backend.py`:

- Instantiates `LocalWorkplaceBackend` and checks it is a concrete `ExecutionBackend` (would have failed before on 3.12+ abstract base enforcement).
- Mocks the inner backend and asserts each file method calls through with the expected arguments.

## How a reviewer can sanity-check

1. Create a local workplace pointing at any directory.
2. Attach an agent with `bash` and/or `runpy`.
3. Run something trivial (`pwd`, `print(1)`).

Before: TypeError on first tool call. After: command runs in the workplace workspace.

I did not run a full fresh install in this PR; validation is unit tests plus the code path review above. Happy to run a manual pass if you want that noted in the PR thread.

## Risk / compatibility

Low. The methods are pure delegation; behavior matches whatever `LocalBackend` or `DockerBackend` already does for non-workplace sessions.

Sandbox workplaces (`sandbox_enabled=True`) lazy-init `DockerBackend` on first use; file calls after that follow the same inner instance as `run_bash`.

Closes [#34](https://github.com/anvie/evonic/issues/34).
