### PR TITLE
fix(ssh): enable host key verification with known_hosts loading

### DIFF
--- a/backend/tools/lib/backends/ssh_backend.py
+++ b/backend/tools/lib/backends/ssh_backend.py
@@ -54,8 +54,43 @@ class SSHBackend(ExecutionBackend):
         self._evonic_installed = False
 
         self._client = paramiko.SSHClient()
-        self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self._load_host_keys()
+        self._client.set_missing_host_key_policy(paramiko.WarningPolicy())
         self._connect()
+
+    def _load_host_keys(self):
+        """Load known_hosts from standard locations for host key verification.
+
+        Tries the user's ~/.ssh/known_hosts first, then falls back to the
+        system-wide known_hosts. If neither exists, the client will still
+        connect (via WarningPolicy) but will log a warning for unknown hosts.
+        """
+        import paramiko
+
+        candidates = [
+            os.path.expanduser('~/.ssh/known_hosts'),
+        ]
+        # System-wide known_hosts (platform-dependent)
+        if os.name == 'posix':
+            candidates.extend([
+                '/etc/ssh/ssh_known_hosts',
+                '/etc/ssh/known_hosts',
+            ])
+
+        for path in candidates:
+            if os.path.isfile(path):
+                try:
+                    self._client.load_host_keys(path)
+                    logger.debug("[ssh] Loaded host keys from %s", path)
+                    return
+                except Exception:
+                    logger.debug("[ssh] Failed to load host keys from %s", path)
+
+        logger.warning(
+            "[ssh] No known_hosts file found; unknown hosts will be accepted "
+            "with a warning (MITM risk). Add host keys via: ssh-keyscan -H %s >> ~/.ssh/known_hosts",
+            self._host,
+        )
 
     def _connect(self):
         import paramiko

--- a/unit_tests/test_ssh_host_keys.py
+++ b/unit_tests/test_ssh_host_keys.py
@@ -1,0 +1,40 @@
+"""Tests for SSH backend host key verification."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_warning_policy_is_set():
+    """Verify that WarningPolicy (not AutoAddPolicy) is the default."""
+    import paramiko
+    assert paramiko.WarningPolicy is not paramiko.AutoAddPolicy
+    policy = paramiko.WarningPolicy()
+    assert isinstance(policy, paramiko.MissingHostKeyPolicy)
+
+
+def test_auto_add_policy_removed():
+    """Verify the codebase no longer uses AutoAddPolicy for SSH connections."""
+    ssh_backend_path = os.path.join(
+        os.path.dirname(__file__), '..',
+        'backend', 'tools', 'lib', 'backends', 'ssh_backend.py'
+    )
+    with open(ssh_backend_path, 'r') as f:
+        content = f.read()
+
+    assert 'set_missing_host_key_policy(paramiko.AutoAddPolicy())' not in content, \
+        "SSH backend should not use AutoAddPolicy"
+
+    assert 'set_missing_host_key_policy(paramiko.WarningPolicy())' in content, \
+        "SSH backend should use WarningPolicy"
+
+    assert '_load_host_keys' in content, \
+        "SSH backend should have _load_host_keys method"
+
+
+def test_load_host_keys_method_exists():
+    """Verify _load_host_keys is a proper method on SSHBackend."""
+    from backend.tools.lib.backends.ssh_backend import SSHBackend
+    assert hasattr(SSHBackend, '_load_host_keys')
+    assert callable(getattr(SSHBackend, '_load_host_keys'))


### PR DESCRIPTION
The SSH backend in `backend/tools/lib/backends/ssh_backend.py` was using `paramiko.AutoAddPolicy()`, which silently accepts any host key presented by the remote server. No verification, no warning, no record. This makes every SSH workplace connection vulnerable to man-in-the-middle attacks — an attacker on the same network could intercept the connection, present their own host key, and capture all transmitted data including commands, file contents, and credentials.

Two changes:

1. **`AutoAddPolicy()` → `WarningPolicy()`**. Unknown hosts still connect (backward compatible — we don't want to break existing setups on first run), but paramiko now logs a warning instead of silently accepting. This at least makes the risk visible in logs.

2. **New `_load_host_keys()` method**. Before connecting, the backend now tries to load known host keys from standard locations: `~/.ssh/known_hosts` first, then `/etc/ssh/ssh_known_hosts` and `/etc/ssh/known_hosts` as fallbacks. If a host key is found in one of these files and the remote server presents a different key, paramiko will reject the connection rather than accepting it. If no known_hosts file exists anywhere, it falls back to `WarningPolicy` behavior and logs a hint suggesting the user run `ssh-keyscan -H <host> >> ~/.ssh/known_hosts`.

This mirrors how the `ssh` CLI works by default — it trusts keys it has seen before and warns about new ones. The difference is that before this change, the SSH backend was effectively running with `StrictHostKeyChecking no` on every connection.

**For users who already have SSH workplaces configured:** Their first connection after this upgrade will still succeed (via `WarningPolicy`), but they'll see a warning in the logs. If they want full verification, they can pre-populate known_hosts by connecting once via the `ssh` CLI or running `ssh-keyscan`.

**For new connections:** Same behavior as before, just with a visible warning instead of silent acceptance.

Three tests verify that `WarningPolicy` is used, `AutoAddPolicy` is gone, and the `_load_host_keys` method exists on `SSHBackend`.