### PR TITLE
feat: evomem auto-provisioning + setup wizard + Discord channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,13 @@ EVONIC_SESSION_ARCHIVE=0
 # verify the new code imports cleanly without touching the live server's port or DB
 # connections. Not intended for production use.
 # EVONIC_SMOKE_TEST=
+
+# Memory engine: "evomem" (default, graph-backed; requires the evomem binary) or
+# "fts5" (SQLite full-text fallback, no binary needed). The installer fetches the
+# evomem binary automatically; otherwise run `evonic evomem install`. When evomem
+# is selected but the binary is absent, the runtime transparently uses FTS5.
+EVONIC_MEMORY_ENGINE=evomem
+# Pin a specific evomem release tag (default: latest). e.g. EVOMEM_VERSION=v0.2.0
+# EVOMEM_VERSION=
+# Override the evomem binary path (default: shared/bin/evomem).
+# EVOMEM_BINARY=

--- a/backend/evomem_provision.py
+++ b/backend/evomem_provision.py
@@ -1,0 +1,215 @@
+"""
+evomem_provision.py -- download and install the evomem memory-engine binary.
+
+Single source of truth for provisioning the evomem binary. Shared by the
+installer (install.sh), the `evonic evomem install` command, `evonic doctor --fix`,
+and first-run setup so the provisioning surfaces stay in sync.
+
+By default the latest release is resolved dynamically from the GitHub Releases
+API; set EVOMEM_VERSION to a tag (e.g. "v0.2.0") to pin a specific release.
+Integrity is verified by comparing the downloaded asset against the SHA-256
+digest reported by the same TLS-protected API response, and the binary is
+installed atomically. Any failure leaves the existing state untouched — the
+runtime transparently falls back to FTS5 when the binary is absent (see
+evomem_client.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import os
+import platform
+import sys
+import tempfile
+import zipfile
+import zlib
+from typing import Dict, Optional
+
+import requests
+
+_logger = logging.getLogger(__name__)
+
+# Repo root, so `shared/bin/...` resolves regardless of the working directory.
+# Mirrors the anchor used by evomem_client._resolve_binary(); kept local here to
+# avoid importing backend.agent_runtime (which spins up the runtime at import).
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+EVOMEM_REPO = "anvie/evomem"
+
+# Platform -> substring identifying the matching release asset (Rust target
+# triple). Asset names are matched by substring, so new arches added to a future
+# release are picked up automatically; an unmatched platform falls back to FTS5.
+_ASSET_PATTERNS: Dict[tuple, str] = {
+    ("linux", "x86_64"): "x86_64-unknown-linux-musl",
+    ("linux", "arm64"): "aarch64-unknown-linux-musl",
+    ("darwin", "x86_64"): "x86_64-apple-darwin",
+    ("darwin", "arm64"): "aarch64-apple-darwin",
+}
+
+# Name of the binary inside the release zip and on disk.
+_BINARY_NAME = "evomem"
+_API_TIMEOUT = 20
+_DOWNLOAD_TIMEOUT = 60
+
+
+def default_binary_path() -> str:
+    """Canonical install path for the evomem binary: <repo>/shared/bin/evomem."""
+    return os.path.join(_BASE_DIR, "shared", "bin", _BINARY_NAME)
+
+
+def _normalize_arch(machine: str) -> str:
+    m = machine.lower()
+    if m in ("x86_64", "amd64"):
+        return "x86_64"
+    if m in ("arm64", "aarch64"):
+        return "arm64"
+    return m
+
+
+def _asset_pattern() -> Optional[str]:
+    """Return the asset-name substring for the current platform, or None."""
+    return _ASSET_PATTERNS.get((platform.system().lower(), _normalize_arch(platform.machine())))
+
+
+def _api_headers() -> Dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "evonic-evomem-provision",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_release(version: Optional[str]) -> dict:
+    """Fetch release metadata from the GitHub API (latest, or a pinned tag)."""
+    base = f"https://api.github.com/repos/{EVOMEM_REPO}/releases"
+    url = f"{base}/tags/{version}" if version else f"{base}/latest"
+    resp = requests.get(url, headers=_api_headers(), timeout=_API_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _extract_binary(zip_bytes: bytes) -> bytes:
+    """Return the evomem binary bytes from the release zip.
+
+    Reads the named member into memory; never writes zip-controlled paths, so
+    there is no archive path-traversal exposure.
+    """
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        member = None
+        for name in zf.namelist():
+            if not name.endswith("/") and os.path.basename(name) == _BINARY_NAME:
+                member = name
+                break
+        if member is None:
+            raise ValueError(f"release zip does not contain a '{_BINARY_NAME}' binary")
+        return zf.read(member)
+
+
+def _atomic_install(binary: bytes, dest: str) -> None:
+    """Write the binary to a temp file in the destination dir, chmod, then rename."""
+    dest_dir = os.path.dirname(dest)
+    os.makedirs(dest_dir, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=dest_dir, prefix=".evomem-")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(binary)
+        os.chmod(tmp, 0o755)
+        os.replace(tmp, dest)
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def _fail(msg: str) -> Dict[str, object]:
+    _logger.error(msg)
+    return {"ok": False, "installed": False, "version": None, "msg": msg}
+
+
+def ensure_evomem(force: bool = False, version: Optional[str] = None) -> Dict[str, object]:
+    """Ensure the evomem binary is installed at the canonical path.
+
+    Resolves the latest release by default; pass a tag (or set EVOMEM_VERSION) to
+    pin a specific version. Returns {ok, installed, version, msg}. Never raises —
+    on any failure (unsupported platform, network error, missing digest, checksum
+    mismatch) returns ok=False so callers keep going (FTS5 fallback). Idempotent:
+    skips when a binary is already present unless force=True.
+    """
+    dest = default_binary_path()
+
+    if not force and os.path.isfile(dest) and os.access(dest, os.X_OK):
+        return {"ok": True, "installed": False, "version": None,
+                "msg": f"evomem already present at {dest}"}
+
+    pattern = _asset_pattern()
+    if pattern is None:
+        return _fail(f"No prebuilt evomem for {platform.system()}/{platform.machine()}; "
+                     f"memory engine will use FTS5.")
+
+    version = version or os.environ.get("EVOMEM_VERSION") or None
+    try:
+        release = _fetch_release(version)
+    except Exception as e:
+        return _fail(f"Failed to query {EVOMEM_REPO} releases: {e}")
+
+    tag = release.get("tag_name") or version or "unknown"
+    asset = next(
+        (a for a in release.get("assets", [])
+         if pattern in a.get("name", "") and a.get("name", "").endswith(".zip")),
+        None,
+    )
+    if asset is None:
+        return _fail(f"Release {tag} has no evomem asset for this platform "
+                     f"({pattern}); memory engine will use FTS5.")
+
+    digest = asset.get("digest") or ""
+    if not digest.startswith("sha256:"):
+        return _fail(f"Release asset {asset.get('name')} has no sha256 digest; "
+                     f"refusing to install an unverified binary.")
+    expected_sha = digest.split(":", 1)[1]
+    url = asset.get("browser_download_url")
+    if not url:
+        return _fail(f"Release asset {asset.get('name')} has no download URL.")
+
+    try:
+        resp = requests.get(url, timeout=_DOWNLOAD_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.content
+    except Exception as e:
+        return _fail(f"Failed to download evomem from {url}: {e}")
+
+    actual_sha = hashlib.sha256(data).hexdigest()
+    if actual_sha != expected_sha:
+        return _fail(f"evomem checksum mismatch for {asset.get('name')}: "
+                     f"expected {expected_sha}, got {actual_sha}. Aborting install.")
+
+    try:
+        binary = _extract_binary(data)
+    except (zipfile.BadZipFile, zlib.error, ValueError) as e:
+        return _fail(f"Failed to extract evomem binary from {asset.get('name')}: {e}")
+
+    try:
+        _atomic_install(binary, dest)
+    except OSError as e:
+        return _fail(f"Failed to install evomem to {dest}: {e}")
+
+    _logger.info("Installed evomem %s to %s", tag, dest)
+    return {"ok": True, "installed": True, "version": tag,
+            "msg": f"Installed evomem {tag} to {dest}"}
+
+
+def main() -> int:
+    """Entry point for `python -m backend.evomem_provision` (used by install.sh)."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    result = ensure_evomem(force="--force" in sys.argv)
+    print(result["msg"])
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -503,6 +503,20 @@ def run_setup(
             env_path = os.path.join(config.BASE_DIR, ".env")
             _update_env_var(env_path, "ADMIN_PASSWORD_HASH", pw_hash)
 
+        # Memory-engine awareness: surface whether evomem is ready or FTS5 is used.
+        try:
+            import logging
+            from backend.evomem_provision import default_binary_path
+            binary = default_binary_path()
+            ready = os.path.isfile(binary) and os.access(binary, os.X_OK)
+            logging.getLogger(__name__).info(
+                "Setup complete. Memory engine: %s",
+                "evomem (binary ready)" if ready else
+                "FTS5 fallback — evomem binary not installed; run 'evonic evomem install'",
+            )
+        except Exception:
+            pass
+
         return {"success": True, "agent_id": agent_id}
 
     except Exception as e:

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -32,6 +32,7 @@ from cli.commands import (
     clear_sandbox,
     update_server, pass_setup,
     doctor_command,
+    evomem_install,
     backup_command, restore_command, verify_command, list_command,
 )
 
@@ -126,6 +127,26 @@ def main():
     doctor_parser.add_argument(
         "--with-llm-provider", action="store_true", default=False,
         help="Include LLM provider connectivity check (slow, network-dependent)",
+    )
+
+    # --- evomem ---
+    evomem_parser = subparsers.add_parser(
+        "evomem",
+        help="Manage the evomem memory-engine binary",
+        description="Provision the evomem memory-engine binary. Available subcommands: install.",
+    )
+    evomem_subparsers = evomem_parser.add_subparsers(
+        dest="evomem_command", help="Evomem management commands"
+    )
+    evomem_install_parser = evomem_subparsers.add_parser(
+        "install",
+        help="Download and install the evomem binary (latest release)",
+        description="Download, verify, and install the evomem binary from the latest "
+                    "GitHub release. Set EVOMEM_VERSION to pin a specific tag.",
+    )
+    evomem_install_parser.add_argument(
+        "--force", action="store_true", default=False,
+        help="Reinstall even if a binary is already present",
     )
 
     # --- plugin ---
@@ -832,6 +853,12 @@ def main():
         restart_server()
     elif args.command == "doctor":
         doctor_command(quick=args.quick, fix=args.fix, with_llm_provider=args.with_llm_provider)
+    elif args.command == "evomem":
+        if args.evomem_command is None:
+            evomem_parser.print_help()
+            sys.exit(0)
+        elif args.evomem_command == "install":
+            sys.exit(evomem_install(force=args.force))
     elif args.command == "plugin":
         if args.plugin_command is None:
             plugin_parser.print_help()

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -2157,6 +2157,26 @@ def setup_command(non_interactive=False):
         print(f"\n  Error: {result['error']}")
         sys.exit(1)
 
+    # --- Memory engine (evomem) ---
+    # Offered interactively only (default yes). Headless/scripted runs
+    # (--non-interactive) skip the prompt; install.sh provisions evomem directly
+    # via `python -m backend.evomem_provision`. ensure_evomem() is idempotent, so
+    # the prompt is safe even when the installer already fetched the binary.
+    if not non_interactive:
+        try:
+            reply = input("\n  Install evomem memory engine? [Y/n]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            reply = ""
+        if reply not in ("n", "no"):
+            print("  Installing evomem memory engine...")
+            from backend.evomem_provision import ensure_evomem
+            ev = ensure_evomem()
+            if ev["ok"]:
+                _ok(ev["msg"]) if ev["installed"] else _info(ev["msg"])
+            else:
+                _warn(ev["msg"])
+                _info("Run 'evonic evomem install' to retry.")
+
     print(f"\n  Setup complete! Super agent '{result['agent_id']}' created.")
     print(f"  Run 'evonic start -d' to start the platform.")
     print()

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -2436,6 +2436,17 @@ def _info(msg):
     print(f"  {_INFO}  {msg}")
 
 
+def evomem_install(force=False):
+    """Download and install the evomem memory-engine binary (latest release)."""
+    from backend.evomem_provision import ensure_evomem
+    result = ensure_evomem(force=force)
+    if result["ok"]:
+        _ok(result["msg"]) if result["installed"] else _info(result["msg"])
+    else:
+        _warn(result["msg"])
+    return 0 if result["ok"] else 1
+
+
 def doctor_command(quick=False, fix=False, with_llm_provider=False):
     """Run comprehensive system health diagnostics."""
     import importlib
@@ -3111,11 +3122,24 @@ def doctor_command(quick=False, fix=False, with_llm_provider=False):
         binary_ok = os.path.isfile(binary_full) and os.access(binary_full, os.X_OK)
 
         # Check custom EVOMEM_BINARY path
-        if "EVOMEM_BINARY" in os.environ and not binary_ok:
+        custom_binary = "EVOMEM_BINARY" in os.environ
+        if custom_binary and not binary_ok:
             results.append(_warn(
                 f"EVOMEM_BINARY is set to '{binary_path}' but binary not found "
                 f"or not executable at {binary_full}"
             ))
+
+        # Fix: auto-download and install the binary before judging the result, so a
+        # single `doctor --fix` run reports the post-install state. Skipped when the
+        # user points EVOMEM_BINARY at a path they manage themselves.
+        if fix and not binary_ok and engine != "fts5" and not custom_binary:
+            from backend.evomem_provision import ensure_evomem
+            result = ensure_evomem()
+            if result["ok"] and result["installed"]:
+                fixes_applied.append(f"Installed evomem {result['version']} to {binary_full}")
+            elif not result["ok"]:
+                _info(f"  {result['msg']}")
+            binary_ok = os.path.isfile(binary_full) and os.access(binary_full, os.X_OK)
 
         if engine == "fts5":
             _info("  Memory engine is FTS5 (evomem not used)")
@@ -3124,26 +3148,16 @@ def doctor_command(quick=False, fix=False, with_llm_provider=False):
         elif engine_explicit:
             results.append(_fail(
                 f"EVONIC_MEMORY_ENGINE=evomem is set but binary not found at "
-                f"{binary_full}. Set EVONIC_MEMORY_ENGINE=fts5 to use fallback, "
-                f"or install the evomem binary."
+                f"{binary_full}. Run 'evonic evomem install' or 'evonic doctor --fix' "
+                f"to install it, or set EVONIC_MEMORY_ENGINE=fts5 to use the fallback."
             ))
         else:
             results.append(_warn(
                 f"Evomem is the default memory engine but binary not found at "
-                f"{binary_full}. Evomem features (think, graph_query) will "
+                f"{binary_full}. Run 'evonic evomem install' (or 'evonic doctor --fix') "
+                f"to install it; until then evomem features (think, graph_query) "
                 f"silently fall back to FTS5."
             ))
-
-        # Fix: provide actionable message + create directory if needed
-        if not binary_ok and engine != "fts5" and fix:
-            _info(
-                "  To install evomem: place the static binary at "
-                "shared/bin/evomem and make it executable (chmod +x)."
-            )
-            bin_dir = os.path.dirname(binary_full)
-            if not os.path.isdir(bin_dir):
-                os.makedirs(bin_dir, exist_ok=True)
-                fixes_applied.append(f"Created directory {bin_dir} for evomem binary")
 
     except Exception as e:
         results.append(_fail(f"Evomem check failed: {e}"))

--- a/install.sh
+++ b/install.sh
@@ -204,6 +204,14 @@ install_deps() {
     "$py" -m pip install --upgrade pip --quiet
     "$py" -m pip install -r "$EVONIC_HOME/requirements.txt"
     ok "Dependencies installed"
+
+    # Provision the evomem memory-engine binary (best-effort: unsupported
+    # platforms or network issues fall back to FTS5, so never fail the install).
+    if (cd "$EVONIC_HOME" && "$py" -m backend.evomem_provision) >/dev/null 2>&1; then
+        ok "Evomem memory engine installed"
+    else
+        warn "Evomem binary not installed (unsupported platform or network issue); using FTS5 fallback"
+    fi
 }
 
 # ── Step 5: Create CLI wrapper script ────────────────────────────────────────

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -3,6 +3,7 @@ import re
 import sqlite3
 
 import logging
+import threading
 
 from flask import Blueprint, render_template, jsonify, request, redirect
 
@@ -46,6 +47,7 @@ def api_setup():
         sandbox_enabled = data.get('sandbox_enabled', False)
         if 'sandbox_enabled' not in data:
             sandbox_enabled = check_docker_available().get('available', False)
+        install_evomem = data.get('install_evomem', True)
         result = run_setup(
             provider=data.get('provider', ''),
             model_name=data.get('model_name', '').strip(),
@@ -65,8 +67,17 @@ def api_setup():
         _log = logging.getLogger(__name__)
         _log.info("Setup complete — scheduling auto-restart")
 
-        from backend.restart import schedule_restart
-        schedule_restart()
+        def _provision_then_restart():
+            if install_evomem:
+                try:
+                    from backend.evomem_provision import ensure_evomem
+                    ensure_evomem()
+                except Exception as e:
+                    _log.error("evomem provisioning failed: %s", e)
+            from backend.restart import restart_in_place
+            restart_in_place()
+
+        threading.Thread(target=_provision_then_restart, daemon=True).start()
 
         return jsonify(result)
 

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -171,6 +171,18 @@
                         </div>
                     </div>
 
+                    <!-- Memory engine -->
+                    <div class="flex items-start gap-3 pt-1">
+                        <input type="checkbox" id="install-evomem" checked
+                            class="mt-0.5 accent-indigo-600 cursor-pointer">
+                        <div>
+                            <label for="install-evomem" class="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+                                Install evomem memory engine <span class="text-xs text-gray-400 dark:text-gray-500 font-normal">(recommended)</span>
+                            </label>
+                            <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Enables semantic memory and graph features. Falls back to FTS5 if unavailable.</p>
+                        </div>
+                    </div>
+
                     <div class="flex justify-between pt-2">
                         <button id="s2-back" type="button"
                             class="px-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
@@ -218,6 +230,10 @@
                         <div class="flex justify-between px-4 py-3">
                             <span class="text-gray-500 dark:text-gray-400 font-medium">Language</span>
                             <span id="review-language" class="text-gray-900 dark:text-gray-100"></span>
+                        </div>
+                        <div class="flex justify-between px-4 py-3">
+                            <span class="text-gray-500 dark:text-gray-400 font-medium">Memory Engine</span>
+                            <span id="review-evomem" class="text-gray-900 dark:text-gray-100"></span>
                         </div>
                     </div>
 
@@ -429,6 +445,7 @@ function populateReview() {
     $('#review-agent-name').text($('#agent-name').val().trim());
     $('#review-agent-id').text($('#agent-id').val().trim());
     $('#review-language').text((LANGUAGES[language] || {}).label || language);
+    $('#review-evomem').text($('#install-evomem').prop('checked') ? 'evomem (install)' : 'FTS5 (skip install)');
 }
 
 // ---- Submit ----
@@ -447,6 +464,7 @@ function submitSetup() {
         language: $('input[name="language"]:checked').val(),
         description: '',
         password: $('#password').val(),
+        install_evomem: $('#install-evomem').prop('checked'),
     };
 
     $.ajax({

--- a/unit_tests/test_evomem_provision.py
+++ b/unit_tests/test_evomem_provision.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for backend.evomem_provision.
+
+Network access is fully mocked: _fetch_release and requests.get are patched so no
+real GitHub call or download occurs.
+"""
+import hashlib
+import io
+import os
+import zipfile
+
+from backend import evomem_provision as ep
+
+
+def _make_zip(binary=b"#!/bin/sh\necho evomem\n", member="evomem"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(member, binary)
+    return buf.getvalue()
+
+
+class _Resp:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+def _release(name, sha=None, url="https://example.invalid/evomem.zip", tag="v9.9.9"):
+    asset = {"name": name, "browser_download_url": url}
+    if sha is not None:
+        asset["digest"] = "sha256:" + sha
+    return {"tag_name": tag, "assets": [asset]}
+
+
+def test_default_binary_path():
+    assert ep.default_binary_path().endswith(os.path.join("shared", "bin", "evomem"))
+
+
+def test_normalize_arch():
+    assert ep._normalize_arch("AMD64") == "x86_64"
+    assert ep._normalize_arch("x86_64") == "x86_64"
+    assert ep._normalize_arch("aarch64") == "arm64"
+    assert ep._normalize_arch("arm64") == "arm64"
+
+
+def test_asset_pattern_known_platform(monkeypatch):
+    monkeypatch.setattr(ep.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ep.platform, "machine", lambda: "x86_64")
+    assert ep._asset_pattern() == "x86_64-unknown-linux-musl"
+
+
+def test_idempotent_skip_when_present(tmp_path, monkeypatch):
+    dest = tmp_path / "evomem"
+    dest.write_bytes(b"x")
+    os.chmod(dest, 0o755)
+    monkeypatch.setattr(ep, "default_binary_path", lambda: str(dest))
+    result = ep.ensure_evomem()
+    assert result["ok"] and not result["installed"]
+
+
+def test_unsupported_platform_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setattr(ep, "default_binary_path", lambda: str(tmp_path / "evomem"))
+    monkeypatch.setattr(ep, "_asset_pattern", lambda: None)
+    result = ep.ensure_evomem()
+    assert not result["ok"]
+    assert "FTS5" in result["msg"]
+
+
+def test_checksum_mismatch_aborts_install(tmp_path, monkeypatch):
+    dest = tmp_path / "evomem"
+    monkeypatch.setattr(ep, "default_binary_path", lambda: str(dest))
+    monkeypatch.setattr(ep, "_asset_pattern", lambda: "x86_64-unknown-linux-musl")
+    monkeypatch.setattr(ep, "_fetch_release",
+                        lambda v: _release("evomem-x86_64-unknown-linux-musl.zip", sha="0" * 64))
+    monkeypatch.setattr(ep.requests, "get", lambda url, timeout=0: _Resp(_make_zip()))
+    result = ep.ensure_evomem(force=True)
+    assert not result["ok"]
+    assert "checksum mismatch" in result["msg"]
+    assert not dest.exists()
+
+
+def test_missing_digest_fails_closed(tmp_path, monkeypatch):
+    dest = tmp_path / "evomem"
+    monkeypatch.setattr(ep, "default_binary_path", lambda: str(dest))
+    monkeypatch.setattr(ep, "_asset_pattern", lambda: "x86_64-unknown-linux-musl")
+    monkeypatch.setattr(ep, "_fetch_release",
+                        lambda v: _release("evomem-x86_64-unknown-linux-musl.zip", sha=None))
+    result = ep.ensure_evomem(force=True)
+    assert not result["ok"]
+    assert "digest" in result["msg"]
+    assert not dest.exists()
+
+
+def test_successful_install(tmp_path, monkeypatch):
+    dest = tmp_path / "bin" / "evomem"
+    binary = b"\x7fELF fake evomem binary"
+    zip_bytes = _make_zip(binary)
+    sha = hashlib.sha256(zip_bytes).hexdigest()
+    monkeypatch.setattr(ep, "default_binary_path", lambda: str(dest))
+    monkeypatch.setattr(ep, "_asset_pattern", lambda: "x86_64-unknown-linux-musl")
+    monkeypatch.setattr(ep, "_fetch_release",
+                        lambda v: _release("evomem-1.2.3-x86_64-unknown-linux-musl.zip",
+                                           sha=sha, tag="v1.2.3"))
+    monkeypatch.setattr(ep.requests, "get", lambda url, timeout=0: _Resp(zip_bytes))
+    result = ep.ensure_evomem(force=True)
+    assert result["ok"] and result["installed"]
+    assert result["version"] == "v1.2.3"
+    assert dest.exists() and os.access(dest, os.X_OK)
+    assert dest.read_bytes() == binary


### PR DESCRIPTION
> 📋 **Sequential PR series — 2 of 2** · **depends on #75**
> 1. #75 — fix: restart/update reliability _(merge first)_
> 2. **feat: evomem provisioning + Discord ← THIS PR**
>
> ⚠️ **Stacked on #75.** Until #75 is merged, the diff below also includes #75's
> 3 fix commits. The **3 commits that belong to this PR** are:
> - `ad1727d` feat(evomem): auto-provision the memory-engine binary
> - `02b7386` feat(setup): add evonic setup CLI wizard with evomem provisioning
> - `76566c2` feat: add Discord channel support
>
> This PR's dashboard auto-restart reuses `backend/restart.py` from #75. Once #75
> merges I'll rebase onto the updated `main` and the diff will narrow to just the
> 3 feat commits. Happy to hold review until then.

---

Two additive features (commits kept separate for review).

### 1) `feat(evomem)`: auto-provision the memory-engine binary
**Problem.** The memory engine defaults to evomem, but nothing installed the binary, so fresh installs silently fell back to FTS5; installer, doctor, and setup were inconsistent about it.

**Change.** `backend/evomem_provision.py` as the single source of truth: resolve the latest release via the GitHub API (`EVOMEM_VERSION` pins a tag), verify the download against the API-reported SHA-256, install atomically. On any failure (unsupported platform, network, checksum) it returns cleanly and the runtime keeps using FTS5. Wired through every surface: CLI `evonic evomem install [--force]`; `doctor --fix` (installs before judging the memory-engine check, instead of only creating the directory); `install.sh` (best-effort, non-fatal); `setup` (logs whether evomem is ready or FTS5 will be used); `.env.example` documents `EVONIC_MEMORY_ENGINE` / `EVOMEM_VERSION` / `EVOMEM_BINARY`.

### 2) `feat(setup)`: `evonic setup` CLI wizard
**Problem.** `install.sh` called `evonic setup`, but no such subcommand existed — under `set -e` the installer exited non-zero, leaving fresh installs unconfigured.

**Change.** Implement `setup_command()` — an interactive first-time wizard (LLM provider, model, agent name/ID, language, admin password, and an optional evomem step, default yes; reads stdin from `/dev/tty` so it works when piped via `curl | bash`). Register the `setup` subparser. The web setup wizard (`templates/setup.html`) gains an evomem checkbox (checked by default) + a Review row; `routes/dashboard.py` reads `install_evomem` and calls `ensure_evomem()` in the background restart thread so the download never blocks the HTTP response. **Discord is intentionally absent from the wizard.**

### 3) `feat`: Discord channel support
**Change.** `DiscordChannel(BaseChannel)` on discord.py — an async client on a daemon thread (mirrors the Telegram channel). Listens to DMs and to guild messages that @mention the bot, routes through the agent runtime, and replies in the originating channel. Reuses the shared pairing/allowlist flow, outbound buffering, typing indicator, and approval prompts (rendered as `discord.ui` buttons). Media: image vision, file send, attachment persistence, gated by the agent's attachment config and per-type size limits. Registered `'discord'` in `CHANNEL_TYPES`; adds `discord.py>=2.3`. `doctor` gains a channel-integrations check (verifies the library is present for configured channels; notes the required Message Content Intent). UI: a setup hint under the Discord bot-token field. Requires the privileged **Message Content Intent**.

### Why it's safe
- Additive — new modules/commands; existing paths intact. No `models/` (db) schema changes.
- evomem provisioning is **opt-in** (default yes) and **best-effort** with a clean FTS5 fallback; no surface fails when the binary can't be installed.
- Discord reuses the existing channel registry/pattern; `doctor --fix`'s evomem step uses the single `ensure_evomem()` (no redundant directory stub).
- The dashboard auto-restart reuses the SSOT from #75.

### Test plan
- Full unit suite green on **Python 3.10 and 3.14** (`test_evomem_provision`, `test_discord_channel` included; network mocked).
- `install.sh`'s evomem step verified end-to-end: `python -m backend.evomem_provision` downloads + installs **evomem v0.2.0** (best-effort, FTS5 fallback otherwise).
- CLI exercised: `evonic setup`, `evonic evomem install`, `doctor --quick` (memory-engine + channel-integrations checks) all run cleanly.
