### PR TITLE
fix: in-place restart, health-gated update/rollback, Python 3.14 test compat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,9 @@ EVONIC_SUBAGENT_IDLE_TTL=1800
 
 # Session Archive: when enabled the session data will be archived before it deleted in active db
 EVONIC_SESSION_ARCHIVE=0
+
+# Boot-gate probe: set to 1 to make `import app` return immediately without starting
+# channels, the scheduler, or app.run(). Used by the update pipeline's smoke test to
+# verify the new code imports cleanly without touching the live server's port or DB
+# connections. Not intended for production use.
+# EVONIC_SMOKE_TEST=

--- a/app.py
+++ b/app.py
@@ -319,7 +319,10 @@ init_super_agent_notifier()
 import os as _os
 _reloader_active = _os.environ.get('WERKZEUG_RUN_MAIN') is not None
 _is_reloader_child = _os.environ.get('WERKZEUG_RUN_MAIN') == 'true'
-if not _reloader_active or _is_reloader_child:
+# Smoke-test import (used by the updater to validate a new tree before
+# restarting): import all modules but skip channel/scheduler startup.
+_smoke_test = _os.environ.get('EVONIC_SMOKE_TEST') == '1'
+if (not _reloader_active or _is_reloader_child) and not _smoke_test:
     # Run SYSTEM.md migration eagerly (not lazily on first GET /api/agents).
     # Agents that predate the on-disk SYSTEM.md feature need their file written
     # before they start processing messages — otherwise read_file("/_self/SYSTEM.md")

--- a/backend/restart.py
+++ b/backend/restart.py
@@ -1,0 +1,80 @@
+"""
+In-place server restart — single source of truth.
+
+Restarts the running server by replacing the current process image with a fresh
+one (os.execv), preserving the PID the run/ lock and PID file point to. This is
+the only restart mechanism that works without an external process manager, so it
+is correct under the documented `evonic start -d` install path as well as under
+systemd/Docker.
+
+Used by the /restart slash command, the super-agent restart tool, the web setup
+auto-restart, and the web update "Restart" action so every restart path behaves
+identically.
+"""
+
+import logging
+import os
+import sys
+import threading
+import time
+
+log = logging.getLogger(__name__)
+
+
+def restart_in_place(delay: float = 1.5) -> None:
+    """Stop channels and the scheduler, free inherited FDs, and re-exec the server.
+
+    Runs in the calling thread and never returns on success (the process image is
+    replaced). Intended to be invoked from a daemon thread via schedule_restart().
+    """
+    time.sleep(delay)  # Let the triggering response/log flush first.
+
+    # Stop all channels cleanly so Telegram releases its long-poll before the
+    # new process re-opens them (otherwise the bot token hits a getUpdates
+    # Conflict on the next boot).
+    try:
+        from backend.channels.registry import channel_manager
+        channel_manager.stop_all()
+        time.sleep(1.0)  # Give Telegram server-side time to release.
+    except Exception as e:
+        log.error("Error stopping channels during restart: %s", e, exc_info=True)
+
+    # Shut down the scheduler so in-flight jobs are not abandoned mid-execution.
+    try:
+        from backend.scheduler import scheduler as global_scheduler
+        global_scheduler.shutdown()
+    except Exception as e:
+        log.error("Error shutting down scheduler during restart: %s", e, exc_info=True)
+
+    # Close inherited file descriptors (including Flask's bound socket) so the
+    # new process can re-bind the same port. close_range(inheritable=False) keeps
+    # the FDs in this process but stops them leaking into the new image; fall back
+    # to closerange on older Python. POSIX-only — skip on Windows.
+    if sys.platform != 'win32':
+        try:
+            import resource
+            maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+            if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
+                maxfd = 4096
+            try:
+                os.close_range(3, maxfd, inheritable=False)
+            except AttributeError:
+                os.closerange(3, maxfd)
+        except Exception:
+            pass
+
+    # Flat-repo architecture: project root IS the live directory.
+    import config
+    target = os.path.realpath(config.BASE_DIR)
+    app_py = os.path.join(target, 'app.py')
+    venv_python = os.path.join(target, '.venv', 'bin', 'python')
+    python = venv_python if os.path.exists(venv_python) else sys.executable
+
+    log.info("Re-executing server process")
+    os.chdir(target)
+    os.execv(python, [python, app_py])
+
+
+def schedule_restart(delay: float = 1.5) -> None:
+    """Run restart_in_place() in a daemon thread and return immediately."""
+    threading.Thread(target=restart_in_place, args=(delay,), daemon=True).start()

--- a/backend/slash_commands.py
+++ b/backend/slash_commands.py
@@ -7,7 +7,6 @@ Commands are parsed and executed in the backend so they work on all channels
 import logging
 import re
 import os
-import sys
 import threading
 from typing import Optional, Dict, Any, Callable, Tuple
 
@@ -533,50 +532,8 @@ def _register_builtins():
         except Exception:
             pass
 
