### PR TITLE
fix: eval engine bugs — tool_calling errors, reasoning extractors, In…

### DIFF
--- a/evaluator/answer_extractor.py
+++ b/evaluator/answer_extractor.py
@@ -49,20 +49,21 @@ Your answer (ya/tidak only):""",
         },
         
         2: {
-            "template": """You are given a question and an AI's response. Extract ONLY the final answer: "ya" or "tidak".
+            "template": """You are given a question asking to sort numbers, and an AI's response. Extract ONLY the sorted numbers as a comma-separated list.
 
 ---BEGIN RESPONSE---
 {response}
 ---END RESPONSE---
 
 Rules:
-1. Return ONLY "ya" or "tidak" (one word, lowercase)
-2. No explanation, no reasoning, no other text
+1. Return ONLY the numbers separated by commas (e.g. "3, 7, 15, 18, 22")
+2. No explanation, no other text
+3. Numbers only, in the order given
 
-Your answer (ya/tidak only):""",
-            "expected_format": "boolean"
+Your answer (numbers only):""",
+            "expected_format": "sequence"
         },
-        
+
         3: {
             "template": """You are given a question and an AI's response. Extract ONLY the final answer (a word, phrase, or short sentence).
 
@@ -81,19 +82,18 @@ Your answer:""",
         },
         
         4: {
-            "template": """You are given a question about causality and an AI's response. Evaluate if the response correctly considers alternative explanations.
+            "template": """You are given a multiple-choice question and an AI's response. Extract ONLY the number(s) of the correct statement(s).
 
 ---BEGIN RESPONSE---
 {response}
 ---END RESPONSE---
 
 Rules:
-1. Return "ya" if the response considers multiple factors/alternatives
-2. Return "tidak" if the response only considers one factor
-3. Just one word, lowercase
+1. Return ONLY the number(s) of the correct statement(s), comma-separated (e.g. "2, 4")
+2. No explanation, no other text
 
-Your answer (ya/tidak only):""",
-            "expected_format": "boolean"
+Your answer (statement numbers only):""",
+            "expected_format": "statements"
         },
         
         5: {

--- a/evaluator/engine.py
+++ b/evaluator/engine.py
@@ -185,7 +185,11 @@ class EvaluationEngine:
         else:
             from evaluator.llm_client import llm_client as run_llm_client
 
-        
+        # Point pass2 evaluator at the same model used for this run,
+        # so it doesn't fall back to the (possibly offline) global default.
+        from evaluator.answer_extractor import answer_extractor as _ae
+        _ae.client = run_llm_client
+
         try:
             if self.use_configurable_tests:
                 self._run_configurable_evaluation(run_id, model_name, domains, run_llm_client)
@@ -357,10 +361,11 @@ class EvaluationEngine:
 
             # Handle tool_calling domain with multi-turn loop
             if domain == "tool_calling":
+                system_prompt = None  # legacy tests don't define a system prompt
                 from evaluator.tools import tool_framework
                 tools = tool_framework.tools
                 self._log(f'[TOOLS] Available: {[t["function"]["name"] for t in tools]}')
-                
+
                 # Run tool calling loop
                 loop_result = self._run_tool_calling_loop(prompt, tools, system_prompt=system_prompt, run_llm_client=_client)
 

--- a/evaluator/strategies/tool_call.py
+++ b/evaluator/strategies/tool_call.py
@@ -102,6 +102,8 @@ class ToolCallEvaluator(BaseEvaluator):
         if isinstance(expected, dict):
             if "tool" in expected:
                 expected_tools = [expected["tool"]]
+            elif "tools_used" in expected:
+                expected_tools = expected.get("tools_used", [])
             elif "tools" in expected:
                 expected_tools = expected.get("tools", [])
             elif "chain" in expected:

--- a/evaluator/test_classes/reasoning.py
+++ b/evaluator/test_classes/reasoning.py
@@ -212,9 +212,13 @@ Seorang member loyal membeli produk seharga Rp 1.200.000. Berapa harga yang haru
         # Clean response for numeric comparison
         clean = response.strip()
         clean = clean.replace(',', '').replace('Rp', '').replace('rp', '').strip()
-        # Handle Indonesian decimal format (dots as thousands separator)
-        if '.' in clean and clean.count('.') > 1:
-            clean = clean.replace('.', '')
+        # Handle Indonesian thousands separator (dot): multiple dots OR single dot
+        # with exactly 3 trailing digits (e.g. "820.800" → "820800")
+        if '.' in clean:
+            if clean.count('.') > 1:
+                clean = clean.replace('.', '')
+            elif re.match(r'^\d+\.\d{3}$', clean):
+                clean = clean.replace('.', '')
         
         try:
             actual = float(clean)

--- a/evaluator/tools.py
+++ b/evaluator/tools.py
@@ -176,7 +176,32 @@ class ToolFramework:
                     }
                 }
             },
-
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "description": "Write content to a file on the filesystem",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filename": {
+                                "type": "string",
+                                "description": "Name or path of the file to write"
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "Content to write to the file"
+                            },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["write", "append"],
+                                "description": "Write mode: 'write' (overwrite) or 'append'"
+                            }
+                        },
+                        "required": ["filename", "content"]
+                    }
+                }
+            },
         ]
     
     def execute_tool(self, tool_call: Dict[str, Any]) -> Dict[str, Any]:
@@ -201,6 +226,8 @@ class ToolFramework:
                 result = self._get_order(arguments)
             elif function_name == "send_notification":
                 result = self._send_notification(arguments)
+            elif function_name == "write_file":
+                result = self._write_file(arguments)
             else:
                 result = {"error": f"Unknown tool: {function_name}"}
             
@@ -362,6 +389,20 @@ class ToolFramework:
         
         # Mock: just return success
         return {"email": email, "message_preview": message[:50], "status": "sent", "notification_id": "NOTIF-12345"}
+
+    def _write_file(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Mock file write — simulates success without touching the real filesystem"""
+        import datetime
+        filename = args.get("filename", "output.txt")
+        content = args.get("content", "")
+        mode = args.get("mode", "write")
+        timestamp = datetime.datetime.now().isoformat()
+        return {
+            "status": "created" if mode == "write" else "appended",
+            "filename": filename,
+            "bytes_written": len(content.encode()),
+            "timestamp": timestamp,
+        }
 
 # Global tool framework instance
 tool_framework = ToolFramework()


### PR DESCRIPTION
…donesian number parsing

- engine.py: redirect pass2 answer_extractor client to the run's LLM so it doesn't fall back to the offline default at port 8000; also add missing system_prompt=None before tool_calling branch to fix NameError
- tools.py: add write_file tool definition and mock handler so tool_calling L4 (and any test that calls it) doesn't fail with unknown tool
- strategies/tool_call.py: recognise "tools_used" key in legacy test expected dicts (alongside existing "tool", "tools", "chain")
- answer_extractor.py: fix reasoning L2 extractor (boolean→sequence, number-sort prompt) and L4 extractor (boolean causality→statements, multiple-choice prompt)
- test_classes/reasoning.py: fix Indonesian thousands-separator parsing in L5 scorer — single dot with exactly 3 trailing digits (e.g. "820.800") was not being stripped, causing 820.8 instead of 820800