### PR TITLE
fix: release PID flock before spawning child in daemon mode

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -211,6 +211,12 @@ def start_server(port=None, host=None, debug=None, daemon=False):
         app_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "..", "app.py"
         )
+        # Release the lock BEFORE spawning — the child process (app.py) will
+        # acquire its own via its single-instance guard. Holding the lock here
+        # causes a race: the child's fcntl.flock(LOCK_NB) fails because this
+        # process still owns the lock, killing the child immediately.
+        os.close(pid_lock_fd)
+
         proc = subprocess.Popen(
             [sys.executable, app_path],
             env=env,
@@ -223,8 +229,6 @@ def start_server(port=None, host=None, debug=None, daemon=False):
 
         if _is_running(proc.pid):
             _write_pid(proc.pid)
-            # Release the lock — the child process (app.py) will acquire its own
-            os.close(pid_lock_fd)
             print(f"Server started in background (PID: {proc.pid})")
             print(f"Host: {host}")
             print(f"Port: {port}")


### PR DESCRIPTION
## Problem

When running `evonic start -d` (daemon mode), the server fails to start with:

```
Another Evonic server instance is already running
```

This happens because the CLI holds `fcntl.flock(LOCK_EX)` on `shared/run/evonic.pid` while spawning the child process via `subprocess.Popen`. The child (`app.py`) then tries `fcntl.flock(LOCK_NB)` on the same file, which fails because the parent still owns the lock, causing the child to exit immediately.

## Fix

Move `os.close(pid_lock_fd)` to **before** `subprocess.Popen` in the daemon branch of `start_server()`. This releases the CLI's lock before spawning, so the child process can acquire its own lock cleanly via its single-instance guard.

## Reproduction

1. Run `evonic start -d`
2. Server fails to start
3. Check server.log — repeated "Another Evonic server instance is already running" errors

## Verification

After this fix, `evony start -d` and `evonic restart` work correctly in daemon mode.