-        def _do_restart():
-            import time
-            import resource
-
-            time.sleep(1.5)  # Brief delay so response is sent first
-
-            # Stop all channels cleanly so Telegram releases its long-poll
-            # before the new process starts and re-opens them
-            from backend.channels.registry import channel_manager
-            channel_manager.stop_all()
-            time.sleep(1.0)  # Give Telegram server-side time to release
-
-            # Close all inherited file descriptors (including Flask's bound
-            # socket) so the new process can bind the same port cleanly.
-            # Use os.close_range with inheritable=False (Python 3.13+) so
-            # the child inherits the same FDs but the parent's semaphores
-            # don't trigger leak warnings on macOS. Fallback to
-            # os.closerange for older Python versions.
-            try:
-                maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                    maxfd = 4096
-                try:
-                    os.close_range(3, maxfd, inheritable=False)
-                except AttributeError:
-                    os.closerange(3, maxfd)
-            except Exception:
-                pass
-
-            # Flat-repo architecture: project root IS the live directory.
-            import config as _config
-            _target = os.path.realpath(_config.BASE_DIR)
-            _app_py = os.path.join(_target, 'app.py')
-            _venv_python = os.path.join(_target, '.venv', 'bin', 'python')
-            _python = _venv_python if os.path.exists(_venv_python) else sys.executable
-
-            # Replace the current process in-place so we preserve the
-            # original execution mode (foreground stays foreground,
-            # daemon stays daemon).
-            os.chdir(_target)
-            os.execv(_python, [_python, _app_py])
-
-        t = threading.Thread(target=_do_restart, daemon=True)
-        t.start()
+        from backend.restart import schedule_restart
+        schedule_restart()
         return "Restarting..."
 
     command_registry.register(

--- a/backend/tools/super_agent_tools.py
+++ b/backend/tools/super_agent_tools.py
@@ -675,9 +675,6 @@ def _exec_set_owner_name(args: dict) -> dict:
 
 def _exec_restart(args: dict, agent_context: dict = None) -> dict:
     """Restart the Evonic server. Same mechanism as /restart slash command."""
-    import sys as _sys
-    import threading
-    import time
     import json as _json
     import logging
 
@@ -798,32 +795,8 @@ def _exec_restart(args: dict, agent_context: dict = None) -> dict:
         'context': recent_context,
     }))
 
-    def _do_restart():
-        time.sleep(1.5)
-        from backend.channels.registry import channel_manager
-        channel_manager.stop_all()
-        time.sleep(1.0)
-        # `resource` is POSIX-only; skip FD cleanup on Windows.
-        if _sys.platform != 'win32':
-            try:
-                import resource
-                maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                    maxfd = 4096
-                os.closerange(3, maxfd)
-            except Exception:
-                pass
-        # Flat-repo architecture: project root IS the live directory.
-        import config as _config
-        _target = os.path.realpath(_config.BASE_DIR)
-        _app_py = os.path.join(_target, 'app.py')
-        _venv_python = os.path.join(_target, '.venv', 'bin', 'python')
-        _python = _venv_python if os.path.exists(_venv_python) else _sys.executable
-        os.chdir(_target)
-        os.execv(_python, [_python, _app_py])
-
-    t = threading.Thread(target=_do_restart, daemon=True)
-    t.start()
+    from backend.restart import schedule_restart
+    schedule_restart()
     return {'result': 'Restarting...'}
 
 

--- a/backend/update_manager.py
+++ b/backend/update_manager.py
@@ -16,7 +16,6 @@ import os
 import queue
 import re
 import subprocess
-import sys
 import threading
 import time
 from datetime import datetime
@@ -536,18 +535,18 @@ def trigger_rollback() -> dict:
 
 
 def trigger_restart() -> dict:
-    """Spawn a detached subprocess that restarts the server after a short delay.
+    """Re-exec the server in place via the shared restart helper.
 
