### PR TITLE
security(workplaces): rate-limit unauthenticated connector pairing

### DIFF
--- a/backend/connector_pair_rate_limit.py
+++ b/backend/connector_pair_rate_limit.py
@@ -1,0 +1,42 @@
+"""
+Per-IP rate limiting for unauthenticated Evonet connector pairing attempts.
+"""
+
+import threading
+import time
+from typing import Dict, List
+
+import config
+
+_attempts: Dict[str, List[float]] = {}
+_lock = threading.Lock()
+
+
+def _max_attempts() -> int:
+    return getattr(config, 'CONNECTOR_PAIR_MAX_ATTEMPTS', 30)
+
+
+def _window_seconds() -> int:
+    return getattr(config, 'CONNECTOR_PAIRING_CODE_TTL', 300)
+
+
+def is_rate_limited(ip: str) -> bool:
+    """Return True if this IP has exceeded pairing attempt limits."""
+    window = _window_seconds()
+    now = time.monotonic()
+    with _lock:
+        timestamps = [t for t in _attempts.get(ip, []) if now - t < window]
+        _attempts[ip] = timestamps
+        return len(timestamps) >= _max_attempts()
+
+
+def record_attempt(ip: str) -> None:
+    now = time.monotonic()
+    with _lock:
+        _attempts.setdefault(ip, []).append(now)
+
+
+def reset_for_tests() -> None:
+    """Clear in-memory state (unit tests only)."""
+    with _lock:
+        _attempts.clear()

