### PR TITLE
Fix: Workplace DB CHECK constraint mismatch — 'tunnel' type rejected as invalid

### DIFF
--- a/models/schema.py
+++ b/models/schema.py
@@ -691,6 +691,7 @@ class SchemaMixin:
                 cursor.execute("UPDATE workplaces SET type = 'tunnel' WHERE type = 'cloud'")
             except (sqlite3.OperationalError, sqlite3.IntegrityError):
                 try:
+                    cursor.execute("DROP TABLE IF EXISTS workplaces_old")
                     cursor.execute("ALTER TABLE workplaces RENAME TO workplaces_old")
                     cursor.execute("""
                         CREATE TABLE workplaces (

--- a/models/schema.py
+++ b/models/schema.py
@@ -685,35 +685,33 @@ class SchemaMixin:
 
 
             # Migration: rename type cloud to tunnel for existing workplaces
-            # If the old CHECK constraint (type IN 'cloud') is still on the table,
-            # the UPDATE will fail with IntegrityError. Recreate the table with the new schema.
+            # The old CHECK constraint (type IN 'cloud') must be replaced with 'tunnel'.
+            # Rebuild the table unconditionally — relying on UPDATE failure to trigger
+            # the rebuild fails when there are no 'cloud' rows (no-op success skips it).
             try:
-                cursor.execute("UPDATE workplaces SET type = 'tunnel' WHERE type = 'cloud'")
-            except (sqlite3.OperationalError, sqlite3.IntegrityError):
-                try:
-                    cursor.execute("DROP TABLE IF EXISTS workplaces_old")
-                    cursor.execute("ALTER TABLE workplaces RENAME TO workplaces_old")
-                    cursor.execute("""
-                        CREATE TABLE workplaces (
-                            id TEXT PRIMARY KEY,
-                            name TEXT NOT NULL,
-                            type TEXT NOT NULL CHECK(type IN ('local', 'remote', 'tunnel')),
-                            config TEXT NOT NULL DEFAULT '{}',
-                            status TEXT DEFAULT 'disconnected',
-                            error_msg TEXT,
-                            last_connected_at TEXT,
-                            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-                        )
-                    """)
-                    cursor.execute("""
-                        INSERT INTO workplaces (id, name, type, config, status, error_msg, last_connected_at, created_at, updated_at)
-                        SELECT id, name, CASE WHEN type = 'cloud' THEN 'tunnel' ELSE type END, config, status, error_msg, last_connected_at, created_at, updated_at
-                        FROM workplaces_old
-                    """)
-                    cursor.execute("DROP TABLE workplaces_old")
-                except sqlite3.OperationalError:
-                    pass
+                cursor.execute("DROP TABLE IF EXISTS workplaces_old")
+                cursor.execute("ALTER TABLE workplaces RENAME TO workplaces_old")
+                cursor.execute("""
+                    CREATE TABLE workplaces (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        type TEXT NOT NULL CHECK(type IN ('local', 'remote', 'tunnel')),
+                        config TEXT NOT NULL DEFAULT '{}',
+                        status TEXT DEFAULT 'disconnected',
+                        error_msg TEXT,
+                        last_connected_at TEXT,
+                        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+                    )
+                """)
+                cursor.execute("""
+                    INSERT INTO workplaces (id, name, type, config, status, error_msg, last_connected_at, created_at, updated_at)
+                    SELECT id, name, CASE WHEN type = 'cloud' THEN 'tunnel' ELSE type END, config, status, error_msg, last_connected_at, created_at, updated_at
+                    FROM workplaces_old
+                """)
+                cursor.execute("DROP TABLE workplaces_old")
+            except sqlite3.OperationalError:
+                pass
 
             # Migration: rename cloud_connectors to tunnel_connectors for existing databases
             try:


### PR DESCRIPTION
## Problem
Creating a workplace with `type=tunnel` fails with:
sqlite3.IntegrityError: CHECK constraint failed: type IN ('local', 'remote', 'cloud')


The route validator (`routes/workplaces.py:59`) accepts `tunnel`, but the database CHECK constraint in `models/schema.py` still references the old value `cloud`.

## Root Cause
The migration block (lines 687–714) only rebuilt the table inside an `except OperationalError` block — triggered when `UPDATE ... SET type='tunnel' WHERE type='cloud'` failed. If no rows had `type='cloud'`, the `UPDATE` was a silent no-op, the exception never fired, and the old constraint remained.

## Fix (commit `6bbdc2c`)
Restructured the migration to rebuild `workplaces` unconditionally:
1. `DROP TABLE IF EXISTS workplaces_old` — handles stale artifacts from prior failed migration attempts
2. Rename → Create with correct `CHECK(type IN ('local','remote','tunnel'))`
3. `INSERT ... CASE WHEN type='cloud' THEN 'tunnel' ELSE type END` for backward compatibility
4. Drop the old table

The migration is now idempotent and works regardless of whether rows with `type='cloud'` exist.

## Testing
- Existing unit tests pass (`routes/workplaces.py` validation)
- Manual verification: `POST /workplaces` with `{"type": "tunnel"}` succeeds