### PR TITLE
feat(chat): support multiple image uploads

### DIFF
--- a/backend/agent_runtime/context.py
+++ b/backend/agent_runtime/context.py
@@ -1052,12 +1052,17 @@ def build_message_entry(msg: dict, agent: dict, has_describe_image: bool = True)
     # Images are NEVER auto-fed to the main LLM — always use the describe_image tool instead.
     # Audio is likewise never auto-fed — agents listen via the transcribe_audio tool.
     has_video = msg_video and agent.get('video_enabled')
-    has_image_attachment = msg_image is not None  # track for attachment note enhancement
+    has_image_attachment = bool(msg_image or _msg_meta.get('image_urls'))
 
-    # Build attachment context note if attachment_info is present in metadata
-    attachment_info = _msg_meta.get('attachment_info') if _msg_meta else None
-    attachment_note = None
-    if attachment_info and isinstance(attachment_info, dict):
+    attachment_infos = _msg_meta.get('attachment_infos') or []
+    if not isinstance(attachment_infos, list):
+        attachment_infos = []
+    attachment_infos = [info for info in attachment_infos if isinstance(info, dict)]
+    if not attachment_infos and isinstance(_msg_meta.get('attachment_info'), dict):
+        attachment_infos = [_msg_meta['attachment_info']]
+
+    attachment_notes = []
+    for index, attachment_info in enumerate(attachment_infos, 1):
         file_path = attachment_info.get('file_path', '')
         # Resolve relative paths (e.g. data/attachments/...) to absolute so agents
         # can access the file from any working directory.
@@ -1074,14 +1079,14 @@ def build_message_entry(msg: dict, agent: dict, has_describe_image: bool = True)
             size_str = f"{size_bytes} B"
         is_image = mime_type and mime_type.startswith("image/")
         is_audio = mime_type and mime_type.startswith("audio/")
-        attachment_note = (
-            f"\n\n[Attachment: {filename} ({mime_type}, {size_str})]"
-            f"\nFile path: {file_path}"
-        )
+        label = f"Attachment #{index}" if len(attachment_infos) > 1 else "Attachment"
+        note = f"\n\n[{label}: {filename} ({mime_type}, {size_str})]\nFile path: {file_path}"
         if is_image and has_image_attachment and has_describe_image:
-            attachment_note += "\nUse the `describe_image` tool to view and analyze this image."
+            note += "\nUse the `describe_image` tool to view and analyze this image."
         if is_audio and agent.get('audio_enabled'):
-            attachment_note += "\nUse the `transcribe_audio` tool to listen to this audio."
+            note += "\nUse the `transcribe_audio` tool to listen to this audio."
+        attachment_notes.append(note)
+    attachment_note = ''.join(attachment_notes) or None
 
     if has_video:
         parts = []

--- a/backend/agent_runtime/runtime.py
+++ b/backend/agent_runtime/runtime.py
@@ -51,6 +51,41 @@ _LOGS_DIR = os.path.join(_BASE_DIR, 'logs')
 _logger = logging.getLogger(__name__)
 
 
+def _append_attachment_context(content: str, attachment_infos, attachment_info,
+                               agent: dict, has_describe_image: bool) -> str:
+    """Append context notes for plural attachments with a legacy singular fallback."""
+    if not isinstance(attachment_infos, list):
+        attachment_infos = []
+    attachment_infos = [info for info in attachment_infos if isinstance(info, dict)]
+    if not attachment_infos and isinstance(attachment_info, dict):
+        attachment_infos = [attachment_info]
+
+    notes = []
+    for index, info in enumerate(attachment_infos, 1):
+        fp = info.get('file_path', '')
+        if fp and not os.path.isabs(fp):
+            fp = os.path.abspath(os.path.join(_BASE_DIR, fp))
+        fn = info.get('filename', '')
+        mt = info.get('mime_type', '')
+        sb = int(info.get('size_bytes', 0) or 0)
+        is_img = bool(mt and mt.startswith('image/'))
+        is_audio = bool(mt and mt.startswith('audio/'))
+        if sb >= 1048576:
+            sz = f"{sb / 1048576:.1f} MB"
+        elif sb >= 1024:
+            sz = f"{sb / 1024:.1f} KB"
+        else:
+            sz = f"{sb} B"
+        label = f"Attachment #{index}" if len(attachment_infos) > 1 else "Attachment"
+        note = f"\n\n[{label}: {fn} ({mt}, {sz})]\nFile path: {fp}"
+        if is_img and has_describe_image:
+            note += "\nUse the `describe_image` tool to view and analyze this image."
+        if is_audio and agent.get('audio_enabled'):
+            note += "\nUse the `transcribe_audio` tool to listen to this audio."
+        notes.append(note)
+    return content.rstrip() + ''.join(notes) if notes else content
+
+
 # --- Configuration constants ---
 CLEANUP_INTERVAL_SECONDS = 300       # Interval between idle session cleanup sweeps (5 minutes)
 CLEANUP_TTL_SECONDS = 3600          # TTL for session state entries before cleanup (1 hour)
@@ -1623,35 +1658,12 @@ class AgentRuntime:
             # Always pop _image_url/_audio_url but NEVER feed them to the LLM.
             msg.pop('_image_url', None)
             msg.pop('_audio_url', None)
