### PR TITLE
fix(agents): setup super user agent failed due incorrect number of bindings supplied

### DIFF
--- a/models/mixins/agents.py
+++ b/models/mixins/agents.py
@@ -43,6 +43,7 @@ class AgentMixin:
                 1 if agent.get('agent_messaging_enabled') is not False else 0,
                 1 if agent.get('sandbox_enabled') else 0,
                 agent.get('summarize_tail', 5),
+                1, # artifacts_enabled
             ))
             conn.commit()
         return agent['id']


### PR DESCRIPTION
Background:
In the last step of initial setup, there is a 400 error. 

```
incorrect number of bindings supplied. the current statement uses 17, and there are 16 supplied.
```

The issue is due this change https://github.com/anvie/evonic/commit/7f6ce20e8edc6aba093c11ec242d1db004bb4b6f#diff-1abbadae03152c1ed03be415f07008f9948c4ab811cca9388a2aae15a25987e2

Changes:
`models/mixins/agents.py` 