### PR TITLE
fix(agents): reject SVG avatar uploads to prevent stored XSS

### DIFF
--- a/routes/agents.py
+++ b/routes/agents.py
@@ -714,8 +714,12 @@ def api_get_avatar(agent_id):
         if mime is None:
             mime = 'application/octet-stream'
         from flask import send_file
-        return send_file(avatar_path, mimetype=mime)
-    # Return default SVG avatar
+        # Force download for all stored avatar files to prevent any stored SVG
+        # from being rendered as an active document in the browser (XSS defence).
+        return send_file(avatar_path, mimetype=mime, as_attachment=True,
+                         download_name=os.path.basename(avatar_path))
+    # Return the default avatar as an inline SVG served from a static string.
+    # This SVG is fully controlled server-side and contains no user content.
     default_svg = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
   <rect width="40" height="40" rx="20" fill="#e0e7ff"/>
   <path d="M20 8a5 5 0 100 10 5 5 0 000-10zm-8 18.5a8 8 0 0116 0" fill="#4f46e5"/>
@@ -727,19 +731,25 @@ def api_get_avatar(agent_id):
 
 @agents_bp.route('/api/agents/<agent_id>/avatar', methods=['POST'])
 def api_upload_avatar(agent_id):
-    agent = db.get_agent(agent_id)
-    if not agent:
-        return jsonify({'error': 'Agent not found'}), 404
+    # --- Validate extension first (fail-fast, before any DB or disk access) ---
+    # SVG is intentionally excluded: SVG files can embed <script> tags and event
+    # handlers that execute when the browser renders the file inline, enabling
+    # stored XSS.  Only raster formats that cannot carry active content are
+    # allowed.  (SEC-1)
+    allowed_exts = {'.png', '.jpg', '.jpeg', '.gif', '.webp'}
     if 'file' not in request.files:
         return jsonify({'error': 'No file provided'}), 400
     f = request.files['file']
     if not f.filename:
         return jsonify({'error': 'No file selected'}), 400
-    # Validate image type
-    allowed_exts = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'}
     ext = os.path.splitext(f.filename)[1].lower()
     if ext not in allowed_exts:
         return jsonify({'error': f'Invalid image type. Allowed: {", ".join(sorted(allowed_exts))}'}), 400
+
+    agent = db.get_agent(agent_id)
+    if not agent:
+        return jsonify({'error': 'Agent not found'}), 404
+
     avatar_dir = _avatar_dir(agent_id)
     # Remove old avatar file if exists
     old_path = agent.get('avatar_path', '')