-            # Append attachment_info note so agents see file path metadata.
-            _att = msg.pop('attachment_info', None) or msg.get('attachment_info')
-            if _att and isinstance(_att, dict):
-                fp = _att.get('file_path', '')
-                # Resolve relative paths (e.g. data/attachments/...) to absolute so
-                # agents can access the file from any working directory.
-                if fp and not os.path.isabs(fp):
-                    fp = os.path.abspath(os.path.join(_BASE_DIR, fp))
-                fn = _att.get('filename', '')
-                mt = _att.get('mime_type', '')
-                sb = int(_att.get('size_bytes', 0) or 0)
-                is_img = bool(mt and mt.startswith('image/'))
-                is_audio = bool(mt and mt.startswith('audio/'))
-                if sb >= 1048576:
-                    sz = f"{sb / 1048576:.1f} MB"
-                elif sb >= 1024:
-                    sz = f"{sb / 1024:.1f} KB"
-                else:
-                    sz = f"{sb} B"
-                note = (
-                    f"\n\n[Attachment: {fn} ({mt}, {sz})]"
-                    f"\nFile path: {fp}"
-                )
-                if is_img and _has_describe_image:
-                    note += "\nUse the `describe_image` tool to view and analyze this image."
-                if is_audio and agent.get('audio_enabled'):
-                    note += "\nUse the `transcribe_audio` tool to listen to this audio."
-                content = msg.get('content', '') or ''
-                msg['content'] = content.rstrip() + note
+            msg['content'] = _append_attachment_context(
+                msg.get('content', '') or '',
+                msg.pop('attachment_infos', None),
+                msg.pop('attachment_info', None),
+                agent, _has_describe_image,
+            )
             video = msg.pop('_video_url', None) if agent.get('video_enabled') else msg.pop('_video_url', None) and None
             if not video:
                 return msg
@@ -1700,6 +1712,9 @@ class AgentRuntime:
                     _vid = _cur_meta.get('video_url')
                     if _vid:
                         _cur_msg['_video_url'] = _vid
+                    _atts = _cur_meta.get('attachment_infos')
+                    if isinstance(_atts, list):
+                        _cur_msg['attachment_infos'] = _atts
                     _att = _cur_meta.get('attachment_info')
                     if _att:
                         _cur_msg['attachment_info'] = _att

--- a/models/chatlog.py
+++ b/models/chatlog.py
@@ -511,6 +511,9 @@ def _reconstruct_llm_messages(entries: List[dict]) -> List[Dict[str, Any]]:
             wrapped = _meta.get('wrapped')
             if wrapped:
                 msg['_wrapped'] = True
+            atts = _meta.get('attachment_infos')
+            if isinstance(atts, list):
+                msg['attachment_infos'] = atts
             att = _meta.get('attachment_info')
             if att:
                 msg['attachment_info'] = att

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -1512,69 +1512,77 @@ def api_chat(agent_id):
     if not db.get_agent(agent_id):
         return jsonify({'error': 'Agent not found'}), 404
 
-    # Support both JSON and multipart/form-data (for file uploads)
+    # Support both JSON and multipart/form-data (including repeated files fields).
     if request.content_type and request.content_type.startswith('multipart/form-data'):
         message = (request.form.get('message') or '').strip()
         user_id = (request.form.get('user_id') or 'anonymous').strip()
-        file = request.files.get('file')
+        files = [f for f in request.files.getlist('files') if f and f.filename]
+        if not files:
+            legacy_file = request.files.get('file')
+            files = [legacy_file] if legacy_file and legacy_file.filename else []
     else:
-        data = request.get_json()
+        data = request.get_json() or {}
         message = data.get('message', '').strip()
         user_id = data.get('user_id', 'anonymous')
-        file = None
+        files = []
 
-    if not message and not file:
+    if not message and not files:
         return jsonify({'error': 'Message is required'}), 400
 
     from backend.agent_runtime import agent_runtime
     from routes.sessions import _process_upload, _ALLOWED_EXTS
 
-    image_url = None
-    upload_meta = None
-    attachment_info = None
+    image_urls = []
+    attachment_infos = []
+    text_prefixes = []
 
-    if file:
-        # Validate extension
-        ext = os.path.splitext(file.filename or '')[1].lower()
-        if ext not in _ALLOWED_EXTS:
-            return jsonify({'error': f'File type {ext} not supported'}), 400
-
-        # Get/create session for attachment storage
+    if files:
         session_id = db.get_or_create_session(agent_id, user_id)
-
-        # Check if attachments are enabled for this agent
         cfg = db.get_agent_attachment_config(agent_id)
         if not cfg.get('enabled'):
             return jsonify({'error': 'File attachments are not enabled for this agent. Enable them in agent settings.'}), 400
 
         max_bytes = cfg.get('max_size_mb', 20) * 1024 * 1024
-        file.seek(0, os.SEEK_END)
-        fsize = file.tell()
-        file.seek(0)
-        if fsize > max_bytes:
-            return jsonify({'error': f'File too large (max {cfg.get("max_size_mb", 20)}MB)'}), 400
+        for file in files:
+            ext = os.path.splitext(file.filename or '')[1].lower()
+            if ext not in _ALLOWED_EXTS:
+                return jsonify({'error': f'File type {ext} not supported'}), 400
+            file.seek(0, os.SEEK_END)
+            fsize = file.tell()
+            file.seek(0)
+            if fsize > max_bytes:
+                return jsonify({'error': f'File too large (max {cfg.get("max_size_mb", 20)}MB)'}), 400
+            try:
+                upload = _process_upload(file, agent_id, session_id, user_id, None)
+            except Exception as e:
+                print(f"[WebChat] Upload processing failed: {e}")
+                return jsonify({'error': 'Failed to process uploaded file'}), 500
+            attachment_infos.append(upload['attachment_info'])
+            if upload['image_url']:
+                image_urls.append(upload['image_url'])
+            if upload['text_prefix']:
+                text_prefixes.append(upload['text_prefix'])
 
