### PR TITLE
feat(sandbox): add Docker container resource usage metrics API

### DIFF
--- a/backend/tools/lib/backends/docker_backend.py
+++ b/backend/tools/lib/backends/docker_backend.py
@@ -142,6 +142,103 @@ def get_pool_status() -> dict:
         }
 
 
+def get_container_stats(session_id: str) -> dict:
+    """Get resource usage statistics for a specific container.
+    
+    Returns CPU percentage, memory usage, memory limit, and network I/O.
+    Returns error dict if container doesn't exist or Docker stats fails.
+    """
+    with _pool_lock:
+        info = _containers.get(session_id)
+        if not info:
+            return {'error': 'No active container for this session'}
+        container_id = info['container_id']
+    
+    # Use docker stats --no-stream to get a single snapshot
+    result = _docker('stats', '--no-stream', '--format',
+                     '{{json .}}', container_id)
+    
+    if result.returncode != 0:
+        return {'error': f'Failed to get container stats: {result.stderr.strip()}'}
+    
+    try:
+        import json
+        stats = json.loads(result.stdout.strip())
+        
+        # Parse memory usage (format: "123.4MiB / 512MiB")
+        mem_usage = stats.get('MemUsage', '0B / 0B')
+        mem_parts = mem_usage.split(' / ')
+        mem_used_str = mem_parts[0].strip() if len(mem_parts) > 0 else '0B'
+        mem_limit_str = mem_parts[1].strip() if len(mem_parts) > 1 else '0B'
+        
+        # Parse CPU percentage (format: "12.34%")
+        cpu_percent_str = stats.get('CPUPerc', '0%').rstrip('%')
+        
+        # Parse network I/O (format: "1.2MB / 3.4MB")
+        net_io = stats.get('NetIO', '0B / 0B')
+        net_parts = net_io.split(' / ')
+        net_input_str = net_parts[0].strip() if len(net_parts) > 0 else '0B'
+        net_output_str = net_parts[1].strip() if len(net_parts) > 1 else '0B'
+        
+        # Parse block I/O (format: "5.6MB / 7.8MB")
+        block_io = stats.get('BlockIO', '0B / 0B')
+        block_parts = block_io.split(' / ')
+        block_input_str = block_parts[0].strip() if len(block_parts) > 0 else '0B'
+        block_output_str = block_parts[1].strip() if len(block_parts) > 1 else '0B'
+        
+        return {
+            'container_id': container_id[:12],
+            'container_name': stats.get('Name', ''),
+            'cpu_percent': float(cpu_percent_str) if cpu_percent_str else 0.0,
+            'memory': {
+                'used': mem_used_str,
+                'limit': mem_limit_str,
+                'percent': stats.get('MemPerc', '0%').rstrip('%'),
+            },
+            'network': {
+                'input': net_input_str,
+                'output': net_output_str,
+            },
+            'block_io': {
+                'read': block_input_str,
+                'write': block_output_str,
+            },
+            'pids': stats.get('PIDs', '0'),
+        }
+    except (json.JSONDecodeError, ValueError, KeyError) as e:
+        return {'error': f'Failed to parse container stats: {str(e)}'}
+
+
+def get_all_container_stats() -> dict:
+    """Get resource usage statistics for all active containers in the pool.
+    
+    Returns a dict with pool summary and per-container stats.
+    """
+    with _pool_lock:
+        session_ids = list(_containers.keys())
+    
+    stats_list = []
+    for sid in session_ids:
+        stats = get_container_stats(sid)
+        if 'error' not in stats:
+            stats['session_id'] = sid[:12]
+            stats['agent_id'] = _containers.get(sid, {}).get('agent_id', '')
+            stats_list.append(stats)
+    
+    # Calculate aggregate metrics
+    total_cpu = sum(s.get('cpu_percent', 0) for s in stats_list)
+    
+    return {
+        'pool_size': len(session_ids),
+        'max_containers': SANDBOX_MAX_CONTAINERS,
+        'containers': stats_list,
+        'aggregate': {
+            'total_cpu_percent': round(total_cpu, 2),
+            'active_containers': len(stats_list),
+        }
+    }
+
+
 def _startup_sweep() -> None:
     """Destroy evonic containers left over from previous (crashed) processes."""
     result = _docker('ps', '--filter', 'label=evonic.managed=1', '--format', '{{.Names}}')

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -705,6 +705,58 @@ def api_create_artifact(agent_id):
         return jsonify({'error': str(e)}), 500
 
 
