### PR TITLE
fix(auth): make ProxyFix trust count configurable to prevent IP spoofing

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,9 +70,19 @@ app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(days=7)
 # Global upload size limit (defense-in-depth for all endpoints)
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50 MB
 
-# Trust proxy headers from Cloudflare / nginx / any reverse proxy
+# Trust proxy headers based on deployment topology.
+# PROXY_TRUST_COUNT=0 for direct deployments (no reverse proxy) to prevent
+# IP spoofing via X-Forwarded-For. Set to 1 for single-proxy (default), or
+# higher for multi-proxy setups (CDN → reverse proxy → app).
+# See config.py for full documentation.
 from werkzeug.middleware.proxy_fix import ProxyFix
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+app.wsgi_app = ProxyFix(
+    app.wsgi_app,
+    x_for=config.PROXY_TRUST_COUNT,
+    x_proto=1,
+    x_host=1,
+    x_prefix=1,
+)
 
 app.register_blueprint(auth_bp)
 app.register_blueprint(agents_bp)

--- a/config.py
+++ b/config.py
@@ -161,6 +161,22 @@ if not _SECRET_KEY_ENV:
     )
 
 SECRET_KEY = _SECRET_KEY_ENV
+# Reverse proxy trust count — how many proxies sit between the client and Evonic.
+#
+# ProxyFix uses this to decide which X-Forwarded-For entry is the real client IP.
+#   0 = no reverse proxy (direct deployment). X-Forwarded-For is IGNORED.
+#       Use this when Evonic is exposed directly to the internet. Without this,
+#       any client can spoof their IP via X-Forwarded-For, defeating login rate
+#       limiting and making security audit logs unreliable.
+#   1 = one proxy in front (nginx, Caddy, Cloudflare, etc.) — DEFAULT.
+#       The rightmost X-Forwarded-For entry is the real client IP.
+#   2 = two proxies (e.g. Cloudflare CDN → nginx → Evonic).
+#       The second-from-right X-Forwarded-For entry is the real client IP.
+#
+# Choose the value that matches your deployment topology. Setting it higher than
+# the actual number of proxies lets attackers spoof their IP.
+PROXY_TRUST_COUNT = _get_env_int("PROXY_TRUST_COUNT", 1, min_val=0, max_val=10)
+
 HOST = os.getenv("HOST", "0.0.0.0")
 PORT = _get_env_int("PORT", 8080, min_val=1, max_val=65535)
 DEBUG = os.getenv("DEBUG", "0") == "1"

