### PR TITLE
fix: handle Qwen models putting response in reasoning_content

### DIFF
--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -1110,6 +1110,12 @@ def run_tool_loop(agent: Dict[str, Any],
             # Recover final response embedded after </think> in reasoning_content
             if not content and embedded_final_in_reasoning:
                 content = embedded_final_in_reasoning
+            # Fallback: when content is empty and the model put its entire response
+            # in reasoning_content (e.g. Qwen models via llama.cpp), treat reasoning_text
+            # as the actual response content.
+            if not content and not embedded_final_in_reasoning and not tool_calls:
+                content = reasoning_text
+                reasoning_text = ''
             event_stream.emit('llm_thinking', {
                 'agent_id': agent_id, 'session_id': session_id,
                 'external_user_id': external_user_id, 'channel_id': channel_id,

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -1029,6 +1029,10 @@ class LLMClient:
             if not cleaned and embedded_final:
                 cleaned = embedded_final
             # Check for Qwen-style XML tool calls that may appear in
+            # Fallback: when cleaned is empty and no embedded_final, the model
+            # put its entire response in reasoning_content (e.g. Qwen via llama.cpp).
+            if not cleaned and not embedded_final and not tool_calls:
+                cleaned = reasoning_text
             # reasoning_content instead of content (common with Qwen-based models).
             # Two forms: (a) trailing after </think> in embedded_final,
             # (b) directly in reasoning_text when content is empty.


### PR DESCRIPTION
When Qwen models run via llama.cpp without --reasoning, they put the entire response in reasoning_content with an empty content field.

This adds a fallback in both llm_loop.py and llm_client.py to treat reasoning_text as the actual response content when:
- content is empty
- no embedded_final from thinking tags
- no tool calls were generated

This fixes silent failures where agents using certain Qwen models appear to not respond.