-    In the flat-repo model, the restart is handled by sending SIGTERM to the
-    parent process after a brief delay, allowing the process manager (systemd,
-    Docker, etc.) to restart it.
+    State is reset to idle BEFORE the restart so the persisted
+    state/update/update_state.json does not carry 'success' across server
+    restarts, which was causing the 'Update complete!' banner to reappear.
     """
     _append_log('info', 'Restart scheduled...')
     _notify_listeners()
 
-    # Reset state to idle BEFORE spawning restart so the persisted state
-    # does not carry over 'success' status after the server restarts.
-    # This must happen while _lock is held and before subprocess.Popen().
+    # Reset state to idle BEFORE restart so the persisted state does not
+    # carry over 'success' status after the server restarts. Must happen
+    # while _lock is held and before schedule_restart() fires the thread.
     with _lock:
         _state['status'] = 'idle'
         _state['progress'] = 0
@@ -557,19 +556,8 @@ def trigger_restart() -> dict:
         _state['crashed'] = False
         _persist_state(_state)
 
-    # Detached subprocess: sleeps 2s, then terminates the parent process.
-    script = (
-        "import time, signal, os; "
-        "time.sleep(2); "
-        "os.kill(os.getppid(), signal.SIGTERM)"
-    )
-
-    subprocess.Popen(
-        [sys.executable, '-c', script],
-        start_new_session=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    from backend.restart import schedule_restart
+    schedule_restart()
     return {'success': True, 'restarting': True}
 
 

--- a/backend/update_manager.py
+++ b/backend/update_manager.py
@@ -16,6 +16,7 @@ import os
 import queue
 import re
 import subprocess
+import sys
 import threading
 import time
 from datetime import datetime
@@ -162,8 +163,8 @@ def _persist_state(state: dict) -> None:
 _lock = threading.Lock()
 _listeners: list = []  # list of queue.Queue, one per SSE client
 
-# Total steps in the simplified update process: fetch + apply
-TOTAL_STEPS = 2
+# Total pipeline steps: fetch + reset + reinstall deps + doctor --fix + smoke test
+TOTAL_STEPS = 5
 
 # Load persisted state on module import (survives crashes/restarts)
 _persisted = _load_persisted_state()
@@ -321,6 +322,219 @@ def _get_current_version():
 
 
 # ---------------------------------------------------------------------------
+# Shared apply pipeline (reused by the web updater and the CLI)
+# ---------------------------------------------------------------------------
+
+def _venv_python() -> str:
+    """Path to the project venv python, falling back to the current interpreter."""
+    venv = os.path.join(config.APP_ROOT, '.venv', 'bin', 'python')
+    return venv if os.path.exists(venv) else sys.executable
+
+
+def _reinstall_deps() -> tuple:
+    """Reinstall dependencies in case requirements.txt changed. Returns (ok, detail)."""
+    req = os.path.join(config.APP_ROOT, 'requirements.txt')
+    if not os.path.isfile(req):
+        return True, 'no requirements.txt'
+    proc = subprocess.run(
+        [_venv_python(), '-m', 'pip', 'install', '-q', '-r', req],
+        cwd=config.APP_ROOT, capture_output=True, text=True,
+    )
+    detail = (proc.stderr.strip() or proc.stdout.strip())[-500:]
+    return proc.returncode == 0, detail
+
+
+def _smoke_test() -> tuple:
+    """Import the updated tree in a subprocess to catch syntax/import errors
+    before the live server is restarted. EVONIC_SMOKE_TEST skips channel and
+    scheduler startup so the probe has no side effects. Returns (ok, detail)."""
+    env = dict(os.environ, EVONIC_SMOKE_TEST='1')
+    try:
+        proc = subprocess.run(
+            [_venv_python(), '-c', 'import app'],
+            cwd=config.APP_ROOT, capture_output=True, text=True,
+            timeout=120, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return False, 'smoke test timed out'
+    detail = (proc.stderr.strip() or proc.stdout.strip())[-1000:]
+    return proc.returncode == 0, detail
+
+
+def _run_doctor_fix() -> tuple:
+    """Repair the environment via `evonic doctor --fix` (creates dirs, installs
+    optional deps). Mirrors the CLI repair step so the web updater behaves the
+    same. Returns (ok, detail)."""
+    evonic_bin = os.path.join(config.APP_ROOT, 'evonic')
+    if not os.path.isfile(evonic_bin):
+        return True, 'no evonic wrapper'
+    proc = subprocess.run(
+        [evonic_bin, 'doctor', '--fix'],
+        cwd=config.APP_ROOT, capture_output=True, text=True,
+    )
+    detail = (proc.stderr.strip() or proc.stdout.strip())[-500:]
+    return proc.returncode == 0, detail
+
+
+def _repair_and_verify() -> tuple:
+    """Reinstall deps, repair the environment (doctor --fix), then smoke-test the
+    tree before it goes live. deps and smoke are gating; doctor is logged
+    best-effort so optional-dependency problems don't fail an otherwise bootable
+    tree (the smoke test is the real gate). Returns (ok, detail)."""
+    deps_ok, deps_detail = _reinstall_deps()
+    if not deps_ok:
+        return False, f'Dependency install failed: {deps_detail}'
+    doctor_ok, doctor_detail = _run_doctor_fix()
+    if not doctor_ok:
+        _append_log('warning', f'doctor --fix reported problems: {doctor_detail}')
+    smoke_ok, smoke_detail = _smoke_test()
+    if not smoke_ok:
+        return False, f'Updated code failed to import: {smoke_detail}'
+    return True, ''
+
+
+def _record_previous_commit(sha: str) -> None:
+    """Persist the pre-update commit so rollback is deterministic. The reflog's
+    HEAD@{1} is unreliable here: apply_update's auto-rollback on a failed update
+    moves HEAD@{1} onto the rejected commit."""
+    with _lock:
+        _state['previous_commit'] = sha
+        _persist_state(_state)
+
+
+def _resolve_rollback_target() -> str:
+    """Commit to roll back to: the recorded pre-update commit if available, else
+    the reflog fallback (HEAD@{1}) for back-compat. Reads persisted state from
+    disk so it works regardless of whether the CLI or the web path did the
+    update."""
+    persisted = _load_persisted_state().get('previous_commit')
+    if persisted:
+        return persisted
+    rc, prev, _ = _git_run('rev-parse', 'HEAD@{1}')
+    return prev if rc == 0 else ''
+
+
+def _acquire_update_lock():
+    """Cross-process advisory lock so concurrent web+CLI calls don't race on
+    git operations. POSIX only; no-op on Windows (single-user install assumption).
+    Returns (acquired: bool, fd: file | None)."""
+    if sys.platform == 'win32':
+        return True, None
+    lock_path = os.path.join(os.path.dirname(_get_state_file_path()), 'update.lock')
+    try:
+        import fcntl
+        fd = open(lock_path, 'w')
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True, fd
+    except (IOError, OSError):
+        try:
+            fd.close()
+        except Exception:
+            pass
+        return False, None
+
+
+def _release_update_lock(fd) -> None:
+    if fd is None:
+        return
+    try:
+        import fcntl
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        fd.close()
+    except Exception:
+        pass
+
+
+def apply_update(target: str, progress_cb=None) -> dict:
+    """Apply an update to the given git ref with reinstall, smoke test, and
+    auto-rollback. Shared by the web updater and the CLI so both behave the same.
+
+    Steps: fetch → record HEAD → reset --hard <ref> → reinstall deps → doctor
+    --fix → smoke test. If a gating step fails, the tree is reset back to the
+    prior commit so the running server stays bootable. Does NOT restart — the
+    caller decides. progress_cb(step, total, label) is called before each step
+    when provided (web notifier hook).
+
+    Returns {'success': True} or {'error': str, 'failed_step': int}.
+    """
+    STEPS = 5
+
+    def _step(n, label):
+        if progress_cb:
+            progress_cb(n, STEPS, label)
+
+    acquired, lock_fd = _acquire_update_lock()
+    if not acquired:
+        return {'error': 'Another update or rollback is already running', 'failed_step': 1}
+    try:
+        _step(1, 'Fetching updates from origin...')
+        rc, _, err = _git_run('fetch', 'origin', '--tags')
+        if rc != 0:
+            return {'error': f'Git fetch failed: {err}', 'failed_step': 1}
+
+        rc, prev, err = _git_run('rev-parse', 'HEAD')
+        if rc != 0:
+            return {'error': f'Could not record current commit: {err}', 'failed_step': 1}
+        _record_previous_commit(prev)
+
+        _step(2, f'Applying update to {target}...')
+        ref = target or 'origin/main'
+        rc, _, err = _git_run('reset', '--hard', ref)
+        if rc != 0:
+            return {'error': f'Git reset failed: {err}', 'failed_step': 2}
+
+        _step(3, 'Reinstalling dependencies...')
+        deps_ok, deps_detail = _reinstall_deps()
+        if not deps_ok:
+            _git_run('reset', '--hard', prev)
+            return {'error': f'Dependency install failed: {deps_detail} (rolled back)',
+                    'failed_step': 3}
+
+        # doctor --fix is best-effort: optional-dep issues must not block an
+        # otherwise bootable tree. The smoke test is the real boot gate.
+        _step(4, 'Repairing environment...')
+        doctor_ok, doctor_detail = _run_doctor_fix()
+        if not doctor_ok:
+            _append_log('warning', f'doctor --fix reported problems: {doctor_detail}')
+
+        _step(5, 'Running smoke test...')
+        smoke_ok, smoke_detail = _smoke_test()
+        if not smoke_ok:
+            _git_run('reset', '--hard', prev)
+            return {'error': f'Updated code failed to import: {smoke_detail} (rolled back)',
+                    'failed_step': 5}
+
+        return {'success': True}
+    finally:
+        _release_update_lock(lock_fd)
+
+
+def apply_rollback() -> dict:
+    """Reset to the recorded previous commit, then repair and verify. Synchronous
+    — shared by the CLI (`evonic update --rollback`) and the threaded web
+    trigger_rollback. Returns {'success': True, 'target': sha} or {'error': str}."""
+    acquired, lock_fd = _acquire_update_lock()
+    if not acquired:
+        return {'error': 'Another update or rollback is already running'}
+    try:
+        target = _resolve_rollback_target()
+        if not target:
+            return {'error': 'No previous state to roll back to'}
+
+        rc, _, stderr = _git_run('reset', '--hard', target)
+        if rc != 0:
+            return {'error': f'Rollback failed: {stderr}'}
+
+        ok, detail = _repair_and_verify()
+        if not ok:
+            return {'error': f'Rolled back to {target[:8]} but {detail}'}
+
+        return {'success': True, 'target': target}
+    finally:
+        _release_update_lock(lock_fd)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -453,28 +667,21 @@ def start_update(tag=None) -> dict:
 def _run_update_thread(target):
     """Run the update in a background thread.
 