--- a/unit_tests/test_proxy_trust.py
+++ b/unit_tests/test_proxy_trust.py
@@ -1,0 +1,129 @@
+"""Tests for PROXY_TRUST_COUNT configuration and IP resolution behaviour.
+
+When Evonic is deployed without a reverse proxy (common for self-hosted
+setups), ProxyFix must NOT trust X-Forwarded-For headers. Otherwise any
+client can spoof its IP address, defeating login rate limiting and audit
+logging.
+
+PROXY_TRUST_COUNT=0  → direct deployment, ignore X-Forwarded-For
+PROXY_TRUST_COUNT=1  → behind one proxy (default, backward-compatible)
+PROXY_TRUST_COUNT=2  → behind two proxies (e.g. CDN → nginx → app)
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestProxyTrustCountConfig(unittest.TestCase):
+    """Verify that config.py reads PROXY_TRUST_COUNT correctly."""
+
+    def test_default_is_one(self):
+        """Default must be 1 for backward compatibility with existing deployments."""
+        os.environ.pop('PROXY_TRUST_COUNT', None)
+        import importlib
+        import config as cfg
+        importlib.reload(cfg)
+        self.assertEqual(cfg.PROXY_TRUST_COUNT, 1)
+
+    def test_zero_for_direct_deployment(self):
+        """PROXY_TRUST_COUNT=0 must be accepted for direct (no-proxy) deployments."""
+        os.environ['PROXY_TRUST_COUNT'] = '0'
+        try:
+            import importlib
+            import config as cfg
+            importlib.reload(cfg)
+            self.assertEqual(cfg.PROXY_TRUST_COUNT, 0)
+        finally:
+            os.environ.pop('PROXY_TRUST_COUNT', None)
+
+    def test_two_for_double_proxy(self):
+        """PROXY_TRUST_COUNT=2 must be accepted for CDN + reverse-proxy setups."""
+        os.environ['PROXY_TRUST_COUNT'] = '2'
+        try:
+            import importlib
+            import config as cfg
+            importlib.reload(cfg)
+            self.assertEqual(cfg.PROXY_TRUST_COUNT, 2)
+        finally:
+            os.environ.pop('PROXY_TRUST_COUNT', None)
+
+    def test_negative_clamped_to_zero(self):
+        """Negative values must be clamped to 0."""
+        os.environ['PROXY_TRUST_COUNT'] = '-1'
+        try:
+            import importlib
+            import config as cfg
+            importlib.reload(cfg)
+            self.assertEqual(cfg.PROXY_TRUST_COUNT, 0)
+        finally:
+            os.environ.pop('PROXY_TRUST_COUNT', None)
+
+    def test_invalid_falls_back_to_default(self):
+        """Non-numeric values must fall back to the default (1)."""
+        os.environ['PROXY_TRUST_COUNT'] = 'abc'
+        try:
+            import importlib
+            import config as cfg
+            importlib.reload(cfg)
+            self.assertEqual(cfg.PROXY_TRUST_COUNT, 1)
+        finally:
+            os.environ.pop('PROXY_TRUST_COUNT', None)
+
+
+class TestProxyTrustIpResolution(unittest.TestCase):
+    """Verify that ProxyFix honours PROXY_TRUST_COUNT for IP resolution."""
+
+    def _make_app(self, trust_count):
+        """Build a minimal Flask app with the given proxy trust count."""
+        os.environ.setdefault('SECRET_KEY', 'test-secret')
+        os.environ['PROXY_TRUST_COUNT'] = str(trust_count)
+
+        from flask import Flask, jsonify, request
+        from werkzeug.middleware.proxy_fix import ProxyFix
+
+        app = Flask(__name__)
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app,
+            x_for=trust_count,
+            x_proto=1,
+            x_host=1,
+            x_prefix=1,
+        )
+
+        @app.route('/ip')
+        def ip():
+            return jsonify({'ip': request.remote_addr})
+
+        return app
+
+    def tearDown(self):
+        os.environ.pop('PROXY_TRUST_COUNT', None)
+        # Reload config to restore defaults
+        import importlib
+        import config as cfg
+        importlib.reload(cfg)
+
+    def test_trust_zero_ignores_xff(self):
+        """With trust=0, X-Forwarded-For must be ignored — real client IP is used."""
+        app = self._make_app(0)
+        client = app.test_client()
+        resp = client.get('/ip', headers={'X-Forwarded-For': '1.2.3.4'})
+        data = resp.get_json()
+        # Flask test client sends 127.0.0.1; with trust=0, XFF is ignored
+        self.assertNotEqual(data['ip'], '1.2.3.4')
+        self.assertEqual(data['ip'], '127.0.0.1')
+
+    def test_trust_one_uses_xff(self):
+        """With trust=1, the rightmost X-Forwarded-For entry is trusted."""
+        app = self._make_app(1)
+        client = app.test_client()
+        resp = client.get('/ip', headers={'X-Forwarded-For': '1.2.3.4'})
+        data = resp.get_json()
+        self.assertEqual(data['ip'], '1.2.3.4')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`app.py` hardcodes `ProxyFix(x_for=1)`, which tells Flask to always trust the rightmost entry in the `X-Forwarded-For` header. That works when there is exactly one reverse proxy in front of Evonic (nginx, Caddy, Cloudflare, etc.), which is the common case.

But it breaks for direct deployments. If someone exposes Evonic straight to the internet without a reverse proxy, any client can send a fake `X-Forwarded-For` header and Evonic will trust it. The real client IP becomes whatever the attacker chose. This defeats the login rate limiter in `routes/auth.py` (keyed on `request.remote_addr`) and pollutes the security audit logs in `backend/security_audit.py` with wrong IPs.

## The fix

Adds a `PROXY_TRUST_COUNT` environment variable so operators can match the trust level to their deployment topology:

- `0` for direct deployments with no proxy. `X-Forwarded-For` is ignored entirely.
- `1` (default) for single proxy setups, same behavior as today.
- `2` or higher for multi proxy chains (CDN in front of nginx in front of the app).

## What changed

- `config.py` defines `PROXY_TRUST_COUNT` with bounds checking (0 to 10, default 1) via `_get_env_int`.
- `app.py` reads `config.PROXY_TRUST_COUNT` instead of the hardcoded `1`.
- `unit_tests/test_proxy_trust.py` covers config parsing edge cases (default, zero, two, negative clamped to zero, invalid falls back to default) plus actual IP resolution behavior for trust=0 and trust=1.

## Testing

All 7 new tests pass. Existing config and health tests still pass.

## Backward compatibility

Default stays at 1, so existing deployments behind a proxy don't need to change anything. If you run Evonic directly on the internet, add `PROXY_TRUST_COUNT=0` to your `.env`.