### PR TITLE
fix: resolve 500 errors after model-column rename and plugin refactor

### DIFF
--- a/backend/plugin_lifecycle.py
+++ b/backend/plugin_lifecycle.py
@@ -700,7 +700,9 @@ class PluginManager:
     def get_all_agent_plugin_settings(self, agent_id: str) -> List[Dict[str, Any]]:
         """Collect per-agent settings from all enabled plugins that declare agent_settings."""
         result = []
-        for plugin_id, info in self._plugins.items():
+        for plugin_data in self.list_plugins():
+            plugin_id = plugin_data['id']
+            info = plugin_data
             schema = self.get_agent_settings_schema(plugin_id)
             if not schema:
                 continue

--- a/models/mixins/dashboard.py
+++ b/models/mixins/dashboard.py
@@ -141,9 +141,9 @@ class DashboardMixin:
             cursor = conn.cursor()
         try:
             cursor.execute("""
-                SELECT COALESCE(model, 'default') as model, COUNT(*) as agent_count
+                SELECT COALESCE(model_id, 'default') as model, COUNT(*) as agent_count
                 FROM agents
-                GROUP BY COALESCE(model, 'default')
+                GROUP BY COALESCE(model_id, 'default')
                 ORDER BY agent_count DESC
             """)
             return [dict(row) for row in cursor.fetchall()]


### PR DESCRIPTION
## Summary

Two bugs introduced between v0.5.24 and latest `main` cause 500 errors when upgrading a running Evonic instance.

## Bug 1: `AttributeError` — `_plugins` attribute removed

**File:** `backend/plugin_lifecycle.py:703`
**Error:** `PluginManager object has no attribute _plugins`

The method iterates `self._plugins.items()` but the `_plugins` attribute was replaced by filesystem-based discovery (`self.list_plugins()`). Every other method already migrated; this one branch was missed.

**Impact:** `GET /api/agents/:id/plugin-settings` → 500. Crashes any agent with enabled plugins.

**Fix:** Replace `self._plugins.items()` → `self.list_plugins()`.

## Bug 2: `OperationalError` — stale column name in dashboard query

**File:** `models/mixins/dashboard.py:144`
**Error:** `no such column: model`

The `agent_model_columns` migration renames `agents.model` → `agents.model_id` but `get_model_usage()` still queries `COALESCE(model, ...)`. The migration then drops the old column.

**Impact:** `GET /api/dashboard/data` → 500. Entire dashboard broken.

**Fix:** `COALESCE(model, ...)` → `COALESCE(model_id, ...)`.

## Verification

Both fixes verified on a running instance:
- Before: both endpoints return HTTP 500
- After: dashboard returns 200 with model_usage data; plugin-settings returns 401 (auth required, not crash)

Closes #63