### PR TITLE
feat: improve ChatView command and Bash modes

### DIFF
--- a/backend/slash_commands.py
+++ b/backend/slash_commands.py
@@ -44,6 +44,33 @@ class SlashCommandRegistry:
         return [(cmd.name, cmd.description) for cmd in self._commands.values()]
 
 
+def list_available_commands(agent_id: str, channel_id: Optional[str] = None) -> list:
+    """Return registered commands available to an agent on the given channel."""
+    commands = command_registry.list_commands()
+    try:
+        from models.db import db
+        super_agent = db.get_super_agent()
+        is_super = bool(super_agent and super_agent.get('id') == agent_id)
+        agent = db.get_agent(agent_id)
+        workplace_id = agent.get('workplace_id') if agent else None
+        workplace = db.get_workplace(workplace_id) if workplace_id else None
+        can_cd = is_super or bool(workplace and workplace.get('type') in ('remote', 'tunnel'))
+        has_subagent = is_super or 'subagent' in db.get_agent_skills(agent_id)
+    except Exception:
+        is_super = can_cd = has_subagent = False
+
+    available = []
+    for name, description in commands:
+        if name in {'cd', 'cwd'} and not can_cd:
+            continue
+        if name in {'restart', 'shutdown'} and not is_super:
+            continue
+        if name == 'sub' and not has_subagent:
+            continue
+        available.append((name, description))
+    return sorted(available, key=lambda command: command[0])
+
+
 # Global registry instance
 command_registry = SlashCommandRegistry()
 
@@ -185,46 +212,8 @@ def _register_builtins():
         channel_id: Optional[str],
         args: str,
     ) -> str:
-        commands = command_registry.list_commands()
-        # Filter out /restart for non-super agents
-        try:
-            from models.db import db
-            super_agent = db.get_super_agent()
-            is_super = super_agent and super_agent.get('id') == agent_id
-        except Exception:
-            is_super = False
-        # /cd and /cwd are also available to agents with remote/tunnel workplaces
-        can_cd = is_super
-        if not can_cd:
-            try:
-                agent = db.get_agent(agent_id)
-                if agent:
-                    workplace_id = agent.get('workplace_id')
-                    if workplace_id:
-                        workplace = db.get_workplace(workplace_id)
-                        if workplace and workplace.get('type') in ('remote', 'tunnel'):
-                            can_cd = True
-            except Exception:
-                pass
         lines = ["**Available commands:**"]
-        super_only = {"restart", "cd", "cwd", "shutdown"}
-        web_only = set()  # all commands now available on both web and channels
-        # /sub requires the subagent skill
-        has_subagent = False
-        try:
-            skills = db.get_agent_skills(agent_id)
-            has_subagent = "subagent" in skills
-        except Exception:
-            pass
-        for name, desc in commands:
-            if name in {"cd", "cwd"} and not can_cd:
-                continue
-            if name in {"restart", "shutdown"} and not is_super:
-                continue
-            if name in web_only and channel_id is not None:
-                continue
-            if name == "sub" and not has_subagent and not is_super:
-                continue
+        for name, desc in list_available_commands(agent_id, channel_id):
             lines.append(f"- `/{name}` — {desc}")
         return "\n".join(lines)
 

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -267,6 +267,19 @@ def api_get_agent(agent_id):
     return jsonify(_sanitize_agent(agent))
 
 
+@agents_bp.route('/api/agents/<agent_id>/commands', methods=['GET'])
+def api_list_agent_commands(agent_id):
+    if not db.get_agent(agent_id):
+        return jsonify({'error': 'Agent not found'}), 404
+    from backend.slash_commands import list_available_commands
+
+    commands = [
+        {'name': name, 'description': description}
+        for name, description in list_available_commands(agent_id)
+    ]
+    return jsonify({'commands': commands})
+
+
 @agents_bp.route('/api/agents', methods=['POST'])
 def api_create_agent():
     if not db.has_super_agent():

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -7,37 +7,31 @@
 <style>
 footer { display: none; }
 main { align-items: flex-start !important; }
