### PR TITLE
fix(frontend): close global SSE streams during page navigation

### DIFF
--- a/static/js/agent-sidebar.js
+++ b/static/js/agent-sidebar.js
@@ -218,6 +218,8 @@ function hideTooltip() {
 
 /** Active bubble popup map: agentId -> { element, timer } */
 var _activeBubbles = {};
+var _busySSE = null;
+var _busyReconnectTimer = null;
 
 /** Maximum characters to show in the bubble preview */
 var _BUBBLE_MAX_CHARS = 140;
@@ -374,26 +376,41 @@ document.addEventListener('click', function (e) {
 });
 
 /** Subscribe via RealtimeClient for real-time busy state updates and turn-complete notifications */
-var _statusSSE = null;
+var _busySSE = null;
+var _busyReconnectTimer = null;
+var _busyRealtimeHandlersBound = false;
+
+function updateBusyAvatar(payload) {
+    if (!payload || !payload.agent_id) return;
+    var avatar = document.querySelector(
+        '#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]'
+    );
+    if (avatar) {
+        avatar.setAttribute('data-busy', payload.busy ? 'true' : 'false');
+    }
+}
+
+function dispatchBusyChanged(payload) {
+    document.dispatchEvent(new CustomEvent('evonic:agent-busy-changed', { detail: payload }));
+}
+
 function subscribeBusySSE() {
     if (typeof RealtimeClient === 'undefined') {
-        // Fallback: use old EventSource if RealtimeClient not loaded
+        if (_busySSE) return;
         try {
-            _statusSSE = new EventSource('/api/agents/status/stream');
-            _statusSSE.addEventListener('agent_busy_changed', function (e) {
+            var es = new EventSource('/api/agents/status/stream');
+            _busySSE = es;
+            es.addEventListener('agent_busy_changed', function (e) {
                 try {
                     var payload = JSON.parse(e.data);
-                    var avatar = document.querySelector(
-                        '#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]'
-                    );
-                    if (avatar) {
-                        avatar.setAttribute('data-busy', payload.busy ? 'true' : 'false');
-                    }
+                    updateBusyAvatar(payload);
+                    dispatchBusyChanged(payload);
                 } catch (_) {}
             });
-            _statusSSE.addEventListener('agent_turn_complete', function (e) {
+            es.addEventListener('agent_turn_complete', function (e) {
                 try {
                     var payload = JSON.parse(e.data);
+                    // Don't show bubble if user is already viewing this agent's page
                     if (window.location.pathname === '/agents/' + payload.agent_id) return;
                     _markUnread(payload.agent_id);
                     var av = document.querySelector('#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]');
@@ -401,36 +418,78 @@ function subscribeBusySSE() {
                     showBubblePopup(payload.agent_id, payload.agent_name, payload.response, payload.session_id, payload.external_user_id);
                 } catch (_) {}
             });
-            _statusSSE.addEventListener('error', function () {});
-        } catch (_) {}
+            es.addEventListener('error', function () {
+                es.close();
+                if (_busySSE === es) _busySSE = null;
+                resyncBusyState();
+                if (_busyReconnectTimer) clearTimeout(_busyReconnectTimer);
+                _busyReconnectTimer = setTimeout(function () {
+                    _busyReconnectTimer = null;
+                    subscribeBusySSE();
+                }, 2000);
+            });
+        } catch (_) {
+            _busySSE = null;
+            // EventSource not supported — polling fallback already active
+        }
         return;
     }
 
     var rt = window._evRealtime = window._evRealtime || new RealtimeClient({
         channels: 'status'
     });
-    rt.on('status', 'agent_busy_changed', function (payload) {
-        var avatar = document.querySelector(
-            '#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]'
-        );
-        if (avatar) {
-            avatar.setAttribute('data-busy', payload.busy ? 'true' : 'false');
-        }
-    });
-    rt.on('status', 'agent_turn_complete', function (payload) {
-        if (window.location.pathname === '/agents/' + payload.agent_id) return;
-        _markUnread(payload.agent_id);
-        var av = document.querySelector('#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]');
-        if (av) av.setAttribute('data-unread', 'true');
-        showBubblePopup(payload.agent_id, payload.agent_name, payload.response, payload.session_id, payload.external_user_id);
-    });
+    if (!_busyRealtimeHandlersBound) {
+        rt.on('status', 'agent_busy_changed', function (payload) {
+            updateBusyAvatar(payload);
+            dispatchBusyChanged(payload);
+        });
+        rt.on('status', 'agent_turn_complete', function (payload) {
+            if (window.location.pathname === '/agents/' + payload.agent_id) return;
+            _markUnread(payload.agent_id);
+            var av = document.querySelector('#agent-sidebar .agent-avatar[data-agent-id="' + CSS.escape(payload.agent_id) + '"]');
+            if (av) av.setAttribute('data-unread', 'true');
+            showBubblePopup(payload.agent_id, payload.agent_name, payload.response, payload.session_id, payload.external_user_id);
+        });
+        _busyRealtimeHandlersBound = true;
+    }
     rt.start();
 }
 
-// Close SSE/RealtimeClient on page unload to free HTTP connections during navigation
-window.addEventListener('beforeunload', function () {
-    if (_statusSSE instanceof EventSource) { _statusSSE.close(); _statusSSE = null; }
-    if (window._evRealtime) { window._evRealtime.stop(); }
+function resyncBusyState() {
+    fetch('/api/agents/busy')
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            document.querySelectorAll('#agent-sidebar .agent-avatar').forEach(function (avatar) {
+                var agentId = avatar.getAttribute('data-agent-id');
+                var busy = !!(data.busy || {})[agentId];
+                avatar.setAttribute('data-busy', busy ? 'true' : 'false');
+            });
+            document.dispatchEvent(new CustomEvent('evonic:agent-busy-resync', { detail: data.busy || {} }));
+        })
+        .catch(function () {});
+}
+
+function closeBusyRealtime() {
+    if (_busyReconnectTimer) {
+        clearTimeout(_busyReconnectTimer);
+        _busyReconnectTimer = null;
+    }
+    if (_busySSE) {
+        try {
+            _busySSE.close();
+        } catch (_) {}
+        _busySSE = null;
+    }
+    if (window._evRealtime) {
+        window._evRealtime.stop();
+    }
+}
+
+window.addEventListener('pagehide', closeBusyRealtime);
+window.addEventListener('beforeunload', closeBusyRealtime);
+window.addEventListener('pageshow', function () {
+    resyncBusyState();
+    subscribeBusySSE();
 });
 
 /** Toggle sidebar collapsed state */

--- a/static/js/approval-modal.js
+++ b/static/js/approval-modal.js
@@ -248,8 +248,12 @@ document.addEventListener('evonic:approval-resolved', function(e) {
 // This receives approval events (any agent, any session) via the 'approvals' channel.
 (function() {
     var _sse = null;
+    var _reconnectTimer = null;
+    var _enabled = false;
+    var _realtimeHandlersBound = false;
 
     function _connectSSE() {
+        if (!_enabled) return;
         if (_sse) return;
 
         // Use RealtimeClient if available
@@ -257,30 +261,35 @@ document.addEventListener('evonic:approval-resolved', function(e) {
             var rt = window._evApprovalRT = window._evApprovalRT || new RealtimeClient({
                 channels: 'approvals'
             });
-            rt.on('approvals', 'approval_required', function(data) {
-                if (!data.approval_id) return;
-                _currentData = data;
-                populateModal(data);
-                openModal();
-            });
-            rt.on('approvals', 'approval_resolved', function(data) {
-                if (_currentData && data.approval_id === _currentData.approval_id) {
-                    closeModal();
-                }
-            });
+            if (!_realtimeHandlersBound) {
+                rt.on('approvals', 'approval_required', function(data) {
+                    if (!data.approval_id) return;
+                    _currentData = data;
+                    populateModal(data);
+                    openModal();
+                });
+                rt.on('approvals', 'approval_resolved', function(data) {
+                    if (_currentData && data.approval_id === _currentData.approval_id) {
+                        closeModal();
+                    }
+                });
+                _realtimeHandlersBound = true;
+            }
             rt.start();
             _sse = { close: function() { rt.stop(); } };
             return;
         }
 
         // Fallback: old EventSource
+        var es;
         try {
-            _sse = new EventSource('/api/approvals/stream');
+            es = new EventSource('/api/approvals/stream');
+            _sse = es;
         } catch (e) {
             return;
         }
 
-        _sse.addEventListener('approval_required', function(e) {
+        es.addEventListener('approval_required', function(e) {
             var data = JSON.parse(e.data);
             if (!data.approval_id) return;
             _currentData = data;
@@ -288,23 +297,43 @@ document.addEventListener('evonic:approval-resolved', function(e) {
             openModal();
         });
 
-        _sse.addEventListener('approval_resolved', function(e) {
+        es.addEventListener('approval_resolved', function(e) {
             var data = JSON.parse(e.data);
             if (_currentData && data.approval_id === _currentData.approval_id) {
                 closeModal();
             }
         });
 
-        _sse.onerror = function() {
-            _sse.close();
-            _sse = null;
-            setTimeout(_startSSE, 3000);
+        es.onerror = function() {
+            es.close();
+            if (_sse === es) _sse = null;
+            if (!_enabled) return;
+            if (_reconnectTimer) clearTimeout(_reconnectTimer);
+            // Reconnect after a short delay
+            _reconnectTimer = setTimeout(function() {
+                _reconnectTimer = null;
+                _connectSSE();
+            }, 3000);
         };
     }
 
     function _startSSE() {
+        _enabled = true;
         if (_sse) return;
         _connectSSE();
+    }
+
+    function _closeSSE() {
+        _enabled = false;
+        if (_reconnectTimer) {
+            clearTimeout(_reconnectTimer);
+            _reconnectTimer = null;
+        }
+        if (!_sse) return;
+        try {
+            _sse.close();
+        } catch (e) {}
+        _sse = null;
     }
 
     // Start SSE when the page loads and when it becomes visible
@@ -318,10 +347,8 @@ document.addEventListener('evonic:approval-resolved', function(e) {
             _startSSE();
         }
     });
-    // Close SSE/RealtimeClient on page unload to free HTTP connections during navigation
-    window.addEventListener('beforeunload', function() {
-        if (_sse) { _sse.close(); _sse = null; }
-        if (window._evApprovalRT) { window._evApprovalRT.stop(); }
-    });
+    window.addEventListener('pagehide', _closeSSE);
+    window.addEventListener('beforeunload', _closeSSE);
+    window.addEventListener('pageshow', _startSSE);
 })();
 })();

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -240,6 +240,7 @@ function switchTab(tab) {
 let agents = [];
 let skillsets = [];
 let busyAgents = {};
+let agentStatusEventsSubscribed = false;
 
 async function loadSkillsets() {
     try {
@@ -281,7 +282,7 @@ async function loadAgents() {
     renderAgents();
     loadSkillsets();
     loadBusyAgents();
-    startAgentStatusStream();
+    subscribeAgentStatusEvents();
 }
 
 function renderAgents() {
@@ -406,70 +407,32 @@ function updateAgentBusyBadge(agentId, busy) {
     }
 }
 
-function startAgentStatusStream() {
-    // Use RealtimeClient if available
-    if (typeof RealtimeClient !== 'undefined') {
-        var rt = window._evAgentsRT = window._evAgentsRT || new RealtimeClient({
-            channels: 'status'
+function subscribeAgentStatusEvents() {
+    if (agentStatusEventsSubscribed) return;
+    agentStatusEventsSubscribed = true;
+    document.addEventListener('evonic:agent-busy-changed', function(e) {
+        const data = e.detail || {};
+        const agentId = data.agent_id;
+        if (!agentId) return;
+        if (data.busy) {
+            busyAgents[agentId] = true;
+        } else {
+            delete busyAgents[agentId];
+        }
+        updateAgentBusyBadge(agentId, data.busy);
+    });
+    document.addEventListener('evonic:agent-busy-resync', function(e) {
+        busyAgents = {};
+        for (const id of Object.keys(e.detail || {})) busyAgents[id] = true;
+        document.querySelectorAll('.busy-badge').forEach(function(b) {
+            const parent = b.closest('[data-badges]');
+            if (parent && !busyAgents[parent.getAttribute('data-badges')]) b.remove();
         });
-        rt.on('status', 'agent_busy_changed', function(data) {
-            const agentId = data.agent_id;
-            if (!agentId) return;
-            if (data.busy) {
-                busyAgents[agentId] = true;
-            } else {
-                delete busyAgents[agentId];
-            }
-            updateAgentBusyBadge(agentId, data.busy);
-        });
-        rt.start();
-        return;
-    }
-
-    // Fallback: old EventSource
-    const url = `/api/agents/status/stream`;
-
-    function connect() {
-        const es = new EventSource(url);
-        es.addEventListener('agent_busy_changed', function(e) {
-            try {
-                const data = JSON.parse(e.data);
-                const agentId = data.agent_id;
-                if (!agentId) return;
-                if (data.busy) {
-                    busyAgents[agentId] = true;
-                } else {
-                    delete busyAgents[agentId];
-                }
-                updateAgentBusyBadge(agentId, data.busy);
-            } catch (_) {}
-        });
-        es.addEventListener('error', function() {
-            es.close();
-            // Reconnect after a short delay
-            setTimeout(function() {
-                // Re-fetch full busy state before reconnecting
-                fetch('/api/agents/busy').then(r => r.json()).then(data => {
-                    busyAgents = {};
-                    for (const id of Object.keys(data.busy || {})) busyAgents[id] = true;
-                    for (const id of Object.keys(busyAgents)) updateAgentBusyBadge(id, true);
-                    // Clear stale badges for agents not in busy list
-                    document.querySelectorAll('.busy-badge').forEach(function(b) {
-                        const parent = b.closest('[data-badges]');
-                        if (parent) {
-                            const agentId = parent.getAttribute('data-badges');
-                            if (!busyAgents[agentId]) b.remove();
-                        }
-                    });
-                }).catch(function() {}).finally(function() {
-                    connect();
-                });
-            }, 2000);
-        });
-    }
-
-    connect();
+        for (const id of Object.keys(busyAgents)) updateAgentBusyBadge(id, true);
+    });
 }
+
+window.addEventListener('pageshow', loadBusyAgents);
 
 function toggleDisabledAgents() {
     const grid = document.getElementById('disabled-agents-grid');

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
     <script src="{{ url_for('static', filename='js/marked.min.js') }}?v=1" defer></script>
     <script src="{{ url_for('static', filename='js/ui-utils.js') }}?v=1" defer></script>
     <script src="{{ url_for('static', filename='js/realtime.js') }}?v=1" defer></script>
-    <script src="{{ url_for('static', filename='js/approval-modal.js') }}?v=1" defer></script>
+    <script src="{{ url_for('static', filename='js/approval-modal.js') }}?v=2" defer></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=18">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/recap-prose.css') }}?v=1">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/agent-sidebar.css') }}?v=9">
@@ -214,7 +214,7 @@
         </div>
     </div>
     <script src="{{ url_for('static', filename='js/update-banner.js') }}?v=1" defer></script>
-    <script src="{{ url_for('static', filename='js/agent-sidebar.js') }}?v=4" defer></script>
+    <script src="{{ url_for('static', filename='js/agent-sidebar.js') }}?v=5" defer></script>
     <script src="{{ url_for('static', filename='js/evonic.js') }}?v=1" defer></script>
     <!-- Wrapped so the deferred agent-sidebar.js has defined initSidebar by DOMContentLoaded -->
     <script>document.addEventListener('DOMContentLoaded', function () { initSidebar(); });</script>

--- a/unit_tests/test_frontend_sse_lifecycle.py
+++ b/unit_tests/test_frontend_sse_lifecycle.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_repo_file(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_global_sse_streams_close_on_page_navigation():
+    approval_modal = read_repo_file("static/js/approval-modal.js")
+    agent_sidebar = read_repo_file("static/js/agent-sidebar.js")
+    agents_page = read_repo_file("templates/agents.html")
+
+    assert "var _sse = null;" in approval_modal
+    assert "function _closeSSE()" in approval_modal
+    assert "RealtimeClient" in approval_modal
+    assert "window.addEventListener('pagehide', _closeSSE);" in approval_modal
+    assert "window.addEventListener('beforeunload', _closeSSE);" in approval_modal
+    assert "window.addEventListener('pageshow', _startSSE);" in approval_modal
+
+    assert "var _busySSE = null;" in agent_sidebar
+    assert "if (_busySSE) return;" in agent_sidebar
+    assert "RealtimeClient" in agent_sidebar
+    assert "evonic:agent-busy-changed" in agent_sidebar
+    assert "function resyncBusyState()" in agent_sidebar
+    assert "evonic:agent-busy-resync" in agent_sidebar
+    assert "_busySSE.close();" in agent_sidebar
+    assert "window.addEventListener('pagehide', closeBusyRealtime);" in agent_sidebar
+    assert "window.addEventListener('beforeunload', closeBusyRealtime);" in agent_sidebar
+    assert "window.addEventListener('pageshow', function ()" in agent_sidebar
+
+    assert "let agentStatusEventsSubscribed = false;" in agents_page
+    assert "function subscribeAgentStatusEvents()" in agents_page
+    assert "document.addEventListener('evonic:agent-busy-changed'" in agents_page
+    assert "document.addEventListener('evonic:agent-busy-resync'" in agents_page
+    assert "window.addEventListener('pageshow', loadBusyAgents);" in agents_page
+    assert "new RealtimeClient({" not in agents_page
+    assert "new EventSource(`/api/agents/status/stream`)" not in agents_page
+    assert "new EventSource('/api/agents/status/stream')" not in agents_page


### PR DESCRIPTION
This fixes a navigation stall I could reproduce locally after clicking around the authenticated UI quickly.

The browser was not waiting on Flask route work. The slow `/skills` load was waiting for a free browser socket while stale long-lived `EventSource` connections were still open from previous pages.

### What changed

- Close the approval modal SSE connection on `pagehide` / `beforeunload` and reconnect on `pageshow`.
- Keep the sidebar busy-status SSE connection as a single guarded owner.
- Stop the Agents page from opening a second `/api/agents/status/stream` connection; it now consumes events from the sidebar owner.
- Preserve the old missed-event recovery path by resyncing `/api/agents/busy` after stream errors and clearing stale busy badges from that map.
- Bump the affected JS asset versions so existing browsers pick up the changed scripts.
- Add a small regression test around the SSE lifecycle hooks.

### Checks

Ran locally:

- `node --check static/js/approval-modal.js`
- `node --check static/js/agent-sidebar.js`
- `.venv/bin/python -m pytest unit_tests/test_frontend_sse_lifecycle.py -q`
- `.venv/bin/python -m pytest plugins/kanban/tests/ -v`
- `cd evonet && go test ./...`
- `git diff --check origin/main...HEAD`

I also ran a browser smoke test against this branch: clicked Sessions, Skills, Plugins, Scheduler, and Agents about one second apart. All pages reached `document.readyState === "complete"`; max navigation `loadEventEnd` was `57.8 ms`, with no console or page errors.

For context, the local reproduction before this fix showed `/skills` waiting about `57.6s` on browser socket availability while stale SSE streams were active. After the lifecycle fix, the socket wait dropped to about `1ms` in the same local test setup.

### Notes

Backend SSE endpoints are unchanged. I did not include raw diagnostic NetLogs because they can contain request headers/cookies.

One local caveat: the full `unit_tests/` run reached `873 passed, 57 skipped` under Python 3.12, then hung during interpreter shutdown due existing background scheduler/docker threads. The targeted test added here and the plugin/Go checks above completed normally.
