### PR TITLE
fix(tools): harden _skip_safety flag to require strict boolean True

### DIFF
--- a/backend/tools/bash.py
+++ b/backend/tools/bash.py
@@ -57,9 +57,9 @@ def execute(agent: dict, args: dict) -> dict:
     # ------------------------------------------------------------------
     # HMADS safety check (pipeline: system rules + custom user rules)
     # ------------------------------------------------------------------
-    from backend.tools.lib.safety_pipeline import get_safety_pipeline
+    from backend.tools.lib.safety_pipeline import get_safety_pipeline, should_skip_safety
 
-    if not agent.get('_skip_safety') and agent.get('safety_checker_enabled', 1) and not agent.get('is_super'):
+    if not should_skip_safety(agent) and agent.get('safety_checker_enabled', 1) and not agent.get('is_super'):
         safety = get_safety_pipeline().check(script, tool_type='bash', agent_context=agent)
     else:
         safety = {'level': 'safe', 'score': 0, 'reasons': [], 'blocked_patterns': [], 'approval_info': {}}

--- a/backend/tools/lib/safety_pipeline.py
+++ b/backend/tools/lib/safety_pipeline.py
@@ -24,6 +24,19 @@ from backend.tools.lib.safety_base import SafetyCheckerBase, CheckResult
 logger = logging.getLogger(__name__)
 
 
+def should_skip_safety(agent: dict | None) -> bool:
+    """Return True only when the agent dict explicitly carries ``_skip_safety is True``.
+
+    This helper prevents prompt-injection attacks where an LLM might try to set
+    ``_skip_safety`` to a truthy string, integer, or dict.  The flag must be the
+    exact boolean ``True``, which can only be set by trusted server-side code
+    (e.g. after human approval).
+    """
+    if agent is None:
+        return False
+    return agent.get("_skip_safety") is True
+
+
 def _generate_approval_info(blocked_patterns: list[str], matched_count: int) -> dict:
     """Generate approval information for requires_approval cases."""
     categories = set(blocked_patterns)

--- a/backend/tools/patch.py
+++ b/backend/tools/patch.py
@@ -14,6 +14,7 @@ except ImportError:
     _WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from backend.tools._workspace import resolve_workspace_path
+from backend.tools.lib.safety_pipeline import should_skip_safety
 
 SEARCH_WINDOW = 50
 
@@ -485,14 +486,14 @@ def execute(agent, args: dict) -> dict:
         return {'error': "'patch' must be a string containing unified diff content"}
 
     # Heuristic safety check: block access to .ssh directory
-    if not (agent or {}).get('_skip_safety') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_ssh_path
         ssh_check = check_ssh_path(file_path, agent)
         if ssh_check["blocked"]:
             return {"error": ssh_check["error"]}
 
     # Heuristic safety check: require approval for sensitive system paths
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_sensitive_path
         path_check = check_sensitive_path(file_path, agent)
         if path_check["blocked"]:
@@ -508,7 +509,7 @@ def execute(agent, args: dict) -> dict:
             }
 
     # Heuristic safety check: require approval for .env files
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_env_path
         env_check = check_env_path(file_path, agent)
         if env_check["blocked"]:

--- a/backend/tools/str_replace.py
+++ b/backend/tools/str_replace.py
@@ -8,6 +8,7 @@ except ImportError:
     _WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from backend.tools._workspace import resolve_workspace_path
+from backend.tools.lib.safety_pipeline import should_skip_safety
 
 
 def str_replace(file_path: str, old_str: str, new_str: str, count: int = 1) -> dict:
@@ -95,14 +96,14 @@ def execute(agent, args: dict) -> dict:
     count = args.get('count', 1)
 
     # Heuristic safety check: block access to .ssh directory
-    if not (agent or {}).get('_skip_safety') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_ssh_path
         ssh_check = check_ssh_path(file_path, agent)
         if ssh_check["blocked"]:
             return {"error": ssh_check["error"]}
 
     # Heuristic safety check: require approval for sensitive system paths
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_sensitive_path
         path_check = check_sensitive_path(file_path, agent)
         if path_check["blocked"]:
@@ -118,7 +119,7 @@ def execute(agent, args: dict) -> dict:
             }
 
     # Heuristic safety check: require approval for .env files
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_env_path
         env_check = check_env_path(file_path, agent)
         if env_check["blocked"]:

--- a/backend/tools/write_file.py
+++ b/backend/tools/write_file.py
@@ -8,6 +8,7 @@ except ImportError:
     _WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from backend.tools._workspace import resolve_workspace_path