-/* Bash mode must read as a terminal state, not as an unobtrusive status badge. */
-#chat-bash-mode {
-    align-items: center;
-    display: flex;
-    left: 8px;
-    position: absolute;
-    top: 7px;
-    z-index: 10;
+/* ! turns the composer itself into a bright red terminal-shell state. */
+#chat-input.chat-bash-input {
+    background: #ffe4e6;
+    border-color: #fb7185;
+    box-shadow: 0 0 0 2px rgba(251, 113, 133, 0.22);
+    caret-color: #e11d48;
+    color: #9f1239;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
-#chat-bash-mode:not(.hidden) {
-    background: #052e16;
-    border: 1px solid #22c55e;
-    border-radius: 6px;
-    box-shadow: 0 0 0 1px #dcfce7, 0 4px 12px rgba(22, 163, 74, 0.18);
-    color: #dcfce7;
+#chat-input.chat-bash-input::placeholder { color: #e11d48; opacity: 0.72; }
+#chat-bash-hint {
+    background: #fb7185;
+    border-radius: 4px 4px 0 0;
+    color: #fff1f2;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     font-size: 11px;
-    font-weight: 700;
-    gap: 6px;
-    letter-spacing: 0.08em;
-    margin-bottom: 6px;
-    padding: 5px 8px;
+    left: 2px;
+    line-height: 1;
+    padding: 4px 7px;
+    position: absolute;
+    top: -17px;
 }
-#chat-bash-mode.hidden { display: none; }
-#chat-bash-mode .bash-mode-status { color: #86efac; font-weight: 500; letter-spacing: normal; }
-#chat-bash-mode:not(.hidden).bash-disabled { background: #451a03; border-color: #f59e0b; box-shadow: 0 0 0 1px #fef3c7; color: #fef3c7; }
-#chat-bash-mode.bash-disabled .bash-mode-status { color: #fcd34d; }
-#chat-input.chat-bash-input { background: #f0fdf4; border-color: #16a34a; box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2); color: #14532d; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; padding-top: 36px; }
-#chat-input.chat-bash-disabled { background: #fffbeb; border-color: #d97706; box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2); color: #78350f; padding-top: 36px; }
-html.dark #chat-input.chat-bash-input { background: #071a12; border-color: #22c55e; color: #dcfce7; }
-html.dark #chat-input.chat-bash-disabled { background: #241300; border-color: #f59e0b; color: #fef3c7; }
+html.dark #chat-input.chat-bash-input { background: #4c1020; border-color: #fb7185; box-shadow: 0 0 0 2px rgba(251, 113, 133, 0.26); caret-color: #fda4af; color: #fff1f2; }
+html.dark #chat-input.chat-bash-input::placeholder { color: #fda4af; }
+html.dark #chat-bash-hint { background: #e11d48; color: #fff1f2; }
 /* Dark mode: chat area */
 html.dark #agent-state-card { background: #1f2937; border-color: #374151; }
 html.dark #state-busy-dot { background: #451a03 !important; color: #fcd34d !important; }
