### PR TITLE
feat(health): add DB, disk, and Docker checks to health endpoint

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1,6 +1,7 @@
 """Health check endpoint — used by the update supervisor for post-deploy validation."""
 import time
 import os
+import shutil
 
 from flask import Blueprint, jsonify
 
@@ -18,10 +19,52 @@ def _get_version() -> str:
         return 'dev'
 
 
+def _check_db() -> bool:
+    try:
+        from models.db import db
+        db.get_agents()
+        return True
+    except Exception:
+        return False
+
+
+def _check_disk() -> dict:
+    try:
+        import config
+        usage = shutil.disk_usage(config.BASE_DIR)
+        return {
+            'total_gb': round(usage.total / (1024**3), 1),
+            'free_gb': round(usage.free / (1024**3), 1),
+            'free_pct': round(usage.free / usage.total * 100, 1),
+        }
+    except Exception:
+        return {}
+
+
+def _check_docker() -> str:
+    try:
+        import subprocess
+        result = subprocess.run(
+            ['docker', 'info', '--format', '{{.ServerVersion}}'],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return 'unavailable'
+    except Exception:
+        return 'unknown'
+
+
 @health_bp.route('/api/health')
 def health():
+    db_ok = _check_db()
     return jsonify({
-        'status': 'ok',
+        'status': 'ok' if db_ok else 'degraded',
         'uptime': round(time.time() - _start_time, 1),
         'version': _get_version(),
+        'checks': {
+            'database': 'ok' if db_ok else 'error',
+            'disk': _check_disk(),
+            'docker': _check_docker(),
+        },
     })


### PR DESCRIPTION
## Summary

Enhances the `/api/health` endpoint with DB connectivity, disk usage, and Docker version checks.

- **Database** — pings the DB and reports `ok`/`error`
- **Disk** — reports total, free, and percentage for the BASE_DIR mount
- **Docker** — reports the Docker server version (or `unavailable`/`unknown`)
- Overall status is `ok` if DB is reachable, otherwise `degraded`

*Clean replacement for #58.*