--- a/config.py
+++ b/config.py
@@ -179,6 +179,7 @@ CONNECTOR_WS_PORT = _get_env_int("CONNECTOR_WS_PORT", 8081, min_val=1024, max_va
 CONNECTOR_PING_INTERVAL = _get_env_int("CONNECTOR_PING_INTERVAL", 30, min_val=5, max_val=300)
 CONNECTOR_PING_TIMEOUT = _get_env_int("CONNECTOR_PING_TIMEOUT", 10, min_val=1, max_val=60)
 CONNECTOR_PAIRING_CODE_TTL = _get_env_int("CONNECTOR_PAIRING_CODE_TTL", 300, min_val=60, max_val=3600)  # seconds
+CONNECTOR_PAIR_MAX_ATTEMPTS = _get_env_int("CONNECTOR_PAIR_MAX_ATTEMPTS", 30, min_val=5, max_val=200)
 
 AGENT_MAX_TOOL_ITERATIONS = _get_env_int("AGENT_MAX_TOOL_ITERATIONS", 100, min_val=1, max_val=1000)
 EVAL_MAX_TOOL_ITERATIONS = _get_env_int("EVAL_MAX_TOOL_ITERATIONS", 30, min_val=1, max_val=500)

--- a/routes/workplaces.py
+++ b/routes/workplaces.py
@@ -11,6 +11,7 @@ import threading
 from flask import Blueprint, Response, jsonify, render_template, request, stream_with_context
 
 from models.db import db
+from backend import connector_pair_rate_limit
 
 workplaces_bp = Blueprint('workplaces', __name__)
 
@@ -299,6 +300,12 @@ def api_cancel_pairing_code(workplace_id):
 
 @workplaces_bp.route('/api/connector/pair', methods=['POST'])
 def api_connector_pair():
+    ip = request.remote_addr or '0.0.0.0'
+    if connector_pair_rate_limit.is_rate_limited(ip):
+        return jsonify({'error': 'Too many pairing attempts. Please try again later.'}), 429
+
+    connector_pair_rate_limit.record_attempt(ip)
+
     data = request.get_json() or {}
     pairing_code = (data.get('pairing_code') or '').strip().upper()
     device_name = (data.get('device_name') or 'unknown').strip()

--- a/unit_tests/test_connector_pair_rate_limit.py
+++ b/unit_tests/test_connector_pair_rate_limit.py
@@ -1,0 +1,35 @@
+"""Tests for Evonet connector pairing rate limiter."""
+
+import unittest
+
+from backend import connector_pair_rate_limit as rate_limit
+
+
+class TestConnectorPairRateLimit(unittest.TestCase):
+    def setUp(self):
+        rate_limit.reset_for_tests()
+
+    def test_allows_attempts_under_limit(self):
+        ip = '10.0.0.1'
+        limit = rate_limit._max_attempts()
+        for _ in range(limit - 1):
+            rate_limit.record_attempt(ip)
+            self.assertFalse(rate_limit.is_rate_limited(ip))
+
+    def test_blocks_at_limit(self):
+        ip = '10.0.0.2'
+        limit = rate_limit._max_attempts()
+        for _ in range(limit):
+            rate_limit.record_attempt(ip)
+        self.assertTrue(rate_limit.is_rate_limited(ip))
+
+    def test_limits_are_per_ip(self):
+        limit = rate_limit._max_attempts()
+        for _ in range(limit):
+            rate_limit.record_attempt('10.0.0.3')
+        self.assertTrue(rate_limit.is_rate_limited('10.0.0.3'))
+        self.assertFalse(rate_limit.is_rate_limited('10.0.0.4'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Cloud workplaces pair through `POST /api/connector/pair`, which is intentionally unauthenticated so the Evonet binary can exchange a short pairing code for a long-lived `connector_token`. That design makes sense for the connector flow, but it also means anyone who can reach the server can keep guessing codes until one works.

Pairing codes are six characters from a reduced alphabet (uppercase letters and digits, with ambiguous characters removed). The search space is large enough that random guessing is not practical in a single request, yet still small enough that a patient attacker could hammer the endpoint for the full TTL window (default five minutes) without hitting any throttle today.

This PR adds a simple per-IP rate limiter for pairing attempts. Before `finalize_pairing()` runs, the route checks whether the client IP has already used up its budget in the current window. If so, it returns **429** with a short error message. Every pairing request counts toward the limit, including wrong or expired codes, because those are exactly the guesses an attacker would send.

The limiter lives in `backend/connector_pair_rate_limit.py` and mirrors the in-memory style already used for failed login attempts in `routes/auth.py`: thread-safe timestamps keyed by IP, old entries pruned on each check. Defaults are aligned with pairing semantics:

- **Window:** `CONNECTOR_PAIRING_CODE_TTL` (default 300 seconds)
- **Max attempts:** `CONNECTOR_PAIR_MAX_ATTEMPTS` (default 30), configurable via `.env`

Legitimate pairing should need only a handful of tries (typo, clock skew, code regenerated once). Thirty attempts per IP per code lifetime is generous for real connectors while making online brute force much slower.

## What changed

- New module `backend/connector_pair_rate_limit.py` with `is_rate_limited()`, `record_attempt()`, and `reset_for_tests()`.
- `routes/workplaces.py`: rate check + `record_attempt()` at the start of `api_connector_pair()`.
- `config.py`: `CONNECTOR_PAIR_MAX_ATTEMPTS` env knob (min 5, max 200).
- `unit_tests/test_connector_pair_rate_limit.py`: under-limit allowed, at-limit blocked, per-IP isolation.

No change to how codes are generated, stored, or validated — only how often a single IP may call the pair endpoint.

## Risk / compatibility

- **Multi-instance deployments:** like the login limiter, state is in-process memory. Behind multiple app workers without sticky sessions, limits are per worker, not global. That is weaker than a shared store but consistent with existing patterns in this repo.
- **Reverse proxies:** limiting uses `request.remote_addr`. If you terminate TLS or proxy in front of Evonic, ensure the deployment forwards the real client IP (or all pairing traffic may appear as one address).
- **False positives:** an office NAT sharing one public IP could hit the cap if many connectors pair at once. Operators can raise `CONNECTOR_PAIR_MAX_ATTEMPTS` or TTL if needed.

## Validation

- `python -m pytest unit_tests/test_connector_pair_rate_limit.py -q`