@@ -1077,12 +1071,8 @@ html.dark .agent-tab.active {
                             style="max-height: 150px;"
                             onkeydown="chatInputKeydown(event)"
                             oninput="chatInputChanged(this)"></textarea>
+                            <div id="chat-bash-hint" class="hidden" aria-live="polite">! Bash mode: shell command</div>
                             <div id="chat-command-menu" class="hidden absolute left-0 right-0 z-50 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800" style="bottom: calc(100% + 0.5rem);" role="listbox" aria-label="Available slash commands"></div>
-                            <div id="chat-bash-mode" class="hidden" aria-live="polite">
-                                <span aria-hidden="true">$_</span>
-                                <span>BASH SHELL</span>
-                                <span class="bash-mode-status">Enabled</span>
-                            </div>
                         </div>
                         <button onclick="handleChatBtn()" id="chat-send-btn" title="Send" class="bg-indigo-500 hover:bg-indigo-600 text-white p-2.5 rounded-md text-sm transition-colors flex items-center justify-center"><svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg></button>
                     </div>
@@ -4917,14 +4907,9 @@ function updateChatComposer(input) {
     const value = input.value;
     const trimmed = value.trimStart();
     const bashMode = trimmed.startsWith('!');
-    const badge = document.getElementById('chat-bash-mode');
-    if (badge) {
-        badge.classList.toggle('hidden', !bashMode);
-        badge.classList.toggle('bash-disabled', bashMode && !BASH_EXEC_ENABLED);
-        badge.querySelector('.bash-mode-status').textContent = BASH_EXEC_ENABLED ? 'Enabled' : 'Disabled';
-    }
-    input.classList.toggle('chat-bash-input', bashMode && BASH_EXEC_ENABLED);
-    input.classList.toggle('chat-bash-disabled', bashMode && !BASH_EXEC_ENABLED);
+    input.classList.toggle('chat-bash-input', bashMode);
+    const bashHint = document.getElementById('chat-bash-hint');
+    if (bashHint) bashHint.classList.toggle('hidden', !bashMode);
     input.classList.toggle('font-mono', bashMode);
 
     const match = trimmed.match(/^\/([\w-]*)$/);

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -7,6 +7,37 @@
 <style>
 footer { display: none; }
 main { align-items: flex-start !important; }
+/* Bash mode must read as a terminal state, not as an unobtrusive status badge. */
+#chat-bash-mode {
+    align-items: center;
+    display: flex;
+    left: 8px;
+    position: absolute;
+    top: 7px;
+    z-index: 10;
+}
+#chat-bash-mode:not(.hidden) {
+    background: #052e16;
+    border: 1px solid #22c55e;
+    border-radius: 6px;
+    box-shadow: 0 0 0 1px #dcfce7, 0 4px 12px rgba(22, 163, 74, 0.18);
+    color: #dcfce7;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 11px;
+    font-weight: 700;
+    gap: 6px;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+    padding: 5px 8px;
+}
+#chat-bash-mode.hidden { display: none; }
+#chat-bash-mode .bash-mode-status { color: #86efac; font-weight: 500; letter-spacing: normal; }
+#chat-bash-mode:not(.hidden).bash-disabled { background: #451a03; border-color: #f59e0b; box-shadow: 0 0 0 1px #fef3c7; color: #fef3c7; }
+#chat-bash-mode.bash-disabled .bash-mode-status { color: #fcd34d; }
+#chat-input.chat-bash-input { background: #f0fdf4; border-color: #16a34a; box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2); color: #14532d; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; padding-top: 36px; }
+#chat-input.chat-bash-disabled { background: #fffbeb; border-color: #d97706; box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2); color: #78350f; padding-top: 36px; }
+html.dark #chat-input.chat-bash-input { background: #071a12; border-color: #22c55e; color: #dcfce7; }
+html.dark #chat-input.chat-bash-disabled { background: #241300; border-color: #f59e0b; color: #fef3c7; }
 /* Dark mode: chat area */
 html.dark #agent-state-card { background: #1f2937; border-color: #374151; }
 html.dark #state-busy-dot { background: #451a03 !important; color: #fcd34d !important; }