-    Flow: git fetch → git reset --hard <target>.
-    Progress is broadcast to SSE listeners via WebNotifier.
+    Applies the update via the shared apply_update pipeline (git → reinstall →
+    doctor --fix → smoke test → auto-rollback on failure). Progress is broadcast
+    to SSE listeners via WebNotifier at each pipeline phase so operators can see
+    which step is running during a long update. On success the user restarts via
+    the existing "Restart" action (unchanged two-step flow).
     """
     notifier = WebNotifier()
     current = _get_current_version() or 'unknown'
     notifier.begin(current, target)
 
     try:
-        # Step 1: Fetch from origin
-        notifier.send_progress(1, TOTAL_STEPS, 'Fetching updates from origin...')
-        rc, stdout, stderr = _git_run('fetch', 'origin')
-        if rc != 0:
-            notifier.send_failure(1, TOTAL_STEPS, f'Git fetch failed: {stderr}')
-            return
-
-        # Step 2: Reset to target ref
-        notifier.send_progress(2, TOTAL_STEPS, f'Applying update to {target}...')
-        # If target is a tag, use it directly; otherwise use origin/main
-        ref = target if target else 'origin/main'
-        rc, stdout, stderr = _git_run('reset', '--hard', ref)
-        if rc != 0:
-            notifier.send_failure(2, TOTAL_STEPS, f'Git reset failed: {stderr}')
+        result = apply_update(target, progress_cb=notifier.send_progress)
+        if 'error' in result:
+            step = result.get('failed_step', TOTAL_STEPS)
+            notifier.send_failure(step, TOTAL_STEPS, result['error'])
             return
 
         notifier.send_success(target)
@@ -501,28 +708,18 @@ def trigger_rollback() -> dict:
 
     def _do_rollback():
         try:
-            # Get the commit hash before the latest pull (HEAD@{1})
-            rc, prev_commit, _ = _git_run('rev-parse', 'HEAD@{1}')
-            if rc != 0:
+            result = apply_rollback()
+            if 'error' in result:
                 with _lock:
                     _state['status'] = 'failed'
-                    _state['error'] = 'No previous state to roll back to'
-                _append_log('error', 'Rollback failed: no previous state found')
-                _notify_listeners()
-                return
-
-            rc, stdout, stderr = _git_run('reset', '--hard', prev_commit)
-            if rc == 0:
+                    _state['error'] = result['error']
+                _append_log('error', f"Rollback failed: {result['error']}")
+            else:
                 with _lock:
                     _state['status'] = 'success'
                     _state['step_label'] = 'Rollback complete'
                     _state['current_version'] = _get_current_version()
-                _append_log('info', f'Rollback successful to {prev_commit[:8]}')
-            else:
-                with _lock:
-                    _state['status'] = 'failed'
-                    _state['error'] = f'Rollback failed: {stderr}'
-                _append_log('error', f'Rollback failed: {stderr}')
+                _append_log('info', f"Rollback successful to {result['target'][:8]}")
         except Exception as e:
             with _lock:
                 _state['status'] = 'failed'

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -2079,17 +2079,18 @@ def update_server(
     check_only=False, force=False, tag=None, rollback_flag=False, nightly=False
 ):
     """