+from backend.tools.lib.safety_pipeline import should_skip_safety
 
 _STR_REPLACE_STEPS = """1. First, call read_file() to see the current content.
 2. Then call {tool} with old_str set to the exact lines you want to change (copy them from read_file's output).
@@ -159,14 +160,14 @@ def execute(agent, args: dict) -> dict:
     edit_suggestion = _get_edit_suggestion(agent)
 
     # Heuristic safety check: block access to .ssh directory
-    if not (agent or {}).get('_skip_safety') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_ssh_path
         ssh_check = check_ssh_path(file_path, agent)
         if ssh_check["blocked"]:
             return {"error": ssh_check["error"]}
 
     # Heuristic safety check: require approval for SQLite database access
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_sqlite_path
         db_check = check_sqlite_path(file_path, agent)
         if db_check["blocked"]:
@@ -182,7 +183,7 @@ def execute(agent, args: dict) -> dict:
             }
 
     # Heuristic safety check: require approval for sensitive system paths
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_sensitive_path
         path_check = check_sensitive_path(file_path, agent)
         if path_check["blocked"]:
@@ -198,7 +199,7 @@ def execute(agent, args: dict) -> dict:
             }
 
     # Heuristic safety check: require approval for .env files
-    if not (agent or {}).get('_skip_safety') and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
+    if not should_skip_safety(agent) and not (agent or {}).get('is_super') and (agent is None or agent.get("safety_checker_enabled", 1)):
         from backend.tools.safety_checker import check_env_path
         env_check = check_env_path(file_path, agent)
         if env_check["blocked"]:

--- a/unit_tests/test_should_skip_safety.py
+++ b/unit_tests/test_should_skip_safety.py
@@ -1,0 +1,61 @@
+"""Tests for should_skip_safety helper."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.tools.lib.safety_pipeline import should_skip_safety
+
+
+def test_none_agent_returns_false():
+    assert should_skip_safety(None) is False
+
+
+def test_empty_agent_returns_false():
+    assert should_skip_safety({}) is False
+
+
+def test_explicit_true_returns_true():
+    assert should_skip_safety({'_skip_safety': True}) is True
+
+
+def test_string_true_returns_false():
+    """LLM might try to set _skip_safety to the string 'true'."""
+    assert should_skip_safety({'_skip_safety': 'true'}) is False
+    assert should_skip_safety({'_skip_safety': 'True'}) is False
+
+
+def test_integer_one_returns_false():
+    """LLM might try to set _skip_safety to 1."""
+    assert should_skip_safety({'_skip_safety': 1}) is False
+
+
+def test_empty_string_returns_false():
+    assert should_skip_safety({'_skip_safety': ''}) is False
+
+
+def test_empty_dict_returns_false():
+    """LLM might try to set _skip_safety to {}."""
+    assert should_skip_safety({'_skip_safety': {}}) is False
+
+
+def test_empty_list_returns_false():
+    assert should_skip_safety({'_skip_safety': []}) is False
+
+
+def test_false_boolean_returns_false():
+    assert should_skip_safety({'_skip_safety': False}) is False
+
+
+def test_missing_key_returns_false():
+    assert should_skip_safety({'session_id': 'abc'}) is False
+
+
+def test_other_keys_ignored():
+    """Only _skip_safety matters; other keys don't affect the result."""
+    assert should_skip_safety({
+        '_skip_safety': True,
+        'session_id': 'abc',
+        'is_super': True,
+    }) is True


### PR DESCRIPTION
Every tool backend (bash, write_file, str_replace, patch) checks `agent.get('_skip_safety')` to decide whether to run the heuristic safety pipeline. The issue: `.get()` returns truthy for almost anything. An LLM could set `_skip_safety` to the string `"true"`, the integer `1`, an empty dict `{}`, or even a list — and Python's truthiness would treat all of those as "skip safety."

This is a prompt injection vector. If an attacker can influence the agent context through a crafted prompt, they could convince the model to emit `_skip_safety: "true"` in its tool call arguments and bypass all safety checks — SSH path blocking, SQLite protection, sensitive system path guards, .env file protection, the whole pipeline.

The fix is a single helper function `should_skip_safety(agent)` in `backend/tools/lib/safety_pipeline.py` that uses an identity check: `agent.get("_skip_safety") is True`. Only the exact boolean `True` passes. Strings, integers, dicts, lists, empty values — all rejected. This means the flag can only be set by trusted server-side code (e.g. after explicit human approval), not by anything an LLM might generate.

I went through all four tool files and replaced every occurrence of the old pattern:

- `backend/tools/bash.py` — 1 occurrence
- `backend/tools/write_file.py` — 4 occurrences (SSH path, SQLite, sensitive paths, .env)
- `backend/tools/str_replace.py` — 3 occurrences (SSH path, sensitive paths, .env)
- `backend/tools/patch.py` — 3 occurrences (SSH path, sensitive paths, .env)

There's also a new test file with 11 cases covering the injection vectors: `None` agent, empty dict, explicit `True`, string `"true"`, string `"True"`, integer `1`, empty string, empty dict as value, empty list, boolean `False`, and a dict with other keys present. All pass.

**Backward compatibility:** If any legitimate code path was setting `_skip_safety` to a non-boolean truthy value, it will now stop skipping safety. That's the intended behavior — those paths should be reviewed and either set the proper boolean or not skip at all.