@@ -1047,8 +1078,10 @@ html.dark .agent-tab.active {
                             onkeydown="chatInputKeydown(event)"
                             oninput="chatInputChanged(this)"></textarea>
                             <div id="chat-command-menu" class="hidden absolute left-0 right-0 z-50 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800" style="bottom: calc(100% + 0.5rem);" role="listbox" aria-label="Available slash commands"></div>
-                            <div id="chat-bash-mode" class="hidden absolute left-2 top-1 flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 font-mono text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200" aria-live="polite">
-                                <span aria-hidden="true">$</span><span>Bash mode</span>
+                            <div id="chat-bash-mode" class="hidden" aria-live="polite">
+                                <span aria-hidden="true">$_</span>
+                                <span>BASH SHELL</span>
+                                <span class="bash-mode-status">Enabled</span>
                             </div>
                         </div>
                         <button onclick="handleChatBtn()" id="chat-send-btn" title="Send" class="bg-indigo-500 hover:bg-indigo-600 text-white p-2.5 rounded-md text-sm transition-colors flex items-center justify-center"><svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg></button>
@@ -4887,12 +4920,12 @@ function updateChatComposer(input) {
     const badge = document.getElementById('chat-bash-mode');
     if (badge) {
         badge.classList.toggle('hidden', !bashMode);
-        badge.lastElementChild.textContent = BASH_EXEC_ENABLED ? 'Bash mode' : 'Bash disabled';
+        badge.classList.toggle('bash-disabled', bashMode && !BASH_EXEC_ENABLED);
+        badge.querySelector('.bash-mode-status').textContent = BASH_EXEC_ENABLED ? 'Enabled' : 'Disabled';
     }
-    input.classList.toggle('border-emerald-500', bashMode);
-    input.classList.toggle('dark:border-emerald-500', bashMode);
+    input.classList.toggle('chat-bash-input', bashMode && BASH_EXEC_ENABLED);
+    input.classList.toggle('chat-bash-disabled', bashMode && !BASH_EXEC_ENABLED);
     input.classList.toggle('font-mono', bashMode);
-    input.classList.toggle('pt-7', bashMode);
 
     const match = trimmed.match(/^\/([\w-]*)$/);
     if (!match) {

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -1046,7 +1046,7 @@ html.dark .agent-tab.active {
                             style="max-height: 150px;"
                             onkeydown="chatInputKeydown(event)"
                             oninput="chatInputChanged(this)"></textarea>
-                            <div id="chat-command-menu" class="hidden absolute bottom-full left-0 right-0 z-50 mb-2 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800" role="listbox" aria-label="Available slash commands"></div>
+                            <div id="chat-command-menu" class="hidden absolute left-0 right-0 z-50 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800" style="bottom: calc(100% + 0.5rem);" role="listbox" aria-label="Available slash commands"></div>
                             <div id="chat-bash-mode" class="hidden absolute left-2 top-1 flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 font-mono text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200" aria-live="polite">
                                 <span aria-hidden="true">$</span><span>Bash mode</span>
                             </div>

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -1040,11 +1040,17 @@ html.dark .agent-tab.active {
                             <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
                         </button>
                         {% endif %}
+                        <div class="relative flex-1 min-w-0">
                         <textarea id="chat-input" placeholder="Type a message..." rows="1"
-                            class="flex-1 p-2.5 border border-gray-300 rounded-md text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/10 resize-none overflow-hidden disabled:opacity-50 disabled:cursor-not-allowed"
+                            class="w-full p-2.5 border border-gray-300 rounded-md text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/10 resize-none overflow-hidden disabled:opacity-50 disabled:cursor-not-allowed"
                             style="max-height: 150px;"
                             onkeydown="chatInputKeydown(event)"
-                            oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,150)+'px';this.style.overflowY=this.scrollHeight>150?'auto':'hidden'"></textarea>
+                            oninput="chatInputChanged(this)"></textarea>
+                            <div id="chat-command-menu" class="hidden absolute bottom-full left-0 right-0 z-50 mb-2 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-600 dark:bg-gray-800" role="listbox" aria-label="Available slash commands"></div>
+                            <div id="chat-bash-mode" class="hidden absolute left-2 top-1 flex items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 font-mono text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/60 dark:text-emerald-200" aria-live="polite">
+                                <span aria-hidden="true">$</span><span>Bash mode</span>
+                            </div>
+                        </div>
                         <button onclick="handleChatBtn()" id="chat-send-btn" title="Send" class="bg-indigo-500 hover:bg-indigo-600 text-white p-2.5 rounded-md text-sm transition-colors flex items-center justify-center"><svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg></button>
                     </div>
                 </div>
@@ -1690,7 +1696,7 @@ let chatLoaded = false;
     });
 
     // Restore on load
-    $(function() { restoreDraft(); });
+    $(function() { restoreDraft(); updateChatComposer(document.getElementById('chat-input')); loadChatCommands(); });
 
     // Safety net: save on page unload
     $(window).on('beforeunload', saveDraft);
@@ -4840,7 +4846,131 @@ function stopIdlePoll() {
 // Desktop = viewport >= 1024px: Enter without Shift submits, Shift+Enter inserts newline.
 // The check runs per-keypress so it reacts immediately to resize / rotation.
 const CHAT_DESKTOP_BREAKPOINT = 1024;
+let chatCommands = [];
+let chatCommandIndex = -1;
+let BASH_EXEC_ENABLED = {{ 'true' if agent.bash_exec_enabled else 'false' }};
+
+function chatInputChanged(input) {
+    input.style.height = 'auto';
+    input.style.height = Math.min(input.scrollHeight, 150) + 'px';
+    input.style.overflowY = input.scrollHeight > 150 ? 'auto' : 'hidden';
+    updateChatComposer(input);
+}
+
+function loadChatCommands() {
+    const requestedAgentId = AGENT_ID;
+    return fetch(`/api/agents/${encodeURIComponent(requestedAgentId)}/commands`)
+        .then(res => res.ok ? res.json() : {commands: []})
+        .then(data => {
+            if (requestedAgentId === AGENT_ID) {
+                chatCommands = Array.isArray(data.commands) ? data.commands : [];
+                updateChatComposer(document.getElementById('chat-input'));
+            }
+        })
+        .catch(() => { if (requestedAgentId === AGENT_ID) chatCommands = []; });
+}
+
+function closeChatCommandMenu() {
+    const menu = document.getElementById('chat-command-menu');
+    if (menu) {
+        menu.classList.add('hidden');
+        menu.replaceChildren();
+    }
+    chatCommandIndex = -1;
+}
+
+function updateChatComposer(input) {
+    if (!input) return;
+    const value = input.value;
+    const trimmed = value.trimStart();
+    const bashMode = trimmed.startsWith('!');
+    const badge = document.getElementById('chat-bash-mode');
+    if (badge) {
+        badge.classList.toggle('hidden', !bashMode);
+        badge.lastElementChild.textContent = BASH_EXEC_ENABLED ? 'Bash mode' : 'Bash disabled';
+    }
+    input.classList.toggle('border-emerald-500', bashMode);
+    input.classList.toggle('dark:border-emerald-500', bashMode);
+    input.classList.toggle('font-mono', bashMode);
+    input.classList.toggle('pt-7', bashMode);
+
+    const match = trimmed.match(/^\/([\w-]*)$/);
+    if (!match) {
+        closeChatCommandMenu();
+        return;
+    }
+    const query = match[1].toLowerCase();
+    const choices = chatCommands.filter(command => command.name.toLowerCase().includes(query));
+    renderChatCommandMenu(choices);
+}
+
+function renderChatCommandMenu(choices) {
+    const menu = document.getElementById('chat-command-menu');
+    if (!menu || !choices.length) {
+        closeChatCommandMenu();
+        return;
+    }
+    if (chatCommandIndex < 0 || chatCommandIndex >= choices.length) chatCommandIndex = 0;
+    menu.replaceChildren();
+    choices.forEach((command, index) => {
+        const option = document.createElement('button');
+        option.type = 'button';
+        option.role = 'option';
+        option.className = 'flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-indigo-50 dark:hover:bg-gray-700';
+        option.classList.toggle('bg-indigo-50', index === chatCommandIndex);
+        option.classList.toggle('dark:bg-gray-700', index === chatCommandIndex);
+        option.setAttribute('aria-selected', String(index === chatCommandIndex));
+        const name = document.createElement('span');
+        name.className = 'font-mono font-medium text-indigo-600 dark:text-indigo-300';
+        name.textContent = '/' + command.name;
+        const description = document.createElement('span');
+        description.className = 'min-w-0 truncate text-xs text-gray-500 dark:text-gray-400';
+        description.textContent = command.description || '';
+        option.append(name, description);
+        option.addEventListener('mousedown', event => event.preventDefault());
+        option.addEventListener('click', () => selectChatCommand(command));
+        menu.appendChild(option);
+    });
+    menu.classList.remove('hidden');
+}
+
+function getVisibleChatCommands() {
+    const input = document.getElementById('chat-input');
+    const match = input && input.value.trimStart().match(/^\/([\w-]*)$/);
+    if (!match) return [];
+    return chatCommands.filter(command => command.name.toLowerCase().includes(match[1].toLowerCase()));
+}
+
+function selectChatCommand(command) {
+    const input = document.getElementById('chat-input');
+    if (!input || !command) return;
+    input.value = `/${command.name} `;
+    closeChatCommandMenu();
+    chatInputChanged(input);
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
+}
+
 function chatInputKeydown(event) {
+    const choices = getVisibleChatCommands();
+    if (choices.length) {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            chatCommandIndex = (chatCommandIndex + (event.key === 'ArrowDown' ? 1 : -1) + choices.length) % choices.length;
+            renderChatCommandMenu(choices);
+            return;
+        }
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            selectChatCommand(choices[chatCommandIndex < 0 ? 0 : chatCommandIndex]);
+            return;
+        }
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeChatCommandMenu();
+            return;
+        }
+    }
     if (event.key !== 'Enter') return;
     if (event.shiftKey) {
         // Shift+Enter inserts a newline natively; offer the editor-mode tip for long messages.
@@ -5092,6 +5222,7 @@ async function sendChat() {
     input.value = '';
     input.style.height = 'auto';
     input.style.overflowY = 'hidden';
+    updateChatComposer(input);
     // Re-apply height reset after async input event (queued by value='') fires.
     // The oninput handler may set height from a stale scrollHeight before the
     // browser has reflowed the now-empty textarea.
@@ -6965,6 +7096,8 @@ window.softSwitchAgent = async function (newId, opts = {}) {
 
     // --- Swap identity + reset per-agent state ---
     AGENT_ID = newId;
+    BASH_EXEC_ENABLED = !!data.bash_exec_enabled;
+    chatCommands = [];
     _chatSessionId = null;
     chatLoaded = false;
     lastChatTs = 0;
@@ -7029,6 +7162,8 @@ window.softSwitchAgent = async function (newId, opts = {}) {
     const input = document.getElementById('chat-input');
     if (input) { input.value = ''; input.style.height = 'auto'; }
     if (window._restoreChatDraft) window._restoreChatDraft();
+    updateChatComposer(input);
+    loadChatCommands();
     if (typeof dismissBubble === 'function') dismissBubble(newId);
 
     // From popstate the browser already moved in history — pushing again would

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -4906,7 +4906,7 @@ function updateChatComposer(input) {
     if (!input) return;
     const value = input.value;
     const trimmed = value.trimStart();
-    const bashMode = trimmed.startsWith('!');
+    const bashMode = BASH_EXEC_ENABLED && trimmed.startsWith('!');
     input.classList.toggle('chat-bash-input', bashMode);
     const bashHint = document.getElementById('chat-bash-hint');
     if (bashHint) bashHint.classList.toggle('hidden', !bashMode);

--- a/unit_tests/test_chat_sessions.py
+++ b/unit_tests/test_chat_sessions.py
@@ -325,3 +325,29 @@ class TestGetAllSessions:
 
         sessions, total = db.get_all_sessions(search='Test Agent')
         assert total >= 1
+
+
+class TestAgentCommandDiscoveryAPI:
+    def test_returns_sorted_commands_available_to_agent(self, agent_id, chat_db):
+        from app import app
+
+        with app.test_client() as client:
+            _auth(client)
+            response = client.get(f'/api/agents/{agent_id}/commands')
+
+        assert response.status_code == 200
+        commands = response.get_json()['commands']
+        names = [command['name'] for command in commands]
+        assert names == sorted(names)
+        assert 'help' in names
+        assert 'restart' not in names
+        assert all(set(command) == {'name', 'description'} for command in commands)
+
+    def test_returns_404_for_unknown_agent(self, agent_id, chat_db):
+        from app import app
+
+        with app.test_client() as client:
+            _auth(client)
+            response = client.get('/api/agents/missing_agent/commands')
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Add a dynamically discovered, keyboard-accessible slash-command palette to the ChatView composer.
- Position command suggestions above the composer and insert a selected command without submitting it.
- Refine `!` Bash mode as a red, monospace shell state with a compact helper message above the composer.
- Preserve the existing server-side Bash permission and web-session enforcement.

## Validation
- Jinja template compilation
- Extracted ChatView composer JavaScript syntax check with `node --check`
- `git diff --check`
- Command API smoke tests, including unknown-agent `404`

## Notes
- The full pytest suite was not run because pytest was unavailable in the local system and virtual environments.