### PR TITLE
Add kanban_bulk_create_tasks tool for batch task creation

### DIFF
--- a/skills/kanban/backend/tools/kanban_bulk_create_tasks.py
+++ b/skills/kanban/backend/tools/kanban_bulk_create_tasks.py
@@ -1,0 +1,105 @@
+"""
+Kanban bulk create tool — create several tasks on the board in a single call.
+
+Why this exists: when asked to create multiple tasks at once (e.g. a plan of
+9B/9C/9D), the model naturally reaches for a single "bulk create" call. Without
+this tool it hallucinates a non-existent ``kanban_bulk_create_tasks``, the quality
+monitor rejects it, and after the correction cap the model often gives up and
+falsely reports a "board/registry error" — so the tasks never get made. Providing
+the real tool removes that failure at the source.
+
+It wraps ``kanban_create_task.execute`` for each item so permission checks,
+validation, and single-task dependency handling stay identical. Intra-batch
+dependencies are supported via ``depends_on_index`` (1-based index of an earlier
+task in the same ``tasks`` array), resolved to the real task id once that task is
+created — so 9C/9D can depend on 9B without knowing ids in advance.
+"""
+
+import importlib.util
+import os
+
+_MAX_BATCH = 50
+_create_one = None  # cached reference to the single-create execute()
+
+
+def _single_create():
+    """Load the sibling kanban_create_task tool by path (skills/ is not a package)."""
+    global _create_one
+    if _create_one is None:
+        here = os.path.dirname(__file__)
+        path = os.path.join(here, "kanban_create_task.py")
+        spec = importlib.util.spec_from_file_location("kanban_create_task_sibling", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _create_one = module.execute
+    return _create_one
+
+
+def execute(agent: dict, args: dict) -> dict:
+    tasks = args.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        return {"status": "error", "message": "tasks must be a non-empty array of task objects"}
+    if len(tasks) > _MAX_BATCH:
+        return {"status": "error", "message": f"cannot create more than {_MAX_BATCH} tasks in one call"}
+
+    create_one = _single_create()
+
+    batch_ids = []   # index -> created task id (or None on failure)
+    results = []
+    errors = []
+
+    for i, t in enumerate(tasks):
+        if not isinstance(t, dict):
+            msg = "each task must be an object"
+            batch_ids.append(None)
+            results.append({"status": "error", "index": i, "message": msg})
+            errors.append({"index": i, "message": msg})
+            continue
+
+        item = dict(t)
+        deps = list(item.get("dependencies") or [])
+
+        # Resolve intra-batch dependencies (1-based indices into this array).
+        doi = item.pop("depends_on_index", None)
+        if doi:
+            try:
+                for idx in (doi if isinstance(doi, list) else [doi]):
+                    ref = batch_ids[int(idx) - 1]
+                    if ref is None:
+                        raise ValueError(f"depends_on_index {idx} refers to a task that was not created")
+                    deps.append(ref)
+            except (ValueError, TypeError, IndexError) as e:
+                msg = f"invalid depends_on_index: {e}"
+                batch_ids.append(None)
+                results.append({"status": "error", "index": i, "message": msg, "title": item.get("title")})
+                errors.append({"index": i, "message": msg, "title": item.get("title")})
+                continue
+
+        if deps:
+            item["dependencies"] = deps
+
+        res = create_one(agent, item)
+        res = {**res, "index": i}
+        results.append(res)
+        if res.get("status") == "success":
+            batch_ids.append(res.get("task_id"))
+        else:
+            batch_ids.append(None)
+            errors.append({"index": i, "message": res.get("message", "create failed"),
+                           "title": item.get("title")})
+
+    created_ids = [tid for tid in batch_ids if tid is not None]
+    if not errors:
+        status = "success"
+    elif created_ids:
+        status = "partial"
+    else:
+        status = "error"
+
+    return {
+        "status": status,
+        "created_count": len(created_ids),
+        "task_ids": created_ids,
+        "results": results,
+        "errors": errors,
+    }

--- a/skills/kanban/tools.json
+++ b/skills/kanban/tools.json
@@ -150,6 +150,68 @@
   {
     "type": "function",
     "function": {
+      "name": "kanban_bulk_create_tasks",
+      "description": "Create MULTIPLE tasks on the Kanban board in one call. Use this whenever you need to create more than one task at once (e.g. a multi-step plan). Returns {status, created_count, task_ids, results, errors}; status is 'success', 'partial' (some failed), or 'error' (all failed). Per-task failures do not abort the rest.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "type": "array",
+            "description": "Array of task objects to create, in order. Each object accepts the same fields as kanban_create_task (title required; description, priority, assignee, dependencies optional) plus depends_on_index.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "The title of the task (required)."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "The description of the task (optional)."
+                },
+                "priority": {
+                  "type": "string",
+                  "description": "The priority of the task. One of: low, medium, high. Default is 'low'.",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ]
+                },
+                "assignee": {
+                  "type": "string",
+                  "description": "The agent ID to assign the task to (optional)."
+                },
+                "dependencies": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "Array of EXISTING task IDs this task depends on (optional)."
+                },
+                "depends_on_index": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  },
+                  "description": "Array of 1-based indices of EARLIER tasks in this same array that this task depends on. Use this to express dependencies on tasks being created in the same call (their IDs are not known yet). Example: the 2nd and 3rd tasks both depending on the 1st use depends_on_index: [1]."
+                }
+              },
+              "required": [
+                "title"
+              ]
+            }
+          }
+        },
+        "required": [
+          "tasks"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
       "name": "kanban_update_task",
       "description": "Update a Kanban task's status, assignee, title, description, and/or priority. This is the successor to kanban_update_status. Supports updating all fields in a single call. For backward compatibility, kanban_update_status is still available.",
       "parameters": {


### PR DESCRIPTION
## Summary

Adds a `kanban_bulk_create_tasks` tool to the **kanban** skill so an agent can create several board tasks in a single call, instead of issuing one `kanban_create_task` call per task.

## Why

When asked to create several tasks at once (e.g. a multi-step plan like 9B/9C/9D), the model naturally reaches for a single "bulk create" call. Since no such tool existed, it would **hallucinate** a `kanban_bulk_create_tasks` call. The quality monitor then rejected the unknown tool, and after the 2-correction cap the model frequently gave up and **falsely reported a "board/registry error server-side"** — so the tasks were never created at all.

Providing the real tool removes that failure at the source: the call the model already wants to make now exists and succeeds.

## What it does

- **`skills/kanban/backend/tools/kanban_bulk_create_tasks.py`** — wraps `kanban_create_task.execute` once per item, so permission checks, validation, and single-task dependency handling stay byte-for-byte identical to the single-create path. The sibling tool is loaded by file path because `skills/` is not an importable package.
- **`skills/kanban/tools.json`** — registers the tool schema so it's exposed to the agent.

### Behaviour

- Accepts a `tasks` array (max 50 per call). Each item takes the same fields as `kanban_create_task` (`title` required; `description`, `priority`, `assignee`, `dependencies` optional).
- **Partial-on-error:** a failure on one task does not abort the rest. Returns `{status, created_count, task_ids, results, errors}` where `status` is:
  - `success` — all created
  - `partial` — some failed
  - `error` — all failed
- **Intra-batch dependencies** via `depends_on_index` (1-based index of an earlier task in the same batch). The referenced task's real id is resolved once it is created, so e.g. 9C/9D can depend on 9B without knowing its id in advance.

## Testing

- `python -c "import ast; ast.parse(...)"` — tool module parses
- `json.load(...)` on `skills/kanban/tools.json` — schema is valid JSON
