### PR TITLE
fix(evaluator): sandbox exec() in python mock test runner with AST validation

### DIFF
--- a/evaluator/engine.py
+++ b/evaluator/engine.py
@@ -748,17 +748,62 @@ class EvaluationEngine:
         return "\n".join(lines)
 
     def _execute_python_mock(self, py_code: str, args: dict):
-        """Execute Python mock response via exec()"""
-        import math, ast as _ast
+        """Execute Python mock response via exec() with AST-based sandboxing.
+
+        Before execution, the code is parsed and validated against a denylist
+        of dangerous AST node patterns (dunder attribute access, imports, class
+        definitions, etc.) that could escape the restricted namespace.
+        """
+        import math
+        import ast
+
+        # --- AST-based sandbox validation ---
+        _DUNDER_DENIES = frozenset({
+            '__class__', '__bases__', '__subclasses__', '__mro__',
+            '__globals__', '__builtins__', '__import__', '__getattr__',
+            '__getattribute__', '__setattr__', '__delattr__',
+            '__reduce__', '__reduce_ex__', '__getstate__',
+            '__code__', '__func__', '__self__',
+        })
+
+        try:
+            tree = ast.parse(py_code, mode='exec')
+        except SyntaxError as e:
+            self._log(f'[PY-MOCK] Syntax error: {e}')
+            return {"error": f"Python mock syntax error: {e}"}
+
+        for node in ast.walk(tree):
+            # Block import statements
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                return {"error": "Python mock: import statements are not allowed"}
+            # Block class/function definitions
+            if isinstance(node, (ast.ClassDef, ast.AsyncFunctionDef)):
+                return {"error": "Python mock: class/async def not allowed"}
+            # Block dunder attribute access (e.g. x.__class__.__bases__)
+            if isinstance(node, ast.Attribute) and node.attr in _DUNDER_DENIES:
+                return {"error": f"Python mock: access to '{node.attr}' is not allowed"}
+            # Block exec()/eval()/compile() calls
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in ('exec', 'eval', 'compile', '__import__'):
+                    return {"error": f"Python mock: {node.func.id}() is not allowed"}
+
         namespace = {
             'args': args,
             'math': math,
             'json': json,
             're': __import__('re'),
             'result': None,
+            # Safe builtins that mock code commonly needs
+            'sum': sum, 'len': len, 'int': int, 'str': str,
+            'list': list, 'dict': dict, 'tuple': tuple, 'set': set,
+            'bool': bool, 'float': float, 'min': min, 'max': max,
+            'abs': abs, 'round': round, 'range': range,
+            'enumerate': enumerate, 'zip': zip, 'map': map,
+            'filter': filter, 'sorted': sorted, 'any': any, 'all': all,
+            'isinstance': isinstance, 'True': True, 'False': False, 'None': None,
         }
         try:
-            exec(py_code, namespace)
+            exec(py_code, {'__builtins__': {}}, namespace)
             result = namespace.get('result')
             if result is None:
                 return {"error": "mock did not set result"}

