### PR TITLE
fix(agents): enforce sandbox disabled on remote and cloud workplaces

### DIFF
--- a/routes/agents.py
+++ b/routes/agents.py
@@ -7,7 +7,7 @@ import re
 import json
 import uuid
 import queue
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from flask import Blueprint, render_template, jsonify, request, Response, stream_with_context
 from models.db import db
 from models.chatlog import chatlog_manager, _DISPLAY_TYPES
@@ -29,6 +29,15 @@ def _sanitize_agents(agents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for a in agents:
         _sanitize_agent(a)
     return agents
+
+
+def _apply_sandbox_workplace_policy(agent_data: dict, workplace_id: Optional[str]) -> None:
+    """Docker sandbox is only supported on local workplaces."""
+    if not workplace_id:
+        return
+    workplace = db.get_workplace(workplace_id)
+    if workplace and workplace.get('type') in ('remote', 'cloud'):
+        agent_data['sandbox_enabled'] = 0
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 AGENTS_DIR = os.path.join(BASE_DIR, 'agents')
@@ -177,11 +186,7 @@ def api_create_agent():
         return jsonify({'error': 'Description too long (max 2000 characters).'}), 400
     if len(data.get('system_prompt', '')) > 102400:
         return jsonify({'error': 'System prompt too long (max 100 KB).'}), 400
-    # Docker Sandbox only available for local workplace mode
-    if data.get('sandbox_enabled') and data.get('workplace_id'):
-        workplace = db.get_workplace(data['workplace_id'])
-        if workplace and workplace.get('type') in ('remote', 'cloud'):
-            data['sandbox_enabled'] = 0
+    _apply_sandbox_workplace_policy(data, data.get('workplace_id'))
     try:
         _ensure_kb_dir(agent_id)
         # Set default workspace for regular agents to shared/agents/[agent-id]
@@ -207,12 +212,8 @@ def api_update_agent(agent_id):
     # Super agent cannot be disabled
     if existing.get('is_super') and data.get('enabled') is False:
         return jsonify({'error': 'Super agent cannot be disabled.'}), 403
-    # Docker Sandbox only available for local workplace mode
     target_workplace_id = data.get('workplace_id', existing.get('workplace_id'))
-    if data.get('sandbox_enabled') and target_workplace_id:
-        workplace = db.get_workplace(target_workplace_id)
-        if workplace and workplace.get('type') in ('remote', 'cloud'):
-            del data['sandbox_enabled']  # Do not overwrite existing value in database
+    _apply_sandbox_workplace_policy(data, target_workplace_id)
     if 'system_prompt' in data:
         _write_system_prompt(agent_id, data['system_prompt'])
     db.update_agent(agent_id, data)

--- a/unit_tests/test_agent_sandbox_workplace_validation.py
+++ b/unit_tests/test_agent_sandbox_workplace_validation.py
@@ -1,0 +1,64 @@
+"""
+Tests for sandbox_enabled enforcement against workplace type (issue #35).
+"""
+
+import unittest
+from unittest.mock import patch
+
+from routes.agents import _apply_sandbox_workplace_policy
+
+
+class TestAgentSandboxWorkplaceValidation(unittest.TestCase):
+    def _mock_get_workplace(self, workplace_id):
+        workplaces = {
+            'local-wp': {'id': 'local-wp', 'type': 'local'},
+            'remote-wp': {'id': 'remote-wp', 'type': 'remote'},
+            'cloud-wp': {'id': 'cloud-wp', 'type': 'cloud'},
+        }
+        return workplaces.get(workplace_id)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_local_workplace_allows_sandbox_on(self, mock_get):
+        mock_get.side_effect = self._mock_get_workplace
+        data = {'sandbox_enabled': 1}
+        _apply_sandbox_workplace_policy(data, 'local-wp')
+        self.assertEqual(data['sandbox_enabled'], 1)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_local_workplace_allows_sandbox_off(self, mock_get):
+        mock_get.side_effect = self._mock_get_workplace
+        data = {'sandbox_enabled': 0}
+        _apply_sandbox_workplace_policy(data, 'local-wp')
+        self.assertEqual(data['sandbox_enabled'], 0)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_remote_workplace_forces_sandbox_off_when_enabling(self, mock_get):
+        mock_get.side_effect = self._mock_get_workplace
+        data = {'sandbox_enabled': 1}
+        _apply_sandbox_workplace_policy(data, 'remote-wp')
+        self.assertEqual(data['sandbox_enabled'], 0)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_remote_workplace_forces_sandbox_off_when_already_disabled(self, mock_get):
+        mock_get.side_effect = self._mock_get_workplace
+        data = {'sandbox_enabled': 0}
+        _apply_sandbox_workplace_policy(data, 'remote-wp')
+        self.assertEqual(data['sandbox_enabled'], 0)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_cloud_workplace_forces_sandbox_off(self, mock_get):
+        mock_get.side_effect = self._mock_get_workplace
+        data = {'sandbox_enabled': 1}
+        _apply_sandbox_workplace_policy(data, 'cloud-wp')
+        self.assertEqual(data['sandbox_enabled'], 0)
+
+    @patch('routes.agents.db.get_workplace')
+    def test_no_workplace_id_leaves_data_unchanged(self, mock_get):
+        data = {'sandbox_enabled': 1}
+        _apply_sandbox_workplace_policy(data, None)
+        self.assertEqual(data['sandbox_enabled'], 1)
+        mock_get.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Background

Docker sandbox mode only applies to **local** workplaces. Remote SSH and cloud (Evonet) workplaces run tools through different execution backends, so a sandbox toggle on those agents does not mean what the UI implies.

There was a gap in how agent create/update handled `sandbox_enabled`:

- On **create**, validation only ran when `sandbox_enabled` was truthy, so sending `0` skipped the workplace check entirely.
- On **update**, the same truthy guard applied, and when the user tried to enable sandbox on a remote/cloud workplace the code **deleted** `sandbox_enabled` from the payload instead of writing `0`. The old value in SQLite could stay out of sync with what the settings page shows.

Issue [#35](https://github.com/anvie/evonic/issues/35) reported the toggle feeling ineffective; the underlying issue is that policy was not applied consistently on every save path.

## How it behaves now

A small helper, `_apply_sandbox_workplace_policy()`, looks up the target workplace and, for `remote` or `cloud` types, always sets `sandbox_enabled` to `0` on the data dict passed to the database layer.

Both API entry points call it:

- **POST** `/api/agents` — uses `workplace_id` from the create body.
- **PUT** `/api/agents/<id>` — uses `workplace_id` from the body when present, otherwise the agent’s existing workplace.

That means a partial update (name, prompt, channel, etc.) on a cloud agent still persists `sandbox_enabled=0`, even when the client omits the sandbox field. Local workplaces are unchanged: both `0` and `1` pass through as sent.

The agent detail UI already disables the sandbox toggle for remote/cloud; this change makes the stored agent record match that expectation.

## Files touched

- `routes/agents.py` — `_apply_sandbox_workplace_policy()` plus calls from create/update handlers.
- `unit_tests/test_agent_sandbox_workplace_validation.py` — unit tests against the helper (local allowed, remote/cloud forced off, no lookup when `workplace_id` is missing).

## Notes for reviewers

- This is separate from workplace file I/O delegation ([#36](https://github.com/anvie/evonic/pull/36)).
- No migration: agents with stale values get corrected the next time they are updated through the API; new creates are correct immediately.
- Setup wizard / CLI agent flows were not modified in this PR; happy to follow up if those paths need the same helper.

## Checked with

- `python -m pytest unit_tests/test_agent_sandbox_workplace_validation.py -q`