-        try:
-            result = _process_upload(
-                file, agent_id, session_id,
-                user_id,
-                None,  # channel_id
-            )
-        except Exception as e:
-            print(f"[WebChat] Upload processing failed: {e}")
-            return jsonify({'error': 'Failed to process uploaded file'}), 500
-
-        image_url = result['image_url']
-        attachment_info = result['attachment_info']
-        upload_meta = {'attachment_info': attachment_info}
-
-        # For non-image files, prepend extracted text to user message
-        if result['text_prefix']:
-            message = f"{result['text_prefix']}\n\n{message}" if message else result['text_prefix']
-
-        # Fallback display text when no user text provided
+        if text_prefixes:
+            message = '\n\n'.join(text_prefixes + ([message] if message else []))
         if not message:
-            message = '[Image]' if attachment_info.get('is_image') else f"[File: {attachment_info['filename']}]"
+            image_slot = 0
+            placeholders = []
+            for info in attachment_infos:
+                if info.get('is_image'):
+                    image_slot += 1
+                    placeholders.append(f'[Image #{image_slot}]')
+                else:
+                    placeholders.append(f'[File: {info["filename"]}]')
+            message = ' '.join(placeholders)
+
+    image_url = image_urls[0] if image_urls else None
+    attachment_info = attachment_infos[0] if attachment_infos else None
+    upload_meta = None
+    if attachment_infos:
+        upload_meta = {'attachment_infos': attachment_infos}
+        if len(attachment_infos) == 1:
+            upload_meta['attachment_info'] = attachment_info
 
     try:
         result = agent_runtime.handle_message(
@@ -1584,13 +1592,17 @@ def api_chat(agent_id):
         )
         if result.get('buffered'):
             resp = {'success': True, 'buffered': True}
-            if attachment_info:
-                resp['attachment_info'] = attachment_info
+            if attachment_infos:
+                resp['attachment_infos'] = attachment_infos
+                if len(attachment_infos) == 1:
+                    resp['attachment_info'] = attachment_info
             return jsonify(resp)
         if result.get('injected'):
             resp = {'success': True, 'injected': True}
-            if attachment_info:
-                resp['attachment_info'] = attachment_info
+            if attachment_infos:
+                resp['attachment_infos'] = attachment_infos
+                if len(attachment_infos) == 1:
+                    resp['attachment_info'] = attachment_info
             return jsonify(resp)
         resp = {
             'success': True,
@@ -1601,8 +1613,10 @@ def api_chat(agent_id):
             'bash_exec': result.get('bash_exec', False),
             'clear_ui': result.get('clear_ui', False),
         }