+# ==================== Docker Sandbox Metrics API ====================
+
+@agents_bp.route('/api/agents/<agent_id>/sandbox/stats', methods=['GET'])
+def api_get_sandbox_stats(agent_id):
+    """Get Docker sandbox resource usage statistics for an agent's active sessions."""
+    agent = db.get_agent(agent_id)
+    if not agent:
+        return jsonify({'error': 'Agent not found'}), 404
+    
+    # Check if sandbox is enabled for this agent
+    if not agent.get('sandbox_enabled', 1):
+        return jsonify({'error': 'Sandbox is disabled for this agent'}), 400
+    
+    # Get all sessions for this agent
+    try:
+        sessions = db._chat_db(agent_id).get_sessions_with_preview()
+    except Exception as e:
+        return jsonify({'error': f'Failed to get sessions: {str(e)}'}), 500
+    
+    # Collect stats for each active session that might have a container
+    from backend.tools.lib.backends.docker_backend import get_container_stats
+    
+    stats_list = []
+    for sess in sessions:
+        session_id = sess['id']
+        stats = get_container_stats(session_id)
+        if 'error' not in stats:
+            stats['session_id'] = session_id
+            stats['external_user_id'] = sess.get('external_user_id', '')
+            stats_list.append(stats)
+    
+    return jsonify({
+        'agent_id': agent_id,
+        'agent_name': agent.get('name', agent_id),
+        'sandbox_enabled': True,
+        'active_containers': len(stats_list),
+        'containers': stats_list,
+    })
+
+
+@agents_bp.route('/api/sandbox/stats', methods=['GET'])
+def api_get_all_sandbox_stats():
+    """Get Docker sandbox resource usage statistics for all active containers."""
+    from backend.tools.lib.backends.docker_backend import get_all_container_stats
+    
+    try:
+        stats = get_all_container_stats()
+        return jsonify(stats)
+    except Exception as e:
+        return jsonify({'error': f'Failed to get sandbox stats: {str(e)}'}), 500
+
+
 # ==================== Agent Avatar API ====================
 
 AVATAR_DIR = os.path.join(BASE_DIR, 'shared', 'avatars')


### PR DESCRIPTION
## Problem

Evonic runs Docker containers to sandbox agent tool execution (bash, Python, file operations). Right now there's no visibility into what those containers are doing resource-wise. When you have multiple agents running simultaneously, you can't tell which ones are chewing through CPU or memory, and you can't tell when you're approaching capacity limits.

This becomes an actual problem in a few scenarios:
- **Multi-agent deployments**: You spin up 5+ agents, things slow down, but you have no idea which agent session is the bottleneck
- **Runaway processes**: An agent starts an infinite loop or leaks memory inside the sandbox, and you don't notice until everything grinds to a halt
- **Capacity planning**: You want to increase `SANDBOX_MAX_CONTAINERS` from 10 to 20, but you don't know if your host can handle it because you're flying blind

The Docker backend already tracks container lifecycle (creation, idle timeout, LRU eviction), but it doesn't expose resource consumption data to the web UI or API consumers.

## What Changed

This PR adds two new API endpoints that surface real-time resource metrics for Docker sandbox containers:

### 1. Per-Agent Container Stats
```
GET /api/agents/<agent_id>/sandbox/stats
```

Returns resource usage for all active containers belonging to a specific agent's sessions. Useful when you want to drill down into one agent's behavior.

**Response includes:**
- Active container count for that agent
- Per-session breakdown with container ID, CPU%, memory usage/limit, network I/O, block I/O, PIDs
- Links each container back to its session ID and external user ID

**Example output:**
```json
{
  "agent_id": "admin",
  "agent_name": "Admin Assistant",
  "sandbox_enabled": true,
  "active_containers": 2,
  "containers": [
    {
      "session_id": "6c1d9542",
      "external_user_id": "user@example.com",
      "container_id": "a3f8b2c1",
      "container_name": "evonic-6c1d9542-admin",
      "cpu_percent": 15.3,
      "memory": {
        "used": "142MiB",
        "limit": "512MiB",
        "percent": "27.7%"
      },
      "network": {
        "input": "2.1MB",
        "output": "4.8MB"
      },
      "block_io": {
        "read": "8.3MB",
        "write": "12.5MB"
      },
      "pids": "28"
    }
  ]
}
```

### 2. Pool-Wide Aggregate Stats
```
GET /api/sandbox/stats
```

Returns metrics for every active container across all agents. Useful for monitoring overall system health and spotting resource hogs.

**Response includes:**
- Pool size vs max capacity
- Per-container breakdown with agent ID association
- Aggregate totals (sum of all CPU%, active container count)

