### PR TITLE
fix(subagent): resolve report_to_id for spawn and messaging

### DIFF
--- a/backend/agent_report_to.py
+++ b/backend/agent_report_to.py
@@ -1,0 +1,51 @@
+"""Resolve report_to_id / report_to_channel_id for agent and sub-agent messaging."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+_AGENT_MSG_PREFIX = "__agent__"
+
+
+def resolve_report_to_from_context(
+    agent_context: Dict[str, Any],
+    sender_id: str,
+) -> Tuple[str, str]:
+    """Map sender context to a human-visible session for reply auto-forward."""
+    report_to_id = agent_context.get("user_id", "") or ""
+    report_to_channel_id = agent_context.get("channel_id", "") or ""
+
+    if not report_to_id.startswith(_AGENT_MSG_PREFIX):
+        return report_to_id, report_to_channel_id
+
+    lookup_id = sender_id
+    if agent_context.get("is_subagent"):
+        parent_id = agent_context.get("parent_id", "") or ""
+        if parent_id:
+            lookup_id = parent_id
+
+    return _lookup_human_session(lookup_id)
+
+
+def resolve_report_to_for_subagent_spawn(
+    parent_agent_id: str,
+    spawner_user_id: str,
+    spawner_channel_id: str,
+) -> Tuple[str, str]:
+    """Resolve where a spawned sub-agent should report its final answer."""
+    report_to_id = spawner_user_id or ""
+    report_to_channel_id = spawner_channel_id or ""
+
+    if report_to_id and not report_to_id.startswith(_AGENT_MSG_PREFIX):
+        return report_to_id, report_to_channel_id
+
+    return _lookup_human_session(parent_agent_id)
+
+
+def _lookup_human_session(lookup_agent_id: str) -> Tuple[str, str]:
+    from models.db import db
+
+    human_sess = db.get_latest_human_session(lookup_agent_id)
+    if human_sess:
+        return human_sess.get("external_user_id", ""), human_sess.get("channel_id") or ""
+    return "", ""

--- a/backend/tools/agent_messaging.py
+++ b/backend/tools/agent_messaging.py
@@ -301,45 +301,18 @@ def _exec_send_agent_message(args: dict, agent_context: dict) -> dict:
     # Build the tagged message content and metadata
     tagged_message = f"[AGENT/{sender_name}] {message}"
 
-    reply_to_id = str(uuid.uuid4())
-    report_to_id = agent_context.get('user_id', '')
-    report_to_channel_id = agent_context.get('channel_id', '') or ''
+    from backend.agent_report_to import resolve_report_to_from_context
 
-    # If the sender is currently in an inter-agent session (external_user_id starts with
-    # __agent__), using that as report_to_id causes the auto-forward chain to bounce
-    # messages back into inter-agent sessions — eventually creating self-sessions
-    # (e.g. siwa/sessions/... with external_user_id = __agent__siwa).
-    # Fix: fall back to the sender's most recent human session so the reply chain
-    # always terminates in a human-visible session.
-    if report_to_id.startswith(_AGENT_MSG_PREFIX):
-        # Sub-agents are ephemeral / in-memory only — they have no row in `agents`
-        # and no human session in `chat_sessions`. Resolve to the parent agent first
-        # so the human-session lookup actually finds something.
-        lookup_id = sender_id
-        if agent_context.get('is_subagent'):
-            parent_id_for_lookup = agent_context.get('parent_id', '')
-            if parent_id_for_lookup:
-                lookup_id = parent_id_for_lookup
-                _logger.debug(
-                    "sender '%s' is a sub-agent — using parent '%s' for human-session lookup.",
-                    sender_id, parent_id_for_lookup,
-                )
-        _logger.debug(
-            "sender '%s' is in inter-agent session ('%s') — looking up human session for report_to_id (lookup_id=%s).",
-            sender_id, report_to_id, lookup_id,
+    reply_to_id = str(uuid.uuid4())
+    report_to_id, report_to_channel_id = resolve_report_to_from_context(
+        agent_context, sender_id,
+    )
+    if (agent_context.get('user_id', '') or '').startswith(_AGENT_MSG_PREFIX) and not report_to_id:
+        _logger.warning(
+            "send_agent_message: no human session found for sender '%s'. "
+            "Reply auto-forward will be skipped.",
+            sender_id,
         )
-        human_sess = db.get_latest_human_session(lookup_id)
-        if human_sess:
-            report_to_id = human_sess.get('external_user_id', '')
-            report_to_channel_id = human_sess.get('channel_id') or ''
-        else:
-            _logger.warning(
-                "send_agent_message: no human session found for sender '%s' (lookup_id=%s). "
-                "Reply auto-forward will be skipped.",
-                sender_id, lookup_id,
-            )
-            report_to_id = ''
-            report_to_channel_id = ''
 
     metadata = {
         'agent_message': True,

--- a/skills/subagent/backend/tools/subagent_spawn.py
+++ b/skills/subagent/backend/tools/subagent_spawn.py
@@ -34,18 +34,13 @@ def execute(agent: dict, args: dict) -> dict:
 
     parent_name = parent_agent.get('name', parent_id)
 
-    # Derive report_to so _on_final_answer can forward the sub-agent's
-    # result back to the parent's user-facing session.
-    report_to_id = agent.get('user_id', '')
-    report_to_channel_id = agent.get('channel_id', '') or ''
-    if report_to_id.startswith('__agent__'):
-        human_sess = db.get_latest_human_session(parent_id)
-        if human_sess:
-            report_to_id = human_sess.get('external_user_id', '')
-            report_to_channel_id = human_sess.get('channel_id') or ''
-        else:
-            report_to_id = ''
-            report_to_channel_id = ''
+    from backend.agent_report_to import resolve_report_to_for_subagent_spawn
+
+    report_to_id, report_to_channel_id = resolve_report_to_for_subagent_spawn(
+        parent_id,
+        agent.get('user_id', ''),
+        agent.get('channel_id', '') or '',
+    )
 
     result = notify_agent(
         agent_id=sub_id,

--- a/unit_tests/test_agent_report_to.py
+++ b/unit_tests/test_agent_report_to.py
@@ -1,0 +1,83 @@
+"""Tests for report_to session resolution (agent messaging + subagent spawn)."""
+
+import unittest
+from unittest import mock
+
+from backend.agent_report_to import (
+    resolve_report_to_for_subagent_spawn,
+    resolve_report_to_from_context,
+)
+
+
+class TestResolveReportToFromContext(unittest.TestCase):
+    def test_human_user_id_unchanged(self):
+        rid, ch = resolve_report_to_from_context(
+            {'user_id': 'telegram_99', 'channel_id': 'tg-1'},
+            'agent_a',
+        )
+        self.assertEqual(rid, 'telegram_99')
+        self.assertEqual(ch, 'tg-1')
+
+    def test_inter_agent_session_resolves_human(self):
+        human = {'external_user_id': 'user_123', 'channel_id': 'ch1'}
+        with mock.patch(
+            'models.db.db.get_latest_human_session',
+            return_value=human,
+        ) as mock_lookup:
+            rid, ch = resolve_report_to_from_context(
+                {'user_id': '__agent__agent_a', 'channel_id': ''},
+                'agent_a',
+            )
+        self.assertEqual(rid, 'user_123')
+        self.assertEqual(ch, 'ch1')
+        mock_lookup.assert_called_once_with('agent_a')
+
+    def test_subagent_uses_parent_for_lookup(self):
+        human = {'external_user_id': 'user_456', 'channel_id': None}
+        with mock.patch(
+            'models.db.db.get_latest_human_session',
+            return_value=human,
+        ) as mock_lookup:
+            rid, ch = resolve_report_to_from_context(
+                {
+                    'user_id': '__agent__sub_1',
+                    'is_subagent': True,
+                    'parent_id': 'parent_a',
+                },
+                'sub_1',
+            )
+        self.assertEqual(rid, 'user_456')
+        self.assertEqual(ch, '')
+        mock_lookup.assert_called_once_with('parent_a')
+
+
+class TestResolveReportToForSubagentSpawn(unittest.TestCase):
+    def test_spawner_human_session_used_directly(self):
+        rid, ch = resolve_report_to_for_subagent_spawn(
+            'parent_a', 'human_user', 'web',
+        )
+        self.assertEqual(rid, 'human_user')
+        self.assertEqual(ch, 'web')
+
+    def test_empty_spawner_user_id_looks_up_parent(self):
+        human = {'external_user_id': 'user_789', 'channel_id': 'ch9'}
+        with mock.patch(
+            'models.db.db.get_latest_human_session',
+            return_value=human,
+        ) as mock_lookup:
+            rid, ch = resolve_report_to_for_subagent_spawn('parent_a', '', '')
+        self.assertEqual(rid, 'user_789')
+        self.assertEqual(ch, 'ch9')
+        mock_lookup.assert_called_once_with('parent_a')
+
+    def test_inter_agent_spawner_looks_up_parent(self):
+        human = {'external_user_id': 'user_abc', 'channel_id': ''}
+        with mock.patch(
+            'models.db.db.get_latest_human_session',
+            return_value=human,
+        ) as mock_lookup:
+            rid, ch = resolve_report_to_for_subagent_spawn(
+                'parent_a', '__agent__parent_a', '',
+            )
+        self.assertEqual(rid, 'user_abc')
+        mock_lookup.assert_called_once_with('parent_a')


### PR DESCRIPTION
## The bug people actually see

[#21](https://github.com/anvie/evonic/issues/21): a parent agent spawns a sub-agent, the sub-agent finishes, and nothing shows up in the human chat. The parent might get an empty agent report.

The metadata field `report_to_id` tells the runtime where to forward the sub-agent's final answer. If it is blank, auto-forward is skipped. That is working as coded; the problem is we often **set it to blank** at spawn time.

## Why `report_to_id` was empty

`subagent_spawn` used to do roughly:

1. Take `user_id` from the parent agent context.
2. If it starts with `__agent__`, call `get_latest_human_session(parent_id)`.
3. Otherwise keep `user_id` as-is.

That misses two common cases:

**Empty `user_id`.** Some parent contexts simply do not populate `user_id` when the spawn happens (even though a human session exists for that agent). The old code never fell back to a DB lookup, so `report_to_id` stayed `""`.

**Inter-agent only.** When the parent is mid chain (`user_id = __agent__<parent>`), lookup is required. `send_agent_message` already had extra handling (including using `parent_id` when the sender is a sub-agent). `subagent_spawn` did not share that logic, so behavior diverged between "message another agent" and "spawn a sub-agent".

## Approach

Introduce `backend/agent_report_to.py` with two entry points:

- `resolve_report_to_for_subagent_spawn(parent_agent_id, spawner_user_id, spawner_channel_id)`  
  Used at spawn. If `spawner_user_id` is a normal human id (not `__agent__…`), use it. If it is empty or inter-agent, resolve via `db.get_latest_human_session(parent_agent_id)`.

- `resolve_report_to_from_context(agent_context, sender_id)`  
  Used by `send_agent_message`. Same rules as before for inter-agent sessions, including sub-agent → parent lookup, but centralized so we do not maintain two copies.

Both call `_lookup_human_session()`, which wraps `get_latest_human_session()` (channel sessions preferred, then web fallback; see `models/chat.py`).

## Code changes

| File | Role |
|------|------|
| `backend/agent_report_to.py` | **New** shared resolver |
| `skills/subagent/backend/tools/subagent_spawn.py` | Call `resolve_report_to_for_subagent_spawn` when building `notify_agent` metadata |
| `backend/tools/agent_messaging.py` | Replace inline block with `resolve_report_to_from_context`; keep warning log when lookup fails |
| `unit_tests/test_agent_report_to.py` | **New** focused tests for both resolvers |

No change to the forward handler itself, session storage format, or `get_latest_human_session` SQL. If lookup still returns `None` (agent has never talked to a human), `report_to_id` remains empty and forward is skipped, same as today, but with a warning in messaging and the same empty metadata at spawn.

## Tests run

```bash
pytest unit_tests/test_agent_report_to.py
pytest unit_tests/test_agent_messaging.py
```

`test_agent_report_to.py` covers:

- Human `user_id` passed through unchanged
- `__agent__` context → human session from DB
- Sub-agent context → lookup uses `parent_id`, not sub-agent id
- Spawn with empty spawner `user_id` → parent human session
- Spawn from inter-agent spawner → parent human session

Existing agent messaging tests still pass; refactor should be behavior-preserving for paths that already worked.

## What I did not validate manually

End-to-end spawn on Telegram/web with a live daemon. If you have a standard repro from #21, this is the right PR to run it against. The code path is entirely in metadata at spawn + existing forward-on-final-answer.

## Notes for review

- `agent_report_to` imports `db` inside `_lookup_human_session` to avoid import cycles at module load (same pattern as elsewhere in the codebase).
- If you prefer the resolver to live under `backend/tools/` instead of a top-level module, I can move it in a follow-up; kept it small and dependency-light for now.

Fixes [#21](https://github.com/anvie/evonic/issues/21).