### PR TITLE
fix(setup): remove dead TONES lookup that breaks Next on Super Agent step

### DIFF
--- a/templates/setup.html
+++ b/templates/setup.html
@@ -428,7 +428,6 @@ function populateReview() {
     $('#review-url').text($('#base-url').val().trim());
     $('#review-agent-name').text($('#agent-name').val().trim());
     $('#review-agent-id').text($('#agent-id').val().trim());
-    $('#review-tone').text((TONES[tone] || {}).label || tone);
     $('#review-language').text((LANGUAGES[language] || {}).label || language);
 }
 


### PR DESCRIPTION
## Summary

The first-time setup wizard at `/setup` throws a JavaScript `ReferenceError` when the user clicks **Next** on step 2 (Super Agent), blocking access to step 3 (Review & Create) and effectively preventing any new user from completing the wizard.

## Stack trace (from a browser console)

```
setup:521 Uncaught ReferenceError: TONES is not defined
    at populateReview (setup:521:29)
    at HTMLButtonElement.<anonymous> (setup:466:5)
    at HTMLButtonElement.dispatch (jquery-3.7.1.min.js:2:40035)
    at ce.event.add.v.handle (jquery-3.7.1.min.js:2:38006)
```

## Root cause

`templates/setup.html` line 431 reads:

```js
$(#review-tone).text((TONES[tone] || {}).label || tone);
```

Both `TONES` (a constants map) and `tone` (a wizard variable) are undefined in this scope. The line is vestigial leftover from a removed feature:

- Step 2 has **no tone UI** — only Agent Name, Agent ID, and Language radios.
- `submitSetup()` payload does **not** include a tone field.
- The review section in the HTML has no `#review-tone` element to populate.

`grep -n \"TONES\" templates/setup.html` returns only this one line — nothing else in the file references it.

## Fix

Delete the orphan line.

## Reproduction

1. Deploy fresh evonic (no prior setup).
2. Open the dashboard URL → redirected to `/setup`.
3. Step 1: pick any provider, fill base URL / key / model, **Test Connection** succeeds.
4. Click **Next →** → step 2 renders.
5. Step 2: fill Agent Name and Agent ID, leave language as English.
6. Click **Next →** → console error, wizard stays on step 2.

## Verification

After applying the patch and restarting the server, the same flow advances cleanly from step 2 → step 3. The Review & Create page renders all collected fields (provider, model, base URL, agent name, agent ID, language) with no console errors. No other wizard step depends on the removed line, and no functionality is lost.