-        if attachment_info:
-            resp['attachment_info'] = attachment_info
+        if attachment_infos:
+            resp['attachment_infos'] = attachment_infos
+            if len(attachment_infos) == 1:
+                resp['attachment_info'] = attachment_info
         if result.get('error'):
             resp['error'] = True
         return jsonify(resp)

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -77,7 +77,7 @@ def _process_upload(file_storage, agent_id: str, session_id: str,
     safe_name = _sanitize_filename(original_name)
     target_dir = os.path.join('data', 'attachments', agent_id, session_id)
     os.makedirs(target_dir, exist_ok=True)
-    target_path = os.path.join(target_dir, f"{int(time.time())}_{safe_name}")
+    target_path = os.path.join(target_dir, f"{time.time_ns()}_{safe_name}")
     with open(target_path, 'wb') as f:
         f.write(file_bytes)
 

--- a/static/js/chat-ui.js
+++ b/static/js/chat-ui.js
@@ -1636,23 +1636,47 @@ function buildMessageBubble(role, content, opts = {}, cfg = {}) {
 
     } else if (isUser) {
         $bubble = $('<div class="rounded-2xl px-4 py-2.5 text-sm whitespace-pre-wrap break-words">').addClass(userBubbleClass);
-        // Render image attachment if present
         const meta = opts.metadata || {};
-        if (meta.image_url) {
-            const $img = createLazyImage(meta.image_url);
+        const attachmentInfos = Array.isArray(meta.attachment_infos)
+            ? meta.attachment_infos
+            : (meta.attachment_info ? [meta.attachment_info] : []);
+        const imageInfos = attachmentInfos.filter(info => info && info.is_image);
+        const imageUrls = Array.isArray(meta.image_urls)
+            ? meta.image_urls
+            : (meta.image_url ? [meta.image_url] : imageInfos.map(info =>
+                `/api/attachments/${encodeURIComponent(info.attachment_id)}/view`));
+        const addImage = (slot) => {
+            const imageUrl = imageUrls[slot - 1];
+            if (!imageUrl) return false;
+            const $img = createLazyImage(imageUrl);
             $bubble.append($img);
             _wrapImageWithDownload($img);
             setupImageForLazy($img);
+            return true;
+        };
+        const referenced = new Set();
+        const tokenPattern = /\[Image #(\d+)\]/g;
+        let cursor = 0;
+        let match;
+        while ((match = tokenPattern.exec(content || ''))) {
+            const slot = Number(match[1]);
+            if (!imageUrls[slot - 1]) continue;
+            if (match.index > cursor) $bubble.append(document.createTextNode(content.slice(cursor, match.index)));
+            addImage(slot);
+            referenced.add(slot);
+            cursor = match.index + match[0].length;
         }
-        // Render non-image file badge
-        if (meta.attachment_info && !meta.attachment_info.is_image) {
-            const info = meta.attachment_info;
+        if (content && cursor < content.length) $bubble.append(document.createTextNode(content.slice(cursor)));
+        for (let slot = 1; slot <= imageUrls.length; slot++) {
+            if (!referenced.has(slot)) addImage(slot);
+        }
+        // Render non-image file badges
+        attachmentInfos.filter(info => info && !info.is_image).forEach(info => {
             const $badge = $('<div class="flex items-center gap-1.5 mb-1 px-2 py-1 bg-white/20 rounded text-xs">')
                 .append($('<svg class="w-3.5 h-3.5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M3 3.5A1.5 1.5 0 0 1 4.5 2h6.879a1.5 1.5 0 0 1 1.06.44l4.122 4.12A1.5 1.5 0 0 1 17 7.622V16.5a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 3 16.5v-13Z"/></svg>'))
                 .append($('<span class="truncate">').text(info.filename));
-            $bubble.append($badge);
-        }
-        if (content) $bubble.append(document.createTextNode(content));
+            $bubble.prepend($badge);
+        });
 
     } else if (isError) {
         const $icon = $('<svg class="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd"/></svg>');

--- a/static/js/chat-ui/renderers.js
+++ b/static/js/chat-ui/renderers.js
@@ -1071,23 +1071,47 @@ export function buildMessageBubble(role, content, opts = {}, cfg = {}) {
 
     } else if (isUser) {
         $bubble = $('<div class="rounded-2xl px-4 py-2.5 text-sm whitespace-pre-wrap break-words">').addClass(userBubbleClass);
-        // Render image attachment if present
         const meta = opts.metadata || {};
-        if (meta.image_url) {
-            const $img = createLazyImage(meta.image_url);
+        const attachmentInfos = Array.isArray(meta.attachment_infos)
+            ? meta.attachment_infos
+            : (meta.attachment_info ? [meta.attachment_info] : []);
+        const imageInfos = attachmentInfos.filter(info => info && info.is_image);
+        const imageUrls = Array.isArray(meta.image_urls)
+            ? meta.image_urls
+            : (meta.image_url ? [meta.image_url] : imageInfos.map(info =>
+                `/api/attachments/${encodeURIComponent(info.attachment_id)}/view`));
+        const addImage = (slot) => {
+            const imageUrl = imageUrls[slot - 1];
+            if (!imageUrl) return false;
+            const $img = createLazyImage(imageUrl);
             $bubble.append($img);
             _wrapImageWithDownload($img);
             setupImageForLazy($img);
+            return true;
+        };
+        const referenced = new Set();
+        const tokenPattern = /\[Image #(\d+)\]/g;
+        let cursor = 0;
+        let match;
+        while ((match = tokenPattern.exec(content || ''))) {
+            const slot = Number(match[1]);
+            if (!imageUrls[slot - 1]) continue;
+            if (match.index > cursor) $bubble.append(document.createTextNode(content.slice(cursor, match.index)));
+            addImage(slot);
+            referenced.add(slot);
+            cursor = match.index + match[0].length;
         }
-        // Render non-image file badge
-        if (meta.attachment_info && !meta.attachment_info.is_image) {
-            const info = meta.attachment_info;
+        if (content && cursor < content.length) $bubble.append(document.createTextNode(content.slice(cursor)));
+        for (let slot = 1; slot <= imageUrls.length; slot++) {
+            if (!referenced.has(slot)) addImage(slot);
+        }
+        // Render non-image file badges
+        attachmentInfos.filter(info => info && !info.is_image).forEach(info => {
             const $badge = $('<div class="flex items-center gap-1.5 mb-1 px-2 py-1 bg-white/20 rounded text-xs">')
                 .append($('<svg class="w-3.5 h-3.5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M3 3.5A1.5 1.5 0 0 1 4.5 2h6.879a1.5 1.5 0 0 1 1.06.44l4.122 4.12A1.5 1.5 0 0 1 17 7.622V16.5a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 3 16.5v-13Z"/></svg>'))
                 .append($('<span class="truncate">').text(info.filename));
-            $bubble.append($badge);
-        }
-        if (content) $bubble.append(document.createTextNode(content));
+            $bubble.prepend($badge);
+        });
 
     } else if (isError) {
         const $icon = $('<svg class="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd"/></svg>');

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -992,7 +992,7 @@ html.dark .agent-tab.active {
                     <div id="chat-drop-overlay" class="hidden absolute inset-0 z-40 flex items-center justify-center pointer-events-none" style="background:rgba(99,102,241,0.08)">
                         <div class="border-2 border-dashed border-indigo-400 rounded-xl px-8 py-6 flex flex-col items-center gap-2 bg-white/80 dark:bg-gray-800/80">
                             <svg class="w-8 h-8 text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/></svg>
-                            <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">Drop file here</span>
+                            <span class="text-sm font-medium text-indigo-600 dark:text-indigo-400">Drop files here</span>
                         </div>
                     </div>
                     <div id="chat-messages" class="flex-1 overflow-y-auto p-4 space-y-3 min-h-0" style="min-height: 300px;">
@@ -1012,16 +1012,8 @@ html.dark .agent-tab.active {
                     <button onclick="retryWorkplaceConnect()" class="ml-auto text-xs text-yellow-700 dark:text-yellow-400 hover:underline flex-shrink-0">Retry</button>
                 </div>
                 <div class="p-4 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
-                    <!-- File preview strip -->
-                    <div id="chat-file-preview" class="hidden mb-2 flex items-center gap-2 px-2 py-1.5 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                        <img id="chat-file-preview-img" class="hidden w-12 h-12 object-cover rounded" alt="">
-                        <svg id="chat-file-preview-icon" class="hidden w-6 h-6 text-gray-400 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 2l5 5h-5V4zm-3 9h4v2h-4v-2zm0 3h4v2h-4v-2zm-2-3h1v2H8v-2zm0 3h1v2H8v-2z"/></svg>
-                        <span id="chat-file-preview-name" class="text-xs text-gray-600 dark:text-gray-300 truncate flex-1"></span>
-                        <span id="chat-file-preview-size" class="text-[10px] text-gray-400 flex-shrink-0"></span>
-                        <button type="button" onclick="clearChatFileInput()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 flex-shrink-0" title="Remove file">
-                            <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clip-rule="evenodd"/></svg>
-                        </button>
-                    </div>
+                    <!-- Pending image/file attachments for the next message -->
+                    <div id="chat-file-preview" class="hidden mb-2 flex flex-wrap gap-2"></div>
                     <!-- Editor-mode tip (shown on Shift+Enter) -->
                     <div id="editor-tip" class="hidden mb-2 flex items-center gap-2 px-3 py-1.5 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded-lg text-xs text-indigo-700 dark:text-indigo-300">
                         <svg class="w-4 h-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.3 1 2.1V18h6v-1.2c0-.8.4-1.6 1-2.1A7 7 0 0 0 12 2z"/></svg>
@@ -1031,7 +1023,7 @@ html.dark .agent-tab.active {
                         </button>
                     </div>
                     <div class="flex gap-2">
-                        <input type="file" id="chat-file-input" class="hidden"
+                        <input type="file" id="chat-file-input" class="hidden" multiple
                                accept="image/*,.pdf,.txt,.md,.log,.json,.yaml,.yml,.xml,.csv,.tsv,.py,.js,.ts,.tsx,.jsx,.java,.go,.rs,.c,.cpp,.h,.rb,.php,.html,.css,.sql,.sh,.toml,.ini,.zip,.docx,.xlsx,.pptx,.odt,.ods,.odp,.rtf,.epub"
                                onchange="onChatFileSelected(this)">
                         {% if agent.attachments_enabled %}
@@ -1596,7 +1588,7 @@ html.dark .agent-tab.active {
     </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/chat-ui.js') }}?v=58" defer></script>
+<script src="{{ url_for('static', filename='js/chat-ui.js') }}?v=59" defer></script>
 <script src="{{ url_for('static', filename='js/agent-state.js') }}?v=4" defer></script>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script>
@@ -4913,40 +4905,155 @@ document.addEventListener('keydown', function (e) {
 
 // ==================== File Upload Helpers ====================
 
-function onChatFileSelected(input) {
-    const file = input.files[0];
+const _chatPendingFiles = [];
+
+function _insertChatImageReference(slot) {
+    const input = document.getElementById('chat-input');
+    const token = `[Image #${slot}]`;
+    const start = input.selectionStart == null ? input.value.length : input.selectionStart;
+    const end = input.selectionEnd == null ? start : input.selectionEnd;
+    const before = input.value.slice(0, start);
+    const after = input.value.slice(end);
+    const prefix = before && !/\s$/.test(before) ? ' ' : '';
+    const suffix = after && !/^\s/.test(after) && !/^[,.;:!?)}\]]/.test(after) ? ' ' : '';
+    const piece = prefix + token + suffix;
+    input.value = before + piece + after;
+    const cursor = (before + piece).length;
+    input.focus();
+    input.setSelectionRange(cursor, cursor);
+    input.dispatchEvent(new Event('input'));
+}
+
+function _renumberChatImageReferences(removedSlot) {
+    const input = document.getElementById('chat-input');
+    input.value = input.value
+        .replace(new RegExp(`\\[Image #${removedSlot}\\]\\s?`, 'g'), '')
+        .replace(/\[Image #(\d+)\]/g, (token, number) =>
+            Number(number) > removedSlot ? `[Image #${Number(number) - 1}]` : token);
+    input.dispatchEvent(new Event('input'));
+}
+
+function _renderChatFilePreviews() {
     const preview = document.getElementById('chat-file-preview');
-    if (!file) { preview.classList.add('hidden'); return; }
+    preview.replaceChildren();
+    _chatPendingFiles.forEach((attachment, index) => {
+        const isImage = attachment.file.type.startsWith('image/');
+        const card = document.createElement('div');
+        card.className = 'relative flex items-center gap-2 max-w-full px-2 py-1.5 bg-gray-50 dark:bg-gray-700 rounded-lg';
+        if (isImage) {
+            card.title = 'Preview image';
+            card.style.cursor = 'zoom-in';
+            card.setAttribute('role', 'button');
+            card.setAttribute('tabindex', '0');
+            card.onclick = () => openChatAttachmentPreview(index);
+            card.onkeydown = event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    openChatAttachmentPreview(index);
+                }
+            };
+        }
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'absolute w-5 h-5 rounded-full bg-gray-700 text-white text-sm leading-none hover:bg-red-600';
+        remove.style.cssText = 'top: -0.35rem; right: -0.35rem; z-index: 10;';
+        remove.title = 'Remove file';
+        remove.setAttribute('aria-label', `Remove ${attachment.file.name}`);
+        remove.textContent = '×';
+        remove.onclick = event => {
+            event.stopPropagation();
+            removeChatFileAttachment(index);
+        };
+        if (isImage) {
+            const image = document.createElement('img');
+            image.src = attachment.url;
+            image.alt = attachment.file.name;
+            image.className = 'w-12 h-12 object-cover rounded';
+            card.append(image);
+        } else {
+            const icon = document.createElement('span');
+            icon.className = 'w-12 h-12 flex items-center justify-center text-gray-400 text-xl';
+            icon.textContent = '📄';
+            card.append(icon);
+        }
+        const details = document.createElement('div');
+        details.className = 'min-w-0 pr-2';
+        const name = document.createElement('div');
+        name.className = 'text-xs text-gray-600 dark:text-gray-300 truncate max-w-40';
+        name.textContent = attachment.file.name;
+        const size = document.createElement('div');
+        size.className = 'text-[10px] text-gray-400';
+        size.textContent = _formatFileSize(attachment.file.size);
+        details.append(name, size);
+        card.append(details, remove);
+        preview.append(card);
+    });
+    preview.classList.toggle('hidden', _chatPendingFiles.length === 0);
+}
 
-    const previewImg = document.getElementById('chat-file-preview-img');
-    const previewIcon = document.getElementById('chat-file-preview-icon');
-    const previewName = document.getElementById('chat-file-preview-name');
-    const previewSize = document.getElementById('chat-file-preview-size');
-
-    previewName.textContent = file.name;
-    previewSize.textContent = file.size < 1024 ? `${file.size} B`
-        : file.size < 1048576 ? `${(file.size / 1024).toFixed(1)} KB`
-        : `${(file.size / 1048576).toFixed(1)} MB`;
-
-    if (file.type.startsWith('image/')) {
-        previewImg.src = URL.createObjectURL(file);
-        previewImg.classList.remove('hidden');
-        previewIcon.classList.add('hidden');
+function openChatAttachmentPreview(index) {
+    const images = _chatPendingFiles.filter(item => item.file.type.startsWith('image/'));
+    const imageIndex = _chatPendingFiles.slice(0, index + 1)
+        .filter(item => item.file.type.startsWith('image/')).length - 1;
+    if (!images.length || imageIndex < 0) return;
+    const urls = images.map(item => item.url);
+    if (window.Lightbox && typeof window.Lightbox.open === 'function') {
+        window.Lightbox.open(urls, imageIndex);
     } else {
-        previewImg.classList.add('hidden');
-        previewIcon.classList.remove('hidden');
+        window.open(urls[imageIndex], '_blank', 'noopener');
     }
-    preview.classList.remove('hidden');
+}
+
+function addChatFileAttachments(files, { insertImageReferences = true } = {}) {
+    const accepted = Array.from(files || []).filter(_isFileAccepted);
+    if (!accepted.length) return;
+    for (const file of accepted) {
+        _chatPendingFiles.push({ file, url: URL.createObjectURL(file) });
+        if (insertImageReferences && file.type.startsWith('image/')) {
+            const imageSlot = _chatPendingFiles.filter(item => item.file.type.startsWith('image/')).length;
+            _insertChatImageReference(imageSlot);
+        }
+    }
+    _renderChatFilePreviews();
+}
+
+function onChatFileSelected(input) {
+    addChatFileAttachments(input.files);
+    input.value = '';
+}
+
+function removeChatFileAttachment(index) {
+    const [attachment] = _chatPendingFiles.splice(index, 1);
+    if (attachment) {
+        URL.revokeObjectURL(attachment.url);
+        if (attachment.file.type.startsWith('image/')) {
+            const removedSlot = _chatPendingFiles.slice(0, index)
+                .filter(item => item.file.type.startsWith('image/')).length + 1;
+            _renumberChatImageReferences(removedSlot);
+        }
+    }
+    _renderChatFilePreviews();
 }
 
 function clearChatFileInput() {
-    const input = document.getElementById('chat-file-input');
-    input.value = '';
-    const preview = document.getElementById('chat-file-preview');
-    preview.classList.add('hidden');
-    const previewImg = document.getElementById('chat-file-preview-img');
-    if (previewImg.src) { URL.revokeObjectURL(previewImg.src); previewImg.src = ''; }
+    while (_chatPendingFiles.length) URL.revokeObjectURL(_chatPendingFiles.pop().url);
+    document.getElementById('chat-file-input').value = '';
+    _renderChatFilePreviews();
 }
+
+(function initChatImagePaste() {
+    const input = document.getElementById('chat-input');
+    if (!input) return;
+    input.addEventListener('paste', function(event) {
+        const images = Array.from(event.clipboardData?.items || [])
+            .filter(item => item.type.startsWith('image/'))
+            .map(item => item.getAsFile())
+            .filter(Boolean);
+        if (!images.length) return;
+        event.preventDefault();
+        addChatFileAttachments(images);
+    });
+})();
 
 // ==================== Drag & Drop File Upload ====================
 
@@ -4968,7 +5075,8 @@ function _isFileAccepted(file) {
 }
 
 (function initChatDropZone() {
-    const zone = document.getElementById('chat-drop-zone');
+    // Listen on the entire panel so a user can drop over the composer as well as messages.
+    const zone = document.getElementById('chat-panel');
     if (!zone) return;
     const overlay = document.getElementById('chat-drop-overlay');
 
@@ -4990,13 +5098,17 @@ function _isFileAccepted(file) {
         e.preventDefault();
         _dragCounter = 0;
         overlay.classList.add('hidden');
-        const file = e.dataTransfer.files[0];
-        if (!file) return;
-        if (!_isFileAccepted(file)) {
+        const droppedFiles = Array.from(e.dataTransfer?.files || []);
+        const accepted = droppedFiles.filter(_isFileAccepted);
+        if (!accepted.length) {
             if (typeof showToast === 'function') showToast('File type not supported', true);
             return;
         }
-        openChatDropModal(file);
+        addChatFileAttachments(accepted);
+        if (accepted.length !== droppedFiles.length && typeof showToast === 'function') {
+            showToast('Some dropped files are not supported', 'error');
+        }
+        document.getElementById('chat-input').focus();
     });
 })();
 
@@ -5039,17 +5151,13 @@ function submitChatDropModal() {
     if (!_droppedFile) return;
     const msgInput = document.getElementById('chat-drop-message');
     const chatInput = document.getElementById('chat-input');
-    const fileInput = document.getElementById('chat-file-input');
 
     // Set message text if provided
     if (msgInput.value.trim()) chatInput.value = msgInput.value.trim();
 
-    // Inject dropped file into the file input
-    const dt = new DataTransfer();
-    dt.items.add(_droppedFile);
-    fileInput.files = dt.files;
-
+    const droppedFile = _droppedFile;
     closeChatDropModal();
+    addChatFileAttachments([droppedFile]);
     sendChat();
 }
 
@@ -5086,9 +5194,12 @@ function stopChat() {
 async function sendChat() {
     const input = document.getElementById('chat-input');
     const msg = input.value.trim();
-    const fileInput = document.getElementById('chat-file-input');
-    const file = fileInput.files[0] || null;
-    if (!msg && !file) return;
+    const files = _chatPendingFiles.map(attachment => attachment.file);
+    if (!msg && !files.length) return;
+    const optimisticUrls = files.map(file => URL.createObjectURL(file));
+    const attachmentInfos = files.map(file => ({
+        filename: file.name, mime_type: file.type, is_image: file.type.startsWith('image/'), size_bytes: file.size,
+    }));
     input.value = '';
     input.style.height = 'auto';
     input.style.overflowY = 'hidden';
@@ -5103,19 +5214,17 @@ async function sendChat() {
     });
     window._clearChatDraft();
     hideEditorTip();
-    if (file) clearChatFileInput();
+    clearChatFileInput();
 
-    // Build optimistic metadata for image/file preview
-    let optimisticMeta = null;
-    if (file && file.type.startsWith('image/')) {
-        optimisticMeta = {image_url: URL.createObjectURL(file), _blob_url: true};
-    } else if (file) {
-        optimisticMeta = {attachment_info: {filename: file.name, mime_type: file.type, is_image: false}};
-    }
-    const displayText = msg || (file ? (file.type.startsWith('image/') ? '[Image]' : `[File: ${file.name}]`) : '');
+    const optimisticMeta = attachmentInfos.length
+        ? { image_urls: optimisticUrls.filter((_, index) => attachmentInfos[index].is_image), attachment_infos: attachmentInfos }
+        : null;
+    let imageSlot = 0;
+    const displayText = msg || attachmentInfos.map(info =>
+        info.is_image ? `[Image #${++imageSlot}]` : `[File: ${info.filename}]`).join(' ');
 
     const $msgEl = chatUI.appendMessage('user', displayText, {metadata: optimisticMeta});
-    if (file) chatUI.markMessageUploading($msgEl);
+    if (files.length) chatUI.markMessageUploading($msgEl);
     // Capture the user message wrapper for anchoring the thinking bubble
     const container = document.getElementById('chat-messages');
     const userWrappers = container ? container.querySelectorAll('[data-msg-role="user"]') : [];
@@ -5123,13 +5232,13 @@ async function sendChat() {
     chatUI.scrollToBottom();
     setChatBusy(true);
 
-    // Post chat message — uses XHR for file uploads (progress tracking), fetch otherwise
+    // Post chat message — uses XHR for uploads so all attachment progress is tracked together.
     function postChat(url, signal) {
-        if (file) {
+        if (files.length) {
             const formData = new FormData();
             formData.append('message', msg);
             formData.append('user_id', 'web_test');
-            formData.append('file', file);
+            files.forEach(file => formData.append('files', file));
             return new Promise((resolve, reject) => {
                 const xhr = new XMLHttpRequest();
                 xhr.open('POST', url);

--- a/unit_tests/test_chat_multiple_images.py
+++ b/unit_tests/test_chat_multiple_images.py
@@ -1,0 +1,134 @@
+import os
+from io import BytesIO
+
+from app import app
+from backend.agent_runtime import agent_runtime
+from backend.agent_runtime.context import build_message_entry
+from backend.agent_runtime.runtime import _append_attachment_context
+from models.chatlog import _reconstruct_llm_messages
+from routes import agents as agents_route
+from routes import sessions as sessions_route
+
+
+def test_build_message_entry_lists_each_attachment_for_image_tools():
+    msg = {
+        'role': 'user',
+        'content': 'Bandingkan [Image #1] dan [Image #2].',
+        'metadata': {
+            'image_url': 'data:image/jpeg;base64,first',
+            'attachment_infos': [
+                {'filename': 'first.png', 'mime_type': 'image/png', 'size_bytes': 1024, 'file_path': 'data/first.png'},
+                {'filename': 'second.png', 'mime_type': 'image/png', 'size_bytes': 2048, 'file_path': 'data/second.png'},
+            ],
+        },
+    }
+
+    content = build_message_entry(msg, {})['content']
+
+    assert '[Attachment #1: first.png (image/png, 1.0 KB)]' in content
+    assert '[Attachment #2: second.png (image/png, 2.0 KB)]' in content
+    assert content.count('Use the `describe_image` tool') == 2
+
+
+def test_jsonl_reconstruction_preserves_every_attachment_info():
+    infos = [
+        {'filename': 'first.png', 'mime_type': 'image/png', 'size_bytes': 1024, 'file_path': 'data/first.png'},
+        {'filename': 'second.png', 'mime_type': 'image/png', 'size_bytes': 2048, 'file_path': 'data/second.png'},
+    ]
+    messages = _reconstruct_llm_messages([{
+        'type': 'user', 'content': 'Bandingkan [Image #1] dan [Image #2].',
+        'metadata': {'attachment_infos': infos},
+    }])
+
+    assert messages == [{
+        'role': 'user', 'content': 'Bandingkan [Image #1] dan [Image #2].',
+        'attachment_infos': infos,
+    }]
+
+
+def test_jsonl_reconstruction_preserves_legacy_singular_attachment_info():
+    info = {'filename': 'legacy.png', 'mime_type': 'image/png', 'size_bytes': 42, 'file_path': 'data/legacy.png'}
+    messages = _reconstruct_llm_messages([{
+        'type': 'user', 'content': '[Image]', 'metadata': {'attachment_info': info},
+    }])
+
+    assert messages == [{'role': 'user', 'content': '[Image]', 'attachment_info': info}]
+
+
+def test_runtime_attachment_context_lists_all_jsonl_images_with_absolute_paths():
+    content = _append_attachment_context(
+        'Bandingkan [Image #1] dan [Image #2].',
+        [
+            {'filename': 'first.png', 'mime_type': 'image/png', 'size_bytes': 1024, 'file_path': 'data/first.png'},
+            {'filename': 'second.png', 'mime_type': 'image/png', 'size_bytes': 2048, 'file_path': 'data/second.png'},
+        ],
+        None, {}, True,
+    )
+
+    assert '[Attachment #1: first.png (image/png, 1.0 KB)]' in content
+    assert '[Attachment #2: second.png (image/png, 2.0 KB)]' in content
+    assert f'File path: {os.path.abspath("data/first.png")}' in content
+    assert f'File path: {os.path.abspath("data/second.png")}' in content
+    assert content.count('Use the `describe_image` tool') == 2
+
+
+def test_legacy_singular_attachment_context_is_unchanged():
+    content = _append_attachment_context(
+        '[Image]', None,
+        {'filename': 'legacy.png', 'mime_type': 'image/png', 'size_bytes': 42, 'file_path': 'data/legacy.png'},
+        {}, True,
+    )
+
+    assert '[Attachment: legacy.png (image/png, 42 B)]' in content
+    assert '[Attachment #' not in content
+    assert f'File path: {os.path.abspath("data/legacy.png")}' in content
+    assert content.count('Use the `describe_image` tool') == 1
+
+
+def test_invalid_plural_attachment_metadata_falls_back_to_legacy_attachment():
+    legacy = {'filename': 'legacy.png', 'mime_type': 'image/png', 'size_bytes': 42, 'file_path': 'data/legacy.png'}
+    msg = {
+        'role': 'user', 'content': '[Image]',
+        'metadata': {'image_url': 'data:image/png;base64,legacy', 'attachment_infos': ['invalid'], 'attachment_info': legacy},
+    }
+
+    db_content = build_message_entry(msg, {})['content']
+    runtime_content = _append_attachment_context('[Image]', ['invalid'], legacy, {}, True)
+
+    for content in (db_content, runtime_content):
+        assert '[Attachment: legacy.png (image/png, 42 B)]' in content
+        assert '[Attachment #' not in content
+        assert content.count('Use the `describe_image` tool') == 1
+
+
+def test_api_chat_accepts_repeated_files_and_preserves_image_order(monkeypatch):
+    uploads = []
+    monkeypatch.setattr(agents_route.db, 'get_agent', lambda agent_id: {'id': agent_id})
+    monkeypatch.setattr(agents_route.db, 'get_or_create_session', lambda *args: 'session-1')
+    monkeypatch.setattr(agents_route.db, 'get_agent_attachment_config', lambda agent_id: {'enabled': True, 'max_size_mb': 20})
+
+    def process(file, *args):
+        uploads.append(file.filename)
+        return {
+            'image_url': f'data:image/jpeg;base64,{file.filename}',
+            'text_prefix': None,
+            'attachment_info': {'filename': file.filename, 'mime_type': 'image/png', 'is_image': True, 'attachment_id': len(uploads)},
+        }
+
+    captured = {}
+    monkeypatch.setattr(sessions_route, '_process_upload', process)
+    monkeypatch.setattr(agent_runtime, 'handle_message', lambda *args, **kwargs: captured.update(kwargs) or {
+        'response': 'ok', 'tool_trace': [], 'timeline': [],
+    })
+
+    with app.test_request_context('/api/agents/a/chat', method='POST', data={
+        'message': 'Compare [Image #1] and [Image #2].',
+        'user_id': 'web_test',
+        'files': [(BytesIO(b'first'), 'first.png'), (BytesIO(b'second'), 'second.png')],
+    }):
+        response = agents_route.api_chat('a')
+
+    assert response.status_code == 200
+    assert uploads == ['first.png', 'second.png']
+    assert captured['image_url'].endswith('first.png')
+    assert [info['filename'] for info in captured['metadata']['attachment_infos']] == uploads


### PR DESCRIPTION
## What

Adds first-class multiple-image uploads to ChatView. Users can select, paste, or drag in several images, review or remove each pending image, and send them together in one message.

The complete attachment list is persisted through the JSONL and runtime context paths, so agents receive a path and `describe_image` instruction for every submitted image after restarts as well as during the initial request.

## Changes

- **ChatView UI**
  - Accept multiple image files from the picker, clipboard, and drag-and-drop.
  - Show per-image previews with removal controls and a lightbox for pending images.
  - Insert ordered `[Image #n]` references into the message and render multiple stored images in chat history.
  - Preserve adaptive image-token spacing while editing and removing attachments.

- **Upload and persistence**
  - Submit repeated `files` multipart fields while retaining legacy single-`file` support.
  - Preserve ordered image URLs and attachment metadata in session messages.

- **Runtime context**
  - Carry plural `attachment_infos` through JSONL reconstruction, turn prefetch, and live runtime context construction.
  - Add an absolute stored path and `describe_image` guidance for each image attachment.
  - Keep singular `attachment_info` as a compatibility fallback for existing sessions.

- **Regression coverage**
  - Add focused tests for repeated uploads, JSONL reconstruction, plural runtime context, legacy singular metadata, and malformed plural metadata fallback.

## Backward Compatibility

- Existing single-image uploads continue to use the legacy `attachment_info` format.
- Existing callers that submit a single `file` remain supported.
- Empty or invalid plural attachment metadata safely falls back to valid legacy singular metadata when present.

## Testing

Focused attachment and chatlog coverage:

```bash
venv/bin/python -m pytest -q \
  unit_tests/test_chat_multiple_images.py \
  unit_tests/test_convs_tail_start.py \
  unit_tests/test_attachments_mixin.py \
  unit_tests/test_read_attachment_tool.py
```

Result: **50 passed**.

Also validated Python compilation and `git diff --check`.

The full `unit_tests` suite completed with **1502 passed, 89 skipped, 3 unrelated failures, and 1 unrelated setup error**. The unrelated failures are in the existing frontend SSE lifecycle, knowledge-builder evaluator, and Kanban state-handler tests.

## Notes

Manual validation with two uploaded images confirmed that the agent can access and describe each image independently, rather than relying only on the textual image references.
