### PR TITLE
test(zip): add regression tests for upload zip validation

### DIFF
--- a/unit_tests/test_zip_validator.py
+++ b/unit_tests/test_zip_validator.py
@@ -1,0 +1,68 @@
+"""Regression tests for backend.zip_validator."""
+
+import os
+import tempfile
+import unittest
+import zipfile
+
+from backend import zip_validator as zv
+
+
+class TestZipValidator(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_zip(self, name: str, entries: dict) -> str:
+        path = os.path.join(self.tmp, name)
+        with zipfile.ZipFile(path, 'w') as zf:
+            for arcname, content in entries.items():
+                zf.writestr(arcname, content)
+        return path
+
+    def test_accepts_valid_plugin_like_zip(self):
+        path = self._write_zip('ok.zip', {
+            'my-skill/skill.json': '{}',
+            'my-skill/tool.py': 'print("hi")',
+        })
+        ok, err = zv.validate_upload_zip(path)
+        self.assertTrue(ok, err)
+
+    def test_rejects_path_traversal(self):
+        path = self._write_zip('traversal.zip', {'../evil.py': 'x'})
+        ok, err = zv.validate_upload_zip(path)
+        self.assertFalse(ok)
+        self.assertIn('traversal', err.lower())
+
+    def test_rejects_absolute_paths(self):
+        path = self._write_zip('abs.zip', {'/etc/passwd': 'x'})
+        ok, err = zv.validate_upload_zip(path)
+        self.assertFalse(ok)
+        self.assertIn('absolute', err.lower())
+
+    def test_rejects_disallowed_extension(self):
+        path = self._write_zip('exe.zip', {'payload.exe': 'MZ'})
+        ok, err = zv.validate_upload_zip(path)
+        self.assertFalse(ok)
+        self.assertIn('not permitted', err)
+
+    def test_rejects_empty_zip(self):
+        path = self._write_zip('empty.zip', {})
+        ok, err = zv.validate_upload_zip(path)
+        self.assertFalse(ok)
+        self.assertIn('empty', err.lower())
+
+    def test_rejects_non_zip_file(self):
+        path = os.path.join(self.tmp, 'not.zip')
+        with open(path, 'w') as f:
+            f.write('not a zip')
+        ok, err = zv.validate_upload_zip(path)
+        self.assertFalse(ok)
+        self.assertIn('zip', err.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Bcakground

Plugin and skill uploads go through `backend/zip_validator.validate_upload_zip()` before extraction. The checks are non-trivial: compressed size limits, per-entry caps, path traversal, extension whitelist, and corrupt-archive handling. Until now that module had no dedicated unit tests, so a refactor or a well-meaning one-line change could weaken install-time defenses without anyone noticing in CI.

This PR adds a focused regression suite. It does not change production code.

## Cases covered

Each test builds small archives under a temp directory and calls `validate_upload_zip()` directly.

| Scenario | Expected |
|----------|----------|
| Typical skill layout (`skill.json` + `.py`) | Accept |
| `../` in entry name | Reject (traversal) |
| Absolute path (`/etc/passwd`) | Reject |
| Disallowed extension (`.exe`) | Reject |
| Empty archive | Reject |
| File that is not a zip | Reject |

Together these lock in the behaviors plugin/skill routes already rely on. They are cheap to run and fail with clear assertion messages on the error string returned by the validator.

## What I don't Fix

- **Cryptographic signing** of plugin packages — covered elsewhere ([#29](https://github.com/anvie/evonic/pull/29)).
- **Route-level** upload tests (multipart form, auth, disk paths) — could be a follow-up; this PR stays at the validator layer.
- Zip bomb limits that need hundreds of entries or huge uncompressed totals — not exercised here; existing constants in `zip_validator.py` are unchanged.

## How to verify

- `python -m pytest unit_tests/test_zip_validator.py -q`