-    Update evonic to the latest release tag, then repair the environment
-    with `evonic doctor --fix`.
+    Update evonic to the latest release tag via the shared apply pipeline
+    (reset → reinstall deps → doctor --fix → smoke test → auto-rollback on
+    failure), so the CLI and the web updater behave identically.
 
     In the flat-repo architecture, the project root IS the live directory.
 
     Modes:
     - check_only: fetch and report current version vs latest tag
-    - default: check out the latest vX.Y.Z tag GREATER than the current
-      version, then run `evonic doctor --fix`
-    - tag=X: check out a specific tag, then run `evonic doctor --fix`
+    - default: update to the latest vX.Y.Z tag GREATER than the current version
+    - tag=X: update to a specific tag
     - nightly: track origin/main instead of release tags
+    - rollback_flag: restore the previously recorded commit
     """
     import re
 
@@ -2133,14 +2134,17 @@ def update_server(
                 return line.strip(), ver
         return None, None
 
-    def _run_doctor_fix():
-        # Run via the wrapper so the freshly checked-out code is used.
-        print("\nRepairing environment (evonic doctor --fix)...")
-        evonic_bin = os.path.join(ROOT, "evonic")
-        proc = subprocess.run([evonic_bin, "doctor", "--fix"], cwd=ROOT)
-        if proc.returncode != 0:
-            print("doctor --fix reported problems. See output above.")
-            sys.exit(proc.returncode)
+    # Rollback to the previous version. Reuses the shared rollback core so the
+    # CLI and the web UI restore the same recorded commit and repair identically.
+    if rollback_flag:
+        print("Rolling back to the previous version...")
+        from backend import update_manager
+        result = update_manager.apply_rollback()
+        if "error" in result:
+            print(result["error"])
+            sys.exit(1)
+        print(f"Rollback complete — now at {result['target'][:8]}.")
+        return
 
     # Nightly channel: track origin/main instead of release tags.
     if nightly:
@@ -2155,12 +2159,12 @@ def update_server(
             print(f"Current     : {cur if rc == 0 else 'unknown'}")
             print(f"origin/main : {rem if rc2 == 0 else 'unknown'}")
             return
-        print("Resetting to origin/main...")
-        rc, _, err = _git(["reset", "--hard", "origin/main"])
-        if rc != 0:
-            print(f"Git reset failed: {err}")
+        print("Applying update (origin/main)...")
+        from backend import update_manager
+        result = update_manager.apply_update("origin/main")
+        if "error" in result:
+            print(result["error"])
             sys.exit(1)
-        _run_doctor_fix()
         print("Update complete.")
         return
 
@@ -2206,13 +2210,13 @@ def update_server(
         return
 
     print(f"Updating to {target_name}...")
-    rc, _, err = _git(["checkout", target_name])
-    if rc != 0:
-        print(f"Git checkout failed: {err}")
+    from backend import update_manager
+    result = update_manager.apply_update(target_name)
+    if "error" in result:
+        print(result["error"])
         print("Resolve local changes/conflicts, then re-run `evonic update`.")
         sys.exit(1)
 
-    _run_doctor_fix()
     print(f"Update complete — now at {target_name}.")
 
 

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -1,11 +1,8 @@
 import os
 import re
-import sys
 import sqlite3
 
 import logging
-import threading
-import time
 
 from flask import Blueprint, render_template, jsonify, request, redirect
 
@@ -16,11 +13,6 @@ from backend.skillsets import list_skillsets
 from backend.setup import (run_setup, test_connection, PROVIDER_DEFAULTS,
                             LANGUAGE_PRESETS, check_docker_available)
 import config
-
-# `resource` is a POSIX-only stdlib module — absent on Windows.
-# Guarded so the app can boot; restart-time FD cleanup is skipped there.
-if sys.platform != 'win32':
-    import resource
 
 dashboard_bp = Blueprint('dashboard', __name__)
 
@@ -73,24 +65,8 @@ def api_setup():
         _log = logging.getLogger(__name__)
         _log.info("Setup complete — scheduling auto-restart")
 
-        def _do_restart():
-            time.sleep(1.5)
-            try:
-                from backend.channels.registry import channel_manager
-                channel_manager.stop_all()
-                time.sleep(1.0)
-                if sys.platform != 'win32':
-                    maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                    if maxfd == resource.RLIM_INFINITY or maxfd > 65535:
-                        maxfd = 4096
-                    os.closerange(3, maxfd)
-            except Exception as e:
-                _log.error("Error during restart cleanup: %s", e, exc_info=True)
-            _log.info("Re-executing server process")
-            os.execv(sys.executable, [sys.executable] + sys.argv)
-
-        t = threading.Thread(target=_do_restart, daemon=True)
-        t.start()
+        from backend.restart import schedule_restart
+        schedule_restart()
 
         return jsonify(result)
 

--- a/unit_tests/test_agent_messaging.py
+++ b/unit_tests/test_agent_messaging.py
@@ -7,6 +7,7 @@ All external dependencies (db, notifier, approval_registry, event_stream)
 are mocked via unittest.mock.
 """
 import time