**Example output:**
```json
{
  "pool_size": 7,
  "max_containers": 10,
  "containers": [
    {
      "session_id": "6c1d9542",
      "agent_id": "admin",
      "container_id": "a3f8b2c1",
      "cpu_percent": 8.2,
      "memory": {...},
      "network": {...},
      "block_io": {...},
      "pids": "18"
    },
    // ... 6 more containers
  ],
  "aggregate": {
    "total_cpu_percent": 42.7,
    "active_containers": 7
  }
}
```

### Implementation Details

**Backend changes** (`backend/tools/lib/backends/docker_backend.py`):
- Added `get_container_stats(session_id)` — fetches metrics for a single container using `docker stats --no-stream --format '{{json .}}'` for a snapshot
- Added `get_all_container_stats()` — iterates the container pool and aggregates metrics across all active sessions
- Parses Docker's output format (handles strings like "123.4MiB / 512MiB", "12.34%", etc.)
- Returns structured dicts with separate memory/network/block_io breakdowns
- Handles error cases (container doesn't exist, Docker command fails, parse errors)

**API changes** (`routes/agents.py`):
- Added `/api/agents/<agent_id>/sandbox/stats` endpoint — checks if agent exists, if sandbox is enabled, then queries `get_container_stats()` for each session belonging to that agent
- Added `/api/sandbox/stats` endpoint — calls `get_all_container_stats()` directly and returns the full pool view
- Both endpoints require authentication (existing session check)
- Returns 400 if sandbox is disabled for an agent
- Returns 404 if agent doesn't exist

**Data source**: Uses Docker's native `stats` command (same as `docker stats` in CLI), so there's no polling overhead or background daemon needed. Each API call fetches a single snapshot.

## Why This Matters

1. **Operational visibility**: You can finally see what's happening inside the sandbox. No more guessing which agent session is stuck or overloaded.

2. **Debugging**: When an agent starts acting weird, check the metrics first. If CPU is pinned at 100% or memory is maxed out, you know it's a sandbox problem, not an LLM prompt issue.

3. **Capacity planning**: Before you bump `SANDBOX_MAX_CONTAINERS` to 50, run a test with 10 agents under load and check the aggregate CPU/memory totals. Now you have actual data to base that decision on.

4. **Future integration**: These endpoints are REST-friendly and JSON-based, so they can easily feed into monitoring dashboards, Prometheus exporters, or whatever observability stack you're running.

## What This Doesn't Do

- **No historical data**: These are point-in-time snapshots. If you want graphs over time, you'll need to poll these endpoints externally and store the results.
- **No alerting**: The API just returns data. You still need to wire up your own alerts if CPU goes over 80% or memory hits the limit.
- **No container logs**: This PR only exposes resource metrics. If you need to see what the container is actually printing, you still use `docker logs <container_id>` manually.
- **No Windows container support**: Evonic's Docker backend assumes Linux containers. If you're running Docker Desktop on Windows with Windows containers, this probably won't work (untested).

## Testing

Validated manually on a local Evonic instance with Docker Desktop:

1. Created two agents with sandbox enabled
2. Started sessions for both agents, triggered bash/Python tool calls to spin up containers
3. Hit `/api/agents/<agent_id>/sandbox/stats` — confirmed it returned metrics for active sessions only
4. Hit `/api/sandbox/stats` — confirmed it showed all containers across both agents with correct agent_id associations
5. Verified that requesting stats for an agent with no active sessions returns `active_containers: 0` with an empty array
6. Verified that requesting stats for an agent with `sandbox_enabled: 0` returns a 400 error with appropriate message
7. Checked that CPU/memory/network/block_io values matched what `docker stats` showed in the terminal

No automated tests were added because the Docker backend test suite doesn't currently mock container stats output, and adding that felt out of scope for this PR. If you want test coverage, let me know and I can follow up.

## Compatibility

- **Backward compatible**: No breaking changes. Existing routes, database schema, and Docker backend behavior are unchanged.
- **Docker version**: Tested with Docker Engine 24.x. Should work with any version that supports `docker stats --no-stream --format '{{json .}}'` (Docker 1.13+).
- **Python version**: No new dependencies. Uses only stdlib (`json`, `subprocess`) and existing Evonic modules.

## Potential Follow-Ups

If this lands and people find it useful, a few natural extensions:
- **Web UI widget**: Add a "Sandbox Stats" panel in the agent detail page that auto-refreshes every 5s
- **Per-tool breakdown**: Track which specific tool call (bash, runpy, read_file, etc.) triggered high resource usage
- **Historical logging**: Store snapshots to SQLite every minute and expose a `/api/sandbox/stats/history?since=<timestamp>` endpoint
- **Alert thresholds**: Let admins configure CPU/memory limits per agent and send notifications when exceeded