--- a/unit_tests/test_avatar_svg_xss.py
+++ b/unit_tests/test_avatar_svg_xss.py
@@ -1,0 +1,135 @@
+"""Regression tests for SVG avatar upload XSS prevention.
+
+SEC-1: SVG files uploaded as agent avatars can contain <script> tags or
+event handlers. When served back via /api/agents/<id>/avatar with
+mimetype image/svg+xml, browsers render them as active documents,
+enabling stored XSS.
+
+Fix: reject .svg uploads; or if SVG is kept, serve with
+Content-Disposition: attachment to prevent inline rendering.
+"""
+import io
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestAvatarSvgUploadRejected(unittest.TestCase):
+    """SVG must be rejected at upload time so XSS payload never reaches disk."""
+
+    def setUp(self):
+        from routes.agents import agents_bp
+        from flask import Flask
+
+        template_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "templates",
+        )
+        self.app = Flask(__name__, template_folder=template_dir)
+        self.app.secret_key = "test-avatar-xss-secret"
+        self.app.register_blueprint(agents_bp)
+        self.client = self.app.test_client()
+
+    def _upload_avatar(self, filename: str, content: bytes, content_type: str):
+        """POST a fake avatar file to the upload endpoint."""
+        data = {
+            "file": (io.BytesIO(content), filename, content_type),
+        }
+        return self.client.post(
+            "/api/agents/test-agent/avatar",
+            data=data,
+            content_type="multipart/form-data",
+        )
+
+    def test_svg_upload_is_rejected(self):
+        """.svg extension must be rejected with 400 to prevent stored XSS."""
+        svg_payload = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        resp = self._upload_avatar("evil.svg", svg_payload, "image/svg+xml")
+        self.assertEqual(
+            resp.status_code,
+            400,
+            "SVG upload should be rejected with HTTP 400 to prevent XSS",
+        )
+
+    def test_svg_with_image_mimetype_upload_is_rejected(self):
+        """.svg with image/png content-type spoofing must still be rejected."""
+        svg_payload = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        resp = self._upload_avatar("evil.svg", svg_payload, "image/png")
+        self.assertEqual(
+            resp.status_code,
+            400,
+            "SVG upload with spoofed MIME type must be rejected based on extension",
+        )
+
+    def test_png_upload_is_still_accepted(self):
+        """Legitimate .png uploads must not be rejected with 400 (non-regression).
+
+        The extension check now runs before the agent DB lookup, so a valid
+        extension with a non-existent agent yields 404, not 400.
+        """
+        # 1x1 transparent PNG
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00"
+            b"\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+            b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        resp = self._upload_avatar("avatar.png", png_bytes, "image/png")
+        # 404 expected: agent 'test-agent' doesn't exist in test DB.
+        # The important invariant is that .png is NOT rejected with 400.
+        self.assertEqual(
+            resp.status_code,
+            404,
+            "PNG should pass extension check and reach the agent-lookup step",
+        )
+
+    def test_jpg_upload_is_still_accepted(self):
+        """.jpg must pass the extension check and reach the agent lookup (non-regression)."""
+        resp = self._upload_avatar("photo.jpg", b"\xff\xd8\xff", "image/jpeg")
+        # 404 because the test agent doesn't exist in DB, NOT 400 (extension rejected).
+        self.assertEqual(
+            resp.status_code,
+            404,
+            ".jpg should pass extension check",
+        )
+
+    def test_webp_upload_is_still_accepted(self):
+        """.webp must pass the extension check and reach the agent lookup (non-regression)."""
+        resp = self._upload_avatar("photo.webp", b"RIFF....WEBP", "image/webp")
+        # 404 because the test agent doesn't exist in DB, NOT 400 (extension rejected).
+        self.assertEqual(
+            resp.status_code,
+            404,
+            ".webp should pass extension check",
+        )
+
+
+class TestAvatarAllowedExtensions(unittest.TestCase):
+    """Unit-test the allowed_exts set in the upload handler directly."""
+
+    def _get_allowed_exts(self):
+        """Import the constant from agents route module."""
+        import importlib
+        import routes.agents as agents_mod
+        importlib.reload(agents_mod)
+        # The allowed_exts set is defined inside api_upload_avatar; we
+        # verify the behaviour via the upload endpoint test above.
+        # Here we just confirm .svg is not in the module-level comment/docs.
+        return agents_mod
+
+    def test_svg_not_in_allowed_exts(self):
+        """Verify .svg is explicitly excluded from avatar allowed extensions."""
+        import routes.agents as agents_mod
+        import inspect
+        source = inspect.getsource(agents_mod.api_upload_avatar)
+        self.assertNotIn(
+            "'.svg'",
+            source,
+            ".svg must be removed from the allowed_exts set in api_upload_avatar",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
SVG files are XML, and XML can have `<script>` tags. When you upload an SVG as an avatar and the server serves it back with `image/svg+xml`, the browser doesn't render it like an image — it renders it as an active document. Any JavaScript inside runs. That's stored XSS, and it persists for anyone who loads the page.

The agent sidebar introduced in a recent PR now loads avatars on every page. So the blast radius is the entire app, not just the agent detail page.

### What changed

The upload handler previously allowed `.svg` alongside the raster formats. Removing it was the obvious fix, but there were two other things worth cleaning up:

The extension check happened *after* the database lookup for the agent. Meaning an invalid file type would still trigger a DB query before being rejected. Swapped the order so bad extensions fail immediately with no backend work.

The GET endpoint for stored avatars was serving files inline via `send_file()`. Switched it to `as_attachment=True` so anything already on disk — including any SVGs uploaded before this fix — gets served with `Content-Disposition: attachment` instead of being rendered in the browser.

The default avatar (a static SVG string hardcoded in the server response) is unaffected. That one is fine because it's fully controlled server-side with no user content.

### Tests

Six new tests in `unit_tests/test_avatar_svg_xss.py`:

- SVG upload (correct MIME type) → 400
- SVG upload with spoofed MIME type → 400 (extension is what's checked, not the MIME)
- PNG, JPG, WEBP → pass the extension check and reach the agent lookup step normally

Full suite: 150 tests, all passing.

### What this doesn't affect

Users who had a custom PNG/JPG/WEBP avatar see no change. The default avatar (shown when no custom avatar is set) is unchanged. The only thing that stops working is uploading `.svg` files as avatars.