+import types
 import unittest
 import unittest.mock as mock
 import sys
@@ -69,25 +70,45 @@ def setup_module(module):
     # collection with the real Database instance attached.
     sys.modules.pop('backend.tools.agent_messaging', None)
 
-    sys.modules['models.db'] = mock.MagicMock(db=_mock_db)
-    # Stub the top-level `models` package but keep a real __path__ so genuine
-    # submodule imports (e.g. `from models.chatlog import ...` triggered when
-    # the autouse conftest fixture imports the full app) still resolve to the
-    # real files.  Without __path__ the bare MagicMock is "not a package" and
-    # any models.* submodule import raises ModuleNotFoundError.
-    _models_stub = mock.MagicMock()
-    _models_stub.__path__ = [os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'models')]
+    # Stubs are real types.ModuleType objects, not bare MagicMocks: a MagicMock
+    # raises AttributeError for unset dunders, and Python 3.14's import machinery
+    # reads parent.__spec__ when resolving `from models.X import ...`. ModuleType
+    # carries __spec__=None, so submodule resolution works; the behavioural mocks
+    # are attached as attributes so existing assertions are unchanged.
+    _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    _models_db_stub = types.ModuleType('models.db')
+    _models_db_stub.db = _mock_db
+    sys.modules['models.db'] = _models_db_stub
+
+    # Real __path__ so genuine submodule imports (e.g. `from models.chatlog
+    # import ...`, triggered when the autouse conftest fixture imports the full
+    # app) still resolve to the real files.
+    _models_stub = types.ModuleType('models')
+    _models_stub.__path__ = [os.path.join(_repo_root, 'models')]
+    # Submodules that conftest's isolate_agent_dirs fixture monkeypatches by
+    # name (models.chat / models.chatlog) must be present as attributes.
+    _models_stub.chat = mock.MagicMock()
+    _models_stub.chatlog = mock.MagicMock()
     sys.modules['models'] = _models_stub
-    sys.modules['backend.agent_runtime.notifier'] = _mock_notifier
-    sys.modules['backend.agent_runtime'] = mock.MagicMock()
-    sys.modules['backend.agent_runtime.approval'] = _mock_approval
+
+    _notifier_stub = types.ModuleType('backend.agent_runtime.notifier')
+    _notifier_stub.notify_agent = _mock_notifier.notify_agent
+    sys.modules['backend.agent_runtime.notifier'] = _notifier_stub
+
+    _approval_stub = types.ModuleType('backend.agent_runtime.approval')
+    _approval_stub.approval_registry = _mock_approval.approval_registry
+    sys.modules['backend.agent_runtime.approval'] = _approval_stub
+
+    _ar_stub = types.ModuleType('backend.agent_runtime')
+    _ar_stub.agent_runtime = mock.MagicMock()
+    _ar_stub.notifier = _notifier_stub
+    _ar_stub.approval = _approval_stub
+    sys.modules['backend.agent_runtime'] = _ar_stub
 
     # mock.patch traverses the real `backend` module via getattr, so we need
     # to expose the mocked submodules as attributes on the real package object.
-    _backend_pkg.agent_runtime = sys.modules['backend.agent_runtime']
-    _backend_pkg.agent_runtime.notifier = _mock_notifier
-    _backend_pkg.agent_runtime.approval = _mock_approval
+    _backend_pkg.agent_runtime = _ar_stub
 
 
 def teardown_module(module):

--- a/unit_tests/test_restart.py
+++ b/unit_tests/test_restart.py
@@ -1,0 +1,79 @@
+"""Tests for the shared in-place restart helper (backend.restart)."""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import backend.restart as restart
+
+
+class TestRestartInPlace(unittest.TestCase):
+    """restart_in_place() must stop channels + scheduler, then re-exec."""
+
+    def _patches(self, stop_all=None, shutdown=None):
+        """Build the common patch set; callers override stop_all/shutdown."""
+        channel_manager = mock.MagicMock()
+        channel_manager.stop_all = stop_all or mock.MagicMock()
+        scheduler = mock.MagicMock()
+        scheduler.shutdown = shutdown or mock.MagicMock()
+        registry = mock.MagicMock(channel_manager=channel_manager)
+        sched_mod = mock.MagicMock(scheduler=scheduler)
+        return channel_manager, scheduler, registry, sched_mod
+
+    def _run(self, registry, sched_mod, execv):
+        with mock.patch.dict(sys.modules, {
+            'backend.channels.registry': registry,
+            'backend.scheduler': sched_mod,
+        }), \
+                mock.patch.object(restart.time, 'sleep'), \
+                mock.patch.object(restart.os, 'execv', execv), \
+                mock.patch.object(restart.os, 'chdir'), \
+                mock.patch.object(restart.os, 'close_range', create=True), \
+                mock.patch.object(restart.os, 'closerange', create=True):
+            restart.restart_in_place(delay=0)
+
+    def test_stops_channels_scheduler_then_execs(self):
+        channel_manager, scheduler, registry, sched_mod = self._patches()
+        execv = mock.MagicMock()
+        self._run(registry, sched_mod, execv)
+
+        channel_manager.stop_all.assert_called_once()
+        scheduler.shutdown.assert_called_once()
+        execv.assert_called_once()
+        # Re-exec the interpreter against app.py.
+        args = execv.call_args[0]
+        self.assertTrue(args[1][-1].endswith('app.py'))
+
+    def test_execs_even_if_stop_all_fails(self):
+        """A channel-stop error must not prevent the re-exec."""
+        _, scheduler, registry, sched_mod = self._patches(
+            stop_all=mock.MagicMock(side_effect=RuntimeError('boom'))
+        )
+        execv = mock.MagicMock()
+        self._run(registry, sched_mod, execv)
+        execv.assert_called_once()
+
+    def test_execs_even_if_scheduler_shutdown_fails(self):
+        _, _, registry, sched_mod = self._patches(
+            shutdown=mock.MagicMock(side_effect=RuntimeError('boom'))
+        )
+        execv = mock.MagicMock()
+        self._run(registry, sched_mod, execv)
+        execv.assert_called_once()
+
+
+class TestScheduleRestart(unittest.TestCase):
+
+    def test_spawns_daemon_thread(self):
+        with mock.patch.object(restart.threading, 'Thread') as Thread:
+            restart.schedule_restart(delay=0)
+        Thread.assert_called_once()
+        self.assertEqual(Thread.call_args.kwargs['target'], restart.restart_in_place)
+        self.assertTrue(Thread.call_args.kwargs['daemon'])
+        Thread.return_value.start.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_update_manager.py
+++ b/unit_tests/test_update_manager.py
@@ -2,9 +2,11 @@
 import os
 import sys
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import backend.update_manager as um
 from backend.update_manager import _version_tuple
 
 
