### PR TITLE
fix(config): warn about .env file permissions when SECRET_KEY is auto-generated

### DIFF
--- a/config.py
+++ b/config.py
@@ -154,6 +154,11 @@ if not _SECRET_KEY_ENV:
 
     os.environ["SECRET_KEY"] = _SECRET_KEY_ENV
     _logger.info("Generated new SECRET_KEY and saved to .env")
+    _logger.warning(
+        "SECRET_KEY was written to .env. Ensure this file is NOT world-readable "
+        "(e.g. chmod 600 .env on Linux) — if leaked, session signing keys and "
+        "all encrypted cookies can be forged."
+    )
 
 SECRET_KEY = _SECRET_KEY_ENV
 HOST = os.getenv("HOST", "0.0.0.0")


### PR DESCRIPTION
## Summary

When SECRET_KEY is auto-generated and written to .env, the user should be warned to restrict file permissions (chmod 600) — if the key leaks, session signing and encrypted cookies can be forged.

*(Clean replacement for #57 — original branch carried unrelated commits, so a clean branch was made with only the relevant change.)*