--- a/unit_tests/test_evaluator_py_mock_sandbox.py
+++ b/unit_tests/test_evaluator_py_mock_sandbox.py
@@ -1,0 +1,145 @@
+"""Tests for evaluator engine Python mock sandbox."""
+
+import sys
+import os
+import queue
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from evaluator.engine import EvaluationEngine
+
+
+def _run_mock(py_code, args=None):
+    """Helper: call _execute_python_mock on a real engine instance."""
+    if args is None:
+        args = {}
+    ev = EvaluationEngine()
+    ev.log_queue = queue.Queue()
+    return ev._execute_python_mock(py_code, args)
+
+
+def test_basic_mock_sets_result():
+    r = _run_mock("result = args.get('x', 0) * 2", {'x': 21})
+    assert r == 42, r
+
+
+def test_mock_with_math():
+    r = _run_mock("import math; result = math.pi", {})
+    assert 'error' in r, r
+
+
+def test_mock_math_available_without_import():
+    r = _run_mock("result = math.sqrt(16)", {})
+    assert r == 4.0, r
+
+
+def test_mock_with_json():
+    r = _run_mock("result = json.dumps({'ok': True})", {})
+    assert '"ok": true' in r or '{"ok": true}' in r, r
+
+
+def test_mock_with_re():
+    r = _run_mock("result = re.sub(r'\\d+', 'N', 'a1b2c3')", {})
+    assert r == 'aNbNcN', r
+
+
+def test_sandbox_blocks_import():
+    r = _run_mock("import os; result = os.getcwd()", {})
+    assert 'error' in r, r
+    assert 'import' in r['error'].lower(), r
+
+
+def test_sandbox_blocks_import_from():
+    r = _run_mock("from os import getcwd; result = getcwd()", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_dunder_class():
+    r = _run_mock("result = ().__class__", {})
+    assert 'error' in r, r
+    assert '__class__' in r['error'], r
+
+
+def test_sandbox_blocks_dunder_bases():
+    r = _run_mock("x = (); result = x.__bases__", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_dunder_subclasses():
+    r = _run_mock("result = object.__subclasses__()", {})
+    assert 'error' in r, r
+    assert '__subclasses__' in r['error'], r
+
+
+def test_sandbox_blocks_dunder_globals():
+    r = _run_mock("result = len.__globals__", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_dunder_builtins():
+    r = _run_mock("result = {}.__builtins__", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_exec_call():
+    r = _run_mock("exec('result = 1')", {})
+    assert 'error' in r, r
+    assert 'exec' in r['error'].lower(), r
+
+
+def test_sandbox_blocks_eval_call():
+    r = _run_mock("result = eval('1+1')", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_classdef():
+    r = _run_mock("class Foo: pass\nresult = Foo()", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_import_call_via_ast():
+    r = _run_mock("__import__('os').system('echo pwned')", {})
+    assert 'error' in r, r
+
+
+def test_mock_no_result_returns_error():
+    r = _run_mock("x = 42", {})
+    assert 'error' in r, r
+    assert 'did not set result' in r['error'], r
+
+
+def test_mock_syntax_error():
+    r = _run_mock("result = [invalid syntax!!!", {})
+    assert 'error' in r, r
+    assert 'syntax' in r['error'].lower(), r
+
+
+def test_mock_complex_logic():
+    code = """
+data = args.get('items', [])
+filtered = [x for x in data if x > 10]
+result = sum(filtered)
+"""
+    r = _run_mock(code, {'items': [5, 15, 3, 20, 8]})
+    assert r == 35, r
+
+
+def test_sandbox_blocks_dunder_mro():
+    r = _run_mock("result = int.__mro__", {})
+    assert 'error' in r, r
+    assert '__mro__' in r['error'], r
+
+
+def test_sandbox_blocks_dunder_code():
+    r = _run_mock("result = len.__code__", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_dunder_reduce():
+    r = _run_mock("result = ().__reduce__()", {})
+    assert 'error' in r, r
+
+
+def test_sandbox_blocks_dunder_getattr():
+    r = _run_mock("result = object.__getattribute__", {})
+    assert 'error' in r, r


### PR DESCRIPTION
The `_execute_python_mock` method in `evaluator/engine.py` was running arbitrary Python code through `exec()` with only a restricted namespace as its defense. The problem is that `{"__builtins__": {}}` is a well-known weak sandbox — it can be escaped through object introspection like `().__class__.__bases__[0].__subclasses__()`, giving access to the full Python runtime from inside what was supposed to be an isolated mock execution environment.

This PR adds an AST-based validation pass that runs before `exec()` is ever called. It parses the mock code into an abstract syntax tree and rejects it if it contains:

- `import` or `from ... import` statements
- `class` or `async def` definitions
- Attribute access to dangerous dunder names (`__class__`, `__bases__`, `__subclasses__`, `__mro__`, `__globals__`, `__builtins__`, `__import__`, `__getattr__`, `__getattribute__`, `__reduce__`, `__code__`, etc.)
- Calls to `exec()`, `eval()`, `compile()`, or `__import__()`

The `__builtins__` dict passed to `exec()` is now explicitly empty, with only a curated set of safe builtins added to the namespace individually: `sum`, `len`, `int`, `str`, `list`, `dict`, `tuple`, `set`, `bool`, `float`, `min`, `max`, `abs`, `round`, `range`, `enumerate`, `zip`, `map`, `filter`, `sorted`, `any`, `all`, `isinstance`, plus `True`/`False`/`None`. This means mock code that legitimately uses `sum()` or `len()` still works, but there's no path back to `__builtins__` from inside the execution context.

I also added 23 tests that cover both the happy path (basic arithmetic, list filtering, json.dumps, re.sub) and the attack surface (dunder access, import attempts, eval/exec calls, class definitions, syntax errors). All 23 pass.

**What this changes:** Python mock responses in the evaluator will now reject any code that tries to escape the sandbox. Existing mocks that just do simple data manipulation will continue to work unchanged. Mocks that relied on importing modules or accessing internals will now return an error instead of executing.

**Risk:** Low. The sandbox was already intended to be restrictive — this just makes it actually restrictive. The only breaking change would be for mock code that was already doing things it shouldn't have been able to do.