@@ -113,6 +115,107 @@ class TestVersionTuple(unittest.TestCase):
         self.assertLess(_version_tuple('v1.0.0-alpha.2'), _version_tuple('v1.0.0-beta'))
         self.assertLess(_version_tuple('v1.0.0-beta'), _version_tuple('v1.0.0-rc.1'))
         self.assertLess(_version_tuple('v1.0.0-rc.1'), _version_tuple('v1.0.0'))
+
+
+class TestApplyUpdate(unittest.TestCase):
+    """apply_update must reinstall, repair, smoke-test, and roll back on failure."""
+
+    def setUp(self):
+        # git: fetch ok, rev-parse HEAD -> 'oldsha', reset ok.
+        def fake_git(*args):
+            if args[0] == 'rev-parse':
+                return 0, 'oldsha', ''
+            return 0, '', ''
+        self._git = mock.patch.object(um, '_git_run', side_effect=fake_git)
+        self.git = self._git.start()
+        self.addCleanup(self._git.stop)
+        # Avoid touching the on-disk state file during apply_update.
+        self._rec = mock.patch.object(um, '_record_previous_commit')
+        self._rec.start()
+        self.addCleanup(self._rec.stop)
+        # doctor --fix is best-effort; keep it green and side-effect free.
+        self._doc = mock.patch.object(um, '_run_doctor_fix', return_value=(True, ''))
+        self._doc.start()
+        self.addCleanup(self._doc.stop)
+
+    def test_success(self):
+        with mock.patch.object(um, '_reinstall_deps', return_value=(True, '')), \
+                mock.patch.object(um, '_smoke_test', return_value=(True, '')):
+            result = um.apply_update('v1.2.3')
+        self.assertEqual(result, {'success': True})
+
+    def test_rolls_back_when_smoke_test_fails(self):
+        with mock.patch.object(um, '_reinstall_deps', return_value=(True, '')), \
+                mock.patch.object(um, '_smoke_test', return_value=(False, 'ImportError: boom')):
+            result = um.apply_update('v1.2.3')
+        self.assertIn('error', result)
+        # Last git call must be the rollback to the recorded prior commit.
+        self.git.assert_called_with('reset', '--hard', 'oldsha')
+
+    def test_rolls_back_when_deps_fail(self):
+        with mock.patch.object(um, '_reinstall_deps', return_value=(False, 'pip exploded')), \
+                mock.patch.object(um, '_smoke_test') as smoke:
+            result = um.apply_update('v1.2.3')
+        self.assertIn('error', result)
+        smoke.assert_not_called()  # never smoke-test if deps failed
+        self.git.assert_called_with('reset', '--hard', 'oldsha')
+
+    def test_records_previous_commit_before_reset(self):
+        with mock.patch.object(um, '_reinstall_deps', return_value=(True, '')), \
+                mock.patch.object(um, '_smoke_test', return_value=(True, '')):
+            um.apply_update('v1.2.3')
+        um._record_previous_commit.assert_called_once_with('oldsha')
+
+    def test_fetch_failure_aborts_before_changes(self):
+        with mock.patch.object(um, '_git_run', return_value=(1, '', 'network down')) as git, \
+                mock.patch.object(um, '_reinstall_deps') as deps:
+            result = um.apply_update('v1.2.3')
+        self.assertIn('error', result)
+        deps.assert_not_called()
+        # Only the fetch was attempted; no reset.
+        self.assertEqual(git.call_args_list[0][0][0], 'fetch')
+
+
+class TestRollback(unittest.TestCase):
+    """Rollback must be deterministic: prefer the recorded commit over reflog."""
+
+    def test_resolve_target_prefers_recorded_commit(self):
+        with mock.patch.object(um, '_load_persisted_state',
+                               return_value={'previous_commit': 'recorded'}):
+            self.assertEqual(um._resolve_rollback_target(), 'recorded')
+
+    def test_resolve_target_falls_back_to_reflog(self):
+        with mock.patch.object(um, '_load_persisted_state', return_value={}), \
+                mock.patch.object(um, '_git_run', return_value=(0, 'reflogsha', '')):
+            self.assertEqual(um._resolve_rollback_target(), 'reflogsha')
+
+    def test_resolve_target_empty_when_nothing_known(self):
+        with mock.patch.object(um, '_load_persisted_state', return_value={}), \
+                mock.patch.object(um, '_git_run', return_value=(1, '', 'no reflog')):
+            self.assertEqual(um._resolve_rollback_target(), '')
+
+    def test_apply_rollback_success(self):
+        with mock.patch.object(um, '_resolve_rollback_target', return_value='goodsha'), \
+                mock.patch.object(um, '_git_run', return_value=(0, '', '')) as git, \
+                mock.patch.object(um, '_repair_and_verify', return_value=(True, '')):
+            result = um.apply_rollback()
+        self.assertEqual(result, {'success': True, 'target': 'goodsha'})
+        git.assert_called_with('reset', '--hard', 'goodsha')
+
+    def test_apply_rollback_no_target(self):
+        with mock.patch.object(um, '_resolve_rollback_target', return_value=''), \
+                mock.patch.object(um, '_repair_and_verify') as repair:
+            result = um.apply_rollback()
+        self.assertIn('error', result)
+        repair.assert_not_called()
+
+    def test_apply_rollback_reports_repair_failure(self):
+        with mock.patch.object(um, '_resolve_rollback_target', return_value='goodsha'), \
+                mock.patch.object(um, '_git_run', return_value=(0, '', '')), \
+                mock.patch.object(um, '_repair_and_verify',
+                                  return_value=(False, 'ImportError: boom')):
+            result = um.apply_rollback()
+        self.assertIn('error', result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
> 📋 **Sequential PR series — 1 of 2**
> 1. **fix: restart/update reliability ← THIS PR** (base: `main`)
> 2. feat: evomem provisioning + Discord _(builds on this; opened after this merges)_
>
> A follow-up feature PR depends on this one (its dashboard auto-restart uses `backend/restart.py` introduced here). I'll open it after this merges so its diff stays clean. Happy to split/reorder per your preference.

---

Three correctness/reliability fixes for the self-update + restart path. Commits are kept separate for review.

### 1) `fix(restart)`: single in-place re-exec helper
**Problem.** The web Update "Restart" button (`update_manager.trigger_restart`) sent `SIGTERM` to the parent and assumed an external process manager (systemd/Docker) would respawn it. The documented install path is `evonic start -d`, which spawns `python app.py` detached with **no** supervisor; `AgentRuntime._signal_handler` turns SIGTERM into `sys.exit(0)`, so the server stayed **down** with a stale PID file. Three other restart paths (`/restart`, super-agent restart tool, web setup auto-restart) already re-exec'd in place, but that logic was copy-pasted with subtle drift — which is how the broken fourth copy went unnoticed. None of them shut the scheduler down.

**Change.** New `backend/restart.py` as the single source of truth (`restart_in_place` / `schedule_restart`): stop channels (so Telegram releases its long-poll before re-bind), shut down the scheduler, free inherited FDs, then `os.execv` against `app.py` — preserving the PID the lock/PID file point to, so it works with or without a process manager. All four call sites repointed, each keeping only its own pre-restart bookkeeping.

### 2) `fix(update)`: health-gated update + deterministic rollback
**Problem.** The web updater ran `git fetch` + `git reset --hard` only — no dependency reinstall (an upstream requirement bump broke the next boot) and no check that the new tree imports. The CLI did git + `doctor --fix` but also no deps reinstall, and hard-failed if doctor returned non-zero. Rollback reset to the reflog's `HEAD@{1}`, which a failed-update auto-rollback corrupts, and `evonic update --rollback` was a dead flag.

**Change.** One shared, health-gated pipeline used by both web and CLI: `reset --hard <ref>` → reinstall requirements → `doctor --fix` → import smoke test. deps and the smoke test are gating; on failure the tree resets back to the recorded prior commit (auto-rollback), so a broken update never takes the running server down. `doctor --fix` is best-effort (logged, non-gating) — the smoke test is the real boot gate. The smoke test runs `import app` in a subprocess with `EVONIC_SMOKE_TEST=1` (skips channel/scheduler startup; `app.run()` is under `__main__`), so it has no side effects on the live server. Rollback is deterministic (recorded `previous_commit`; reflog kept as fallback) and `--rollback` is wired. The two-step UX is preserved (update applies code; the admin restarts via the now-working action); super-agent/supervisor flows are unchanged.

### 3) `fix(tests)`: Python 3.14 compatibility for `agent_messaging`
**Problem.** `setup_module` replaced `models` / `backend.agent_runtime` with bare `MagicMock`s; Python 3.14's import machinery reads `parent.__spec__` while resolving `from models.X import ...`, and MagicMock raises `AttributeError` for unset dunders — 61 errors at setup.

**Change.** Use `types.ModuleType` stand-ins (`__spec__=None`) and attach the behavioural mocks as attributes; assertions unchanged. Test-only.

### Why it's safe
- Restart **decision logic is untouched** — inter-agent approval guard, `restart_ready_needed` / `restart_greeting_needed`, and context capture; only the `_do_restart` mechanics moved into the shared helper. `[python, app.py]` equals the daemon's real argv; `scheduler.shutdown()` is additive (guarded).
- Update keeps the deliberate two-step UX; no auto-restart introduced.
- The test change is portable (no 3.14-only idiom) and raises nothing about the minimum Python.

### Test plan
- Full unit suite: **1093 passed / 0 failed** on **Python 3.10 and 3.14** (this fixes `main`'s 61 errors).
- Manual: web "Restart Now" under `evonic start -d` returns on the same PID/port; restart twice with Telegram enabled → no `Conflict`; simulated broken update → auto-rollback, live server stays up; `evonic update --rollback` restores the prior commit.
