### PR TITLE
fix: model_id column, agent cloning, and realtime command endpoints

### DIFF
--- a/models/mixins/agents.py
+++ b/models/mixins/agents.py
@@ -80,7 +80,7 @@ class AgentMixin:
                    'avatar_path', 'disable_parallel_tool_execution', 'disable_turn_prefetch',
                    'agent_messaging_enabled', 'workplace_id',
                    'attachments_enabled', 'attachment_max_size_mb', 'artifacts_enabled',
-                   'fallback_model_id', 'audio_enabled', 'video_enabled',
+                    'model_id', 'fallback_model_id', 'audio_enabled', 'video_enabled',
                    'run_as_user', 'bash_exec_enabled'}
         updates = {k: v for k, v in data.items() if k in allowed}
         if not updates:
@@ -120,7 +120,7 @@ class AgentMixin:
             raise ValueError(f"Agent ID '{new_id}' already exists")
 
         # Build new agent dict: copy all fields, override id/name/desc, skip auto fields
-        auto_fields = {'id', 'created_at', 'updated_at', 'last_active_at', 'model',
+        auto_fields = {'id', 'created_at', 'updated_at', 'last_active_at',
                        'session_count', 'primary_channel_id', 'avatar_path'}
         clone = {}
         for k, v in source.items():

--- a/models/mixins/dashboard.py
+++ b/models/mixins/dashboard.py
@@ -141,9 +141,9 @@ class DashboardMixin:
             cursor = conn.cursor()
         try:
             cursor.execute("""
-                SELECT COALESCE(model, 'default') as model, COUNT(*) as agent_count
+                SELECT COALESCE(model_id, 'default') as model, COUNT(*) as agent_count
                 FROM agents
-                GROUP BY COALESCE(model, 'default')
+                GROUP BY COALESCE(model_id, 'default')
                 ORDER BY agent_count DESC
             """)
             return [dict(row) for row in cursor.fetchall()]

--- a/routes/realtime.py
+++ b/routes/realtime.py
@@ -1002,7 +1002,7 @@ def _start_producer(channel: str, producer_fn, ring: BoundedRing,
 @realtime_bp.route('/api/realtime/pause', methods=['POST'])
 def api_realtime_pause():
     """Pause chat+workplace event delivery for this session."""
-    data = request.get_json() or {}
+    data = request.get_json(silent=True) or {}
     session_id = data.get('session_id', '').strip()
     if not session_id:
         return Response(json.dumps({'error': 'session_id required'}), status=400,
@@ -1018,7 +1018,7 @@ def api_realtime_pause():
 @realtime_bp.route('/api/realtime/resume', methods=['POST'])
 def api_realtime_resume():
     """Resume chat+workplace event delivery and flush paused buffer."""
-    data = request.get_json() or {}
+    data = request.get_json(silent=True) or {}
     session_id = data.get('session_id', '').strip()
     if not session_id:
         return Response(json.dumps({'error': 'session_id required'}), status=400,

--- a/static/js/realtime.js
+++ b/static/js/realtime.js
@@ -204,7 +204,8 @@ var RealtimeClient = (function () {
         try {
             var xhr = new XMLHttpRequest();
             xhr.open('POST', '/api/realtime/' + cmd, true);
-            xhr.send();
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.send(JSON.stringify({ session_id: this._session_id }));
         } catch (_) {}
     };
 

--- a/static/js/realtime.js
+++ b/static/js/realtime.js
@@ -205,7 +205,7 @@ var RealtimeClient = (function () {
             var xhr = new XMLHttpRequest();
             xhr.open('POST', '/api/realtime/' + cmd, true);
             xhr.setRequestHeader('Content-Type', 'application/json');
-            xhr.send(JSON.stringify({ session_id: this._session_id }));
+            xhr.send(JSON.stringify({ session_id: this._sessionId }));
         } catch (_) {}
     };
 


### PR DESCRIPTION
## Changes

### 1. Fix model_id column in get_model_usage query
- Use `model_id` instead of `model` in the agent model usage query since the `model` column was removed

### 2. Add model_id to allowed update fields in AgentMixin
- Allow `model_id` to be updated via the agent update endpoint
- Remove `model` from auto_fields in agent cloning so model_id is properly copied

### 3. Fix realtime pause/resume endpoints
- Add `silent=True` to `request.get_json()` to avoid 500 errors when the request body is missing or invalid JSON

### 4. Fix session_id variable typo in _sendCommand
- Correct `this._session_id` to `this._sessionId` so the session_id is actually sent in the JSON body
- This ensures status, approval, and cancel commands work correctly from the web UI