### PR TITLE
Fix FD-leak self-shutdown becoming a half-dead zombie

### DIFF
--- a/app.py
+++ b/app.py
@@ -585,6 +585,21 @@ def _close_db_connection(exc):
     SQLite connections accumulate until GC runs → "Too many open files".
     """
     db.close()
+    # The same per-thread SQLite leak applies to the rate-limit stores: the
+    # before_request hook opens a thread-local connection (3 FDs each in WAL
+    # mode: db + -wal + -shm) on every /api/* request, and with thread-per-
+    # request these pile up until GC — the dominant source of the FD-watchdog
+    # self-shutdown. Close them alongside the main DB connection.
+    try:
+        from models.api_rate_limit import close as _close_api_rl
+        _close_api_rl()
+    except Exception:
+        pass
+    try:
+        from models.rate_limit import close as _close_rl
+        _close_rl()
+    except Exception:
+        pass
 
 def _csrf_exempt(path):
     """Return True if the path should skip CSRF validation."""

--- a/backend/agent_runtime/runtime.py
+++ b/backend/agent_runtime/runtime.py
@@ -611,6 +611,20 @@ class AgentRuntime:
         sig_name = signal.Signals(signum).name
         _logger.info("\nReceived %s, initiating graceful shutdown...", sig_name)
         cls.graceful_shutdown()
+        # sys.exit() only raises SystemExit in the main thread. When the signal
+        # arrives while the main thread is blocked in the threaded WSGI server's
+        # accept loop, that SystemExit gets swallowed by the server — the runtime
+        # ends up drained (queue workers + executor stopped) but the process
+        # stays alive serving requests. systemd still sees it as active, so
+        # Restart=always never fires and the FD-watchdog's SIGTERM produces a
+        # half-dead "zombie" instead of a restart. Arm a daemon backstop that
+        # force-exits if the clean exit doesn't take, then attempt the clean
+        # exit (which runs atexit Docker cleanup) first.
+        forcer = threading.Timer(
+            WORKER_JOIN_TIMEOUT_SECONDS + 3.0, lambda: os._exit(0)
+        )
+        forcer.daemon = True
+        forcer.start()
         # Use sys.exit to allow normal Python shutdown — this triggers
         # atexit handlers (including Docker container cleanup) and
         # thread cleanup, whereas os.kill hard-terminates the process.

--- a/backend/tools/lib/backends/ssh_backend.py
+++ b/backend/tools/lib/backends/ssh_backend.py
@@ -52,6 +52,7 @@ class SSHBackend(ExecutionBackend):
         self._remote_pid = None
         self._active_channel = None
         self._evonic_installed = False
+        self._remote_evonic_dir = None
 
         self._client = paramiko.SSHClient()
         self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -315,6 +316,30 @@ class SSHBackend(ExecutionBackend):
         finally:
             process_tracker.unregister(self._session_id)
 
+    def _resolve_remote_evonic_dir(self):
+        """Resolve _REMOTE_EVONIC_DIR's leading ~ against the REMOTE home.
+
+        os.path.expanduser would expand ~ against the local process's HOME
+        (evonic runs as root → /root), producing a path the remote user often
+        cannot write (e.g. /root/.evonic on a host where we log in as ubuntu),
+        which caused an endless SFTP "Permission denied" retry loop and FD leak.
+        """
+        if self._remote_evonic_dir is not None:
+            return self._remote_evonic_dir
+        suffix = _REMOTE_EVONIC_DIR[1:].lstrip('/') if _REMOTE_EVONIC_DIR.startswith('~') else _REMOTE_EVONIC_DIR
+        remote_home = ''
+        try:
+            r = self._exec('printf %s "$HOME"', '', 10)
+            remote_home = (r.get('stdout', '') or '').strip()
+        except Exception:
+            remote_home = ''
+        if remote_home and _REMOTE_EVONIC_DIR.startswith('~'):
+            resolved = remote_home.rstrip('/') + '/' + suffix
+        else:
+            resolved = _REMOTE_EVONIC_DIR
+        self._remote_evonic_dir = resolved
+        return resolved
+
     def _ensure_evonic_on_remote(self):
         """Upload evonic helpers to ~/.evonic/evonic/ on first run_python call.
 
@@ -323,7 +348,7 @@ class SSHBackend(ExecutionBackend):
         """
         if self._evonic_installed:
             return
-        remote_dir = os.path.expanduser(_REMOTE_EVONIC_DIR)
+        remote_dir = self._resolve_remote_evonic_dir()
         remote_bin = remote_dir + '/bin'
         self._exec(f'mkdir -p {shlex.quote(remote_dir)} {shlex.quote(remote_bin)}', '', 10)
         files = [
@@ -352,7 +377,7 @@ class SSHBackend(ExecutionBackend):
 
     def run_python(self, code: str, timeout: int, env: dict) -> dict:
         self._ensure_evonic_on_remote()
-        remote_dir = os.path.expanduser(_REMOTE_EVONIC_DIR)
+        remote_dir = self._resolve_remote_evonic_dir()
         merged = dict(env or {})
         existing = merged.get('PYTHONPATH', '')
         merged['PYTHONPATH'] = f'{remote_dir}:{existing}'.rstrip(':')


### PR DESCRIPTION
## Summary

Three fixes for the recurring failure where `evonic.service` dies on its own — the docker-backend watchdog SIGTERMs the process at `fd > 400`, but the process kept surviving as a **half-dead zombie** (runtime drained, web server still serving), so systemd never restarted it.

## Background

The FD-watchdog (`backend/tools/lib/backends/docker_backend.py`) sends `SIGTERM` to the process when the open-FD count climbs past 400, to prevent a cascade. The original FD source was an SFTP permission-denied retry loop (fixed in #3 below). After that, two further problems remained:

## Fixes

### 1. Close the rate-limiter's thread-local SQLite connections on teardown (`app.py`)

The dominant remaining FD leak. Flask's dev server runs `threaded=True` (one thread per request). The `before_request` rate-limit check opens a **thread-local** SQLite connection — 3 FDs each in WAL mode (`db` + `-wal` + `-shm`). `teardown_request` closed the main `db` connection but **not** the `api_rate_limit` / `rate_limit` ones, so they accumulated until GC — ~180 FDs on `api_rate_limit.db` alone, tripping the watchdog.

Fix: `teardown_request` now also calls `api_rate_limit.close()` and `rate_limit.close()`, mirroring the existing `db.close()` pattern.

**Verified:** open handles on `api_rate_limit.db` stayed flat at 8 across 70+ requests (previously grew unbounded toward 180+).

### 2. Guarantee the process actually exits on SIGTERM (`backend/agent_runtime/runtime.py`)

`_signal_handler` runs `graceful_shutdown()` then `sys.exit(0)`. But `sys.exit()` only raises `SystemExit` in the main thread, and when SIGTERM arrives while the main thread is blocked in the threaded WSGI accept loop, the server **swallows** that `SystemExit`. The result: queue workers + background executor stop, but the process keeps serving requests. systemd still sees it as `active`, so `Restart=always` never fires.

Fix: arm a daemon `threading.Timer(WORKER_JOIN_TIMEOUT_SECONDS + 3, os._exit(0))` backstop *before* `sys.exit(0)`. The clean exit (running atexit Docker cleanup) is still attempted first; the backstop guarantees the process dies — and thus restarts — if the clean exit is swallowed.

### 3. Resolve the remote evonic dir against the REMOTE `$HOME` (`backend/tools/lib/backends/ssh_backend.py`)

Root cause of the original FD leak. `_ensure_evonic_on_remote` used `os.path.expanduser('~/.evonic/evonic')`, which expands `~` against the **local** process HOME (`/root`, since evonic runs as root). On the deploy VPS we log in as `ubuntu`, who can't write under `/root`, producing an endless SFTP `[Errno 13] Permission denied` retry loop (~every 10–20s) that leaked sockets until `fd > 400`.

Fix: `_resolve_remote_evonic_dir()` resolves the leading `~` via the remote shell (`printf %s "$HOME"`), cached per connection.

## Testing

- `ast.parse(...)` on both changed Python modules — parse OK
- Imports `models.api_rate_limit.close` / `models.rate_limit.close` resolve
- Live: restarted the service, hammered 70+ `/api/*` requests, confirmed FD count stays bounded and queue workers/scheduler come back up
