### PR TITLE
fix: resolve fresh-install issues (dashboard, doctor, installer)

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -3179,6 +3179,37 @@ def doctor_command(quick=False, fix=False, with_llm_provider=False):
         results.append(_fail(f"Asset build check failed: {e}"))
 
 
+    # ── 13. Database Schema / Query Health Check ──────────────
+    _section("13. Database Schema / Query Health Check")
+    try:
+        import sqlite3 as _sqlite3
+        from models.db import db as _schema_db
+
+        dashboard_queries = [
+            ("dashboard stats", _schema_db.get_dashboard_stats),
+            ("model usage", _schema_db.get_model_usage),
+            ("model leaderboard", _schema_db.get_model_leaderboard),
+            ("recent agents", _schema_db.get_recent_agents),
+            ("recent runs", _schema_db.get_recent_runs),
+        ]
+        schema_ok = True
+        for q_name, q_fn in dashboard_queries:
+            try:
+                q_fn()
+            except _sqlite3.OperationalError as qe:
+                schema_ok = False
+                results.append(_fail(f"{q_name} query failed — schema mismatch: {qe}"))
+            except Exception as qe:
+                results.append(_warn(f"{q_name} query raised {type(qe).__name__}: {qe}"))
+        if schema_ok:
+            results.append(_ok("Dashboard queries match the current database schema"))
+        else:
+            _info("  A column referenced by a query is missing from the schema "
+                  "(commonly a rename/drop that left a query un-updated).")
+    except Exception as e:
+        results.append(_fail(f"Database schema check failed: {e}"))
+
+
     _section("Summary")
 
     # Filter out "skip" entries

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ check_prereqs() {
     step "Step 1/6: Checking prerequisites"
 
     missing=""
-    for cmd in git python3 pip3; do
+    for cmd in git python3; do
         if command -v "$cmd" >/dev/null 2>&1; then
             ok "$cmd found"
         else
@@ -82,6 +82,12 @@ check_prereqs() {
         die "Python 3.9+ is required. Found: $(python3 --version 2>&1)"
     fi
     ok "Python version $(python3 --version 2>&1) meets minimum requirement (3.9+)"
+
+    # The installer needs the venv module (with ensurepip), not a system pip3.
+    if ! python3 -c 'import venv, ensurepip' 2>/dev/null; then
+        die "Python 'venv' module is missing. Install it (e.g. sudo apt install python3-venv) and re-run."
+    fi
+    ok "Python venv module available"
 }
 
 # --- Fix remote fetch config so branches and tags are tracked ---
@@ -90,7 +96,6 @@ check_prereqs() {
 # breaks `git fetch`, `git pull`, and the supervisor auto-updater.
 # Reconfigure to fetch all branches + tags so the repo stays alive.
 fix_remote_fetch() {
-    local rc
     rc=$(git -C "$EVONIC_HOME" config remote.origin.fetch 2>/dev/null)
     case "$rc" in
         *refs/tags/*:refs/tags/*)  # locked to a single tag -- fix it
@@ -166,7 +171,13 @@ create_venv() {
         return
     fi
 
-    python3 -m venv "$VENV_DIR"
+    python3 -m venv "$VENV_DIR" || die "Virtual environment creation failed. Install the venv module (e.g. sudo apt install python3-venv) and re-run."
+
+    # Some distros create the venv without bootstrapping pip; ensure it exists.
+    if [ ! -x "$VENV_DIR/bin/pip" ] && [ ! -x "$VENV_DIR/bin/pip3" ]; then
+        "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null 2>&1 || \
+            die "Virtual environment has no pip. Install the venv module (e.g. sudo apt install python3-venv) and re-run."
+    fi
     ok "Virtual environment created at $VENV_DIR"
 }
 
@@ -174,13 +185,11 @@ create_venv() {
 install_deps() {
     step "Step 4/6: Installing Python dependencies"
 
-    pip="$VENV_DIR/bin/pip"
-    if [ ! -f "$pip" ]; then
-        pip="$VENV_DIR/bin/pip3"
-    fi
+    py="$VENV_DIR/bin/python"
+    [ -x "$py" ] || py="$VENV_DIR/bin/python3"
 
-    "$pip" install --upgrade pip --quiet
-    "$pip" install -r "$EVONIC_HOME/requirements.txt"
+    "$py" -m pip install --upgrade pip --quiet
+    "$py" -m pip install -r "$EVONIC_HOME/requirements.txt"
     ok "Dependencies installed"
 }
 
@@ -198,6 +207,8 @@ EVONIC_HOME="\${EVONIC_HOME:-$EVONIC_HOME}"
 # Activate venv and run
 if [ -f "\$EVONIC_HOME/.venv/bin/activate" ]; then
     . "\$EVONIC_HOME/.venv/bin/activate"
+elif [ -f "\$EVONIC_HOME/venv/bin/activate" ]; then
+    . "\$EVONIC_HOME/venv/bin/activate"
 fi
 
 cd "\$EVONIC_HOME"

--- a/models/mixins/dashboard.py
+++ b/models/mixins/dashboard.py
@@ -141,9 +141,9 @@ class DashboardMixin:
             cursor = conn.cursor()
         try:
             cursor.execute("""
-                SELECT COALESCE(model, 'default') as model, COUNT(*) as agent_count
+                SELECT COALESCE(model_id, 'default') as model, COUNT(*) as agent_count
                 FROM agents
-                GROUP BY COALESCE(model, 'default')
+                GROUP BY COALESCE(model_id, 'default')
                 ORDER BY agent_count DESC
             """)
             return [dict(row) for row in cursor.fetchall()]

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -21,6 +21,10 @@ function loadDashboard() {
     });
 }
 
+function emptyState(message) {
+    return '<div class="p-6 text-center text-sm text-gray-400 dark:text-gray-500">' + message + '</div>';
+}
+
 function renderStats(stats) {
     $('#stat-agent-count').text(stats.agent_count);
     $('#stat-active-channel-count').text(stats.active_channel_count);
@@ -89,7 +93,7 @@ function renderAgents(agents) {
 
     if (!agents || agents.length === 0) {
         $container.hide();
-        $empty.show();
+        $empty.html(emptyState('No agents yet')).show();
         return;
     }
 
@@ -105,7 +109,7 @@ function renderAgents(agents) {
         if (desc.length > 50) {
             desc = desc.substring(0, 50) + '...';
         }
-        var modelBadge = a.model ? '<span class="text-xs bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 px-2 py-0.5 rounded font-mono hidden sm:inline">' + a.model.substring(0, 20) + '</span>' : '';
+        var modelBadge = a.model_id ? '<span class="text-xs bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 px-2 py-0.5 rounded font-mono hidden sm:inline">' + a.model_id.substring(0, 20) + '</span>' : '';
 
         html += '<a href="/agents/' + a.id + '" class="flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors no-underline text-inherit">\n';
         html += '    <div class="flex items-center gap-3 min-w-0">\n';
@@ -137,7 +141,7 @@ function renderLeaderboard(leaderboard) {
 
     if (!leaderboard || leaderboard.length === 0) {
         $container.hide();
-        $empty.show();
+        $empty.html(emptyState('No model scores yet')).show();
         return;
     }
 
@@ -182,7 +186,7 @@ function renderRecentRuns(runs) {
 
     if (!runs || runs.length === 0) {
         $container.hide();
-        $empty.show();
+        $empty.html(emptyState('No evaluation runs yet')).show();
         return;
     }
 
@@ -226,7 +230,7 @@ function renderModelUsage(modelUsage) {
 
     if (!modelUsage || modelUsage.length === 0) {
         $container.hide();
-        $empty.show();
+        $empty.html(emptyState('No model usage data yet')).show();
         return;
     }
 

--- a/unit_tests/test_dashboard_model_usage.py
+++ b/unit_tests/test_dashboard_model_usage.py
@@ -1,0 +1,84 @@
+"""Regression test for get_model_usage on a fresh-install agents table.
+
+A fresh agents table has model_id but no legacy 'model' column. The query must
+group by model_id, otherwise it raises OperationalError: no such column: model
+and 500s the dashboard.
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+from contextlib import contextmanager
+
+_DASHBOARD_PY = os.path.join(
+    os.path.dirname(__file__), '..', 'models', 'mixins', 'dashboard.py'
+)
+
+# Load dashboard.py directly (it only depends on sqlite3 + typing) so the test
+# runs even when full project deps are not installed.
+_spec = importlib.util.spec_from_file_location('_dashboard_under_test', _DASHBOARD_PY)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+DashboardMixin = _mod.DashboardMixin
+
+
+class _FreshInstallDB(DashboardMixin):
+    """Minimal host exposing _connect(), backed by a fresh-install agents table."""
+
+    def __init__(self, db_path):
+        self.db_path = db_path
+        # One persistent connection, mirroring Database._connect (commits but
+        # does not close on context exit, so get_model_usage's no-arg path works).
+        self._conn = sqlite3.connect(db_path)
+        # Mirror the v0.8.0 fresh CREATE TABLE: model_id exists, 'model' does NOT.
+        self._conn.execute(
+            """CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                default_model_id TEXT,
+                model_id TEXT
+            )"""
+        )
+        self._conn.executemany(
+            "INSERT INTO agents (id, name, model_id) VALUES (?, ?, ?)",
+            [('a1', 'A1', 'gpt-x'), ('a2', 'A2', 'gpt-x'), ('a3', 'A3', None)],
+        )
+        self._conn.commit()
+
+    @contextmanager
+    def _connect(self):
+        with self._conn:
+            yield self._conn
+
+    def close(self):
+        self._conn.close()
+
+
+class TestDashboardModelUsageFreshInstall(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        self.db = _FreshInstallDB(self.path)
+
+    def tearDown(self):
+        self.db.close()
+        os.unlink(self.path)
+
+    def test_no_model_column_on_fresh_agents_table(self):
+        with self.db._connect() as conn:
+            cols = {row[1] for row in conn.execute('PRAGMA table_info(agents)')}
+        self.assertNotIn('model', cols, "fresh agents table must not have legacy 'model'")
+        self.assertIn('model_id', cols)
+
+    def test_get_model_usage_groups_by_model_id(self):
+        # Must not raise OperationalError: no such column: model
+        rows = self.db.get_model_usage()
+        usage = {r['model']: r['agent_count'] for r in rows}
+        self.assertEqual(usage, {'gpt-x': 2, 'default': 1})
+        # Response field name stays 'model' so the dashboard JS contract is intact.
+        self.assertIn('model', rows[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
On a fresh v0.8.0 install, the dashboard landing page fails to load and the installer can abort with a cryptic error on common setups. This PR fixes the broken queries, adds a diagnostic to catch the regression class, and hardens the installer.

## Dashboard
- **`get_model_usage` 500 on fresh install.** The query selected `COALESCE(model, …)`, but the agents `model` column was removed in v0.6.78 (renamed to `model_id`). Existing databases keep the old column, so the bug was masked; fresh installs never create `model`, so the query raised `no such column: model` and 500'd both `/api/dashboard/data` and `/api/dashboard/stats` — the landing page. Point the query at `model_id`; the `AS model` alias preserves the response shape (no API change).
- **Recent-agents model badge** read `a.model` (always `undefined` after the rename) → use `a.model_id`.
- **Empty states.** The dashboard widgets reused their skeleton loaders as the "no data" state, so on a fresh install (no agents/models/evaluation runs) they animated indefinitely. Show a "no data yet" message instead.

## Doctor
- Add a **Database Schema / Query Health Check** that runs the dashboard read queries against the live schema. A plain `SELECT 1` connection check can't catch a column rename/drop that leaves a query stale — this does. Runs read-only in both normal and `--fix` mode.

## Installer (`install.sh`)
- **Verify the `venv`/`ensurepip` module** (the real requirement) instead of an unused system `pip3`, failing fast with guidance to install `python3-venv`. On distros that create a venv without bootstrapping pip, `python3 -m venv` returns 0 yet leaves no pip, so dependency install previously failed later with a cryptic `pip3: not found`.
- **Bootstrap pip via `ensurepip`** if the venv comes up without it; install dependencies via `python -m pip` rather than a `pip`/`pip3` shim.
- **Activate `.venv` first, then legacy `venv`** in the generated wrapper, matching the repo `evonic` wrapper (`.venv` primary, `venv` fallback).
- Drop non-POSIX `local` (the script is `#!/bin/sh`); verified with `sh -n`, `dash -n`, and `bash -n` (the `curl … | bash` one-liner).

## Testing
- Reproduced the dashboard 500 on a fresh DB; confirmed `/api/dashboard/data` and `/api/dashboard/stats` return 200 after the fix.
- Added `unit_tests/test_dashboard_model_usage.py` (fails on the old query, passes on the fix). Full suite: no new failures.
- `evonic doctor` and `evonic doctor --fix` run the new schema check cleanly.

## Scope
5 files — query/UI/installer fixes plus one regression test. No schema migration, no API changes.
