### PR TITLE
fix(patch): standardize Git diff input format

### DIFF
--- a/backend/tools/patch.py
+++ b/backend/tools/patch.py
@@ -722,6 +722,23 @@ def apply_patch(file_path: str, patch_text: str) -> dict:
     return apply_hunks(file_path, patch_text)
 
 
+_LEGACY_FORMAT_WARNING = (
+    'Legacy hunk-only patch accepted for backward compatibility; '
+    'prefer a complete single-file git diff.'
+)
+
+
+def _with_legacy_format_warning(result: dict, legacy_hunk_only: bool) -> dict:
+    if not legacy_hunk_only or result.get('result') != 'success':
+        return result
+    existing = result.get('warning')
+    result['warning'] = (
+        f'{existing} {_LEGACY_FORMAT_WARNING}' if existing
+        else _LEGACY_FORMAT_WARNING
+    )
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Tool entry point
 # ---------------------------------------------------------------------------
@@ -779,11 +796,24 @@ def execute(agent, args: dict) -> dict:
     # Normalise smart quotes in patch content before applying
     from backend.normalizer import normalize_code_quotes
     patch_text = normalize_code_quotes(patch_text)
-    try:
-        patch_info = validate_git_patch_format(patch_text)
-    except ValueError as e:
-        return {'error': f'Invalid Git unified diff: {e}'}
-    creating_new = patch_info['is_new_file']
+    parsed_hunks = parse_hunks(patch_text)
+    has_git_header = any(
+        line.startswith('diff --git ') for line in patch_text.splitlines()
+    )
+    legacy_hunk_only = not has_git_header and bool(parsed_hunks)
+    if legacy_hunk_only:
+        creating_new = all(
+            h['old_start'] == 0 and h['old_count'] == 0
+            for h in parsed_hunks
+        )
+        declares_new_file = False
+    else:
+        try:
+            patch_info = validate_git_patch_format(patch_text)
+        except ValueError as e:
+            return {'error': f'Invalid Git unified diff: {e}'}
+        creating_new = patch_info['is_new_file']
+        declares_new_file = creating_new
 
     # /_self/ path: always route to the agent's local directory on the evonic server.
     # Sub-agents inherit their parent's directory — use effective agent ID.
@@ -795,7 +825,7 @@ def execute(agent, args: dict) -> dict:
         if not local_path:
             return {'error': "Access denied — path escapes agent directory."}
         target_exists = os.path.exists(local_path)
-        if creating_new and target_exists:
+        if declares_new_file and target_exists:
             return {'error': f'File already exists: {file_path}'}
         # If the file doesn't exist (and patch isn't creating a new file),
         # check for similar names (typos).
@@ -821,7 +851,7 @@ def execute(agent, args: dict) -> dict:
                         result['warning'] = _warn
                 except Exception:
                     pass
-        return result
+        return _with_legacy_format_warning(result, legacy_hunk_only)
 
     # Hint when path starts with _self/ but missing leading slash
     if agent_id and file_path and (file_path.startswith('_self/') or file_path == '_self'):
@@ -834,7 +864,7 @@ def execute(agent, args: dict) -> dict:
             return {'error': real_path}  # error message
 
         target_exists = backend.file_exists(real_path)
-        if creating_new and target_exists:
+        if declares_new_file and target_exists:
             return {'error': f'File already exists: {file_path}'}
         if not target_exists:
             if not creating_new:
@@ -858,7 +888,10 @@ def execute(agent, args: dict) -> dict:
         if 'error' in wr:
             return {'error': wr['error']}
 
-        return {'result': 'success', 'hunks_applied': result.get('hunks_applied', 0)}
+        return _with_legacy_format_warning({
+            'result': 'success',
+            'hunks_applied': result.get('hunks_applied', 0),
+        }, legacy_hunk_only)
 
     # When sandbox is enabled, the agent has a workplace, or run-as-user is
     # set, route file I/O through the execution backend (Docker container,
@@ -877,7 +910,7 @@ def execute(agent, args: dict) -> dict:
         # Convert host path to the backend's view (e.g. /workspace for Docker)
         target_path = backend.resolve_path(target_path)
         target_exists = backend.file_exists(target_path)
-        if creating_new and target_exists:
+        if declares_new_file and target_exists:
             return {'error': f'File already exists: {file_path}'}
         if not target_exists:
             if not creating_new:
@@ -901,7 +934,10 @@ def execute(agent, args: dict) -> dict:
         if 'error' in wr:
             return {'error': wr['error']}
 
-        return {'result': 'success', 'hunks_applied': result.get('hunks_applied', 0)}
+        return _with_legacy_format_warning({
+            'result': 'success',
+            'hunks_applied': result.get('hunks_applied', 0),
+        }, legacy_hunk_only)
 
     # No sandbox — direct host filesystem access (original behavior)
     workspace_root = None
@@ -915,7 +951,7 @@ def execute(agent, args: dict) -> dict:
                 workspace_root = os.path.abspath(agent_workspace or fallback)
                 file_path = resolved
 
-    if creating_new and os.path.exists(file_path):
+    if declares_new_file and os.path.exists(file_path):
         return {'error': f'File already exists: {file_path}'}
 
     result = apply_patch(file_path, patch_text)
@@ -925,7 +961,7 @@ def execute(agent, args: dict) -> dict:
     if workspace_root and 'error' in result:
         result['error'] = result['error'].replace(workspace_root, '/workspace')
 
-    return result
+    return _with_legacy_format_warning(result, legacy_hunk_only)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tools/patch.py
+++ b/backend/tools/patch.py
@@ -1,13 +1,16 @@
-"""Backend implementation for the patch tool — applies unified diff patches to files.
+"""Backend implementation for the patch tool.
 
-Primary backend: system `patch` utility (used when available on PATH).
-Fallback backend: pure-Python implementation that is reliable for all hunk types,
-including insertion-only hunks with no surrounding context.
+The model-facing tool accepts a single-file text patch in the standard format
+emitted by ``git diff``.  Application is handled by the pure-Python engine so
+tracked, untracked, and not-yet-created files all work without requiring a Git
+repository.
 """
 
+import ast
 import logging
 import os
 import re
+import shlex
 
 try:
     from config import SANDBOX_WORKSPACE as _WORKSPACE_ROOT
@@ -23,6 +26,17 @@ except ImportError:
     logger.warning("safety_pipeline unavailable — safety checks disabled for patch tool")
     should_skip_safety = lambda agent: True
 SEARCH_WINDOW = 50
+_HUNK_HEADER_RE = re.compile(
+    r'^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$'
+)
+_UNSUPPORTED_GIT_METADATA = (
+    'GIT binary patch',
+    'Binary files ',
+    'rename from ',
+    'rename to ',
+    'copy from ',
+    'copy to ',
+)
 
 
 def _unescape_llm(s: str) -> str:
@@ -43,6 +57,189 @@ def _normalize_for_match(s: str) -> str:
 # ---------------------------------------------------------------------------
 # Patch parser
 # ---------------------------------------------------------------------------
+
+def _patch_header_path(line: str, prefix: str) -> str:
+    """Extract a path from a ``---`` or ``+++`` patch header."""
+    value = line[len(prefix):]
+    if not value:
+        raise ValueError(f'Missing path after {prefix.strip()} header.')
+    # Traditional unified diffs may append a timestamp after a tab.
+    return _decode_git_path(value.split('\t', 1)[0])
+
+
+def _decode_git_path(value: str) -> str:
+    """Decode Git's C-style quoted path representation."""
+    if not value.startswith('"'):
+        return value
+    if not value.endswith('"'):
+        raise ValueError(f'Invalid quoted Git path: {value!r}.')
+    try:
+        raw = ast.literal_eval('b' + value)
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(f'Invalid quoted Git path: {value!r}.') from exc
+    return raw.decode('utf-8', errors='surrogateescape')
+
+
+def _strip_git_prefix(path: str) -> str:
+    if path.startswith(('a/', 'b/')):
+        return path[2:]
+    return path
+
+
+def validate_git_patch_format(patch_text: str) -> dict:
+    """Validate the model-facing single-file ``git diff`` patch contract.
+
+    The runtime intentionally does not invoke Git.  This validator enforces the
+    textual format before the pure-Python engine applies the hunks.
+    """
+    lines = patch_text.splitlines()
+    if not lines:
+        raise ValueError('Patch is empty.')
+
+    diff_indexes = [
+        i for i, line in enumerate(lines) if line.startswith('diff --git ')
+    ]
+    if not diff_indexes:
+        raise ValueError(
+            'Missing "diff --git a/<path> b/<path>" header. '
+            'Hunk-only patches are not accepted by the patch tool.'
+        )
+    if len(diff_indexes) != 1:
+        raise ValueError(
+            'The patch tool accepts exactly one file per call; '
+            'split multi-file patches into separate calls.'
+        )
+
+    diff_index = diff_indexes[0]
+    try:
+        diff_parts = shlex.split(lines[diff_index], posix=False)
+    except ValueError as exc:
+        raise ValueError(f'Invalid diff --git header: {exc}') from exc
+    if len(diff_parts) != 4 or diff_parts[:2] != ['diff', '--git']:
+        raise ValueError('Invalid diff --git header.')
+    diff_old_path = _decode_git_path(diff_parts[2])
+    diff_new_path = _decode_git_path(diff_parts[3])
+
+    section = lines[diff_index + 1:]
+    first_hunk_index = next(
+        (i for i, line in enumerate(section) if line.startswith('@@ ')),
+        None,
+    )
+    if first_hunk_index is None:
+        raise ValueError('Patch contains no hunks.')
+    metadata = section[:first_hunk_index]
+    for line in metadata:
+        if line.startswith(_UNSUPPORTED_GIT_METADATA):
+            raise ValueError(
+                'Binary, rename, and copy patches are not supported by this '
+                'single-file text patch tool.'
+            )
+
+    old_header_indexes = [
+        i for i, line in enumerate(metadata) if line.startswith('--- ')
+    ]
+    new_header_indexes = [
+        i for i, line in enumerate(metadata) if line.startswith('+++ ')
+    ]
+    if len(old_header_indexes) != 1 or len(new_header_indexes) != 1:
+        raise ValueError(
+            'A text patch must contain exactly one --- path and one +++ path header.'
+        )
+
+    old_header_index = old_header_indexes[0]
+    new_header_index = new_header_indexes[0]
+    if new_header_index != old_header_index + 1:
+        raise ValueError('The +++ path header must immediately follow the --- path header.')
+
+    old_path = _patch_header_path(section[old_header_index], '--- ')
+    new_path = _patch_header_path(section[new_header_index], '+++ ')
+    if old_path == '/dev/null' and new_path == '/dev/null':
+        raise ValueError('Both patch paths cannot be /dev/null.')
+    if new_path == '/dev/null':
+        raise ValueError(
+            'File-deletion patches are not supported; use the delete_file tool.'
+        )
+
+    is_new_file = old_path == '/dev/null'
+    normalized_new = _strip_git_prefix(new_path)
+    normalized_diff_old = _strip_git_prefix(diff_old_path)
+    normalized_diff_new = _strip_git_prefix(diff_new_path)
+    if normalized_diff_old != normalized_diff_new:
+        raise ValueError('Rename patches are not supported.')
+    if normalized_diff_new != normalized_new:
+        raise ValueError('The diff --git and +++ paths refer to different files.')
+    if not is_new_file and _strip_git_prefix(old_path) != normalized_new:
+        raise ValueError('The --- and +++ paths refer to different files.')
+
+    body = section[new_header_index + 1:]
+    if not body:
+        raise ValueError('Patch contains no hunks.')
+
+    hunk_count = 0
+    i = 0
+    while i < len(body):
+        header = body[i]
+        match = _HUNK_HEADER_RE.match(header)
+        if not match:
+            raise ValueError(f'Unexpected line outside a hunk: {header!r}.')
+
+        old_count = int(match.group(2)) if match.group(2) is not None else 1
+        new_count = int(match.group(4)) if match.group(4) is not None else 1
+        old_seen = 0
+        new_seen = 0
+        saw_patch_line = False
+        previous_was_patch_line = False
+        i += 1
+
+        while i < len(body) and not body[i].startswith('@@ '):
+            line = body[i]
+            if line.startswith(' '):
+                old_seen += 1
+                new_seen += 1
+                saw_patch_line = True
+                previous_was_patch_line = True
+            elif line.startswith('-'):
+                old_seen += 1
+                saw_patch_line = True
+                previous_was_patch_line = True
+            elif line.startswith('+'):
+                new_seen += 1
+                saw_patch_line = True
+                previous_was_patch_line = True
+            elif line == r'\ No newline at end of file':
+                if not previous_was_patch_line:
+                    raise ValueError(
+                        'The no-newline marker must follow a patch content line.'
+                    )
+                previous_was_patch_line = False
+            else:
+                raise ValueError(f'Invalid hunk line: {line!r}.')
+            i += 1
+
+        if not saw_patch_line:
+            raise ValueError('Patch hunk has no content.')
+        if old_seen != old_count or new_seen != new_count:
+            raise ValueError(
+                'Hunk line counts do not match its @@ header '
+                f'(expected old={old_count}, new={new_count}; '
+                f'found old={old_seen}, new={new_seen}).'
+            )
+        hunk_count += 1
+
+    if is_new_file:
+        hunks = parse_hunks(patch_text)
+        if any(h['old_start'] != 0 or h['old_count'] != 0 for h in hunks):
+            raise ValueError(
+                'A new-file patch must use an empty old range such as -0,0.'
+            )
+
+    return {
+        'old_path': old_path,
+        'new_path': new_path,
+        'is_new_file': is_new_file,
+        'hunk_count': hunk_count,
+    }
+
 
 def parse_hunks(patch_text: str) -> list:
     """
@@ -67,15 +264,16 @@ def parse_hunks(patch_text: str) -> list:
         line = raw_line.rstrip('\r\n')
 
         if re.match(r'^(diff --git|index |old mode|new mode|deleted file|new file)', line):
-            continue
-
-        if line.startswith('--- ') or line.startswith('+++ '):
-            if current_hunk is not None:
+            if line.startswith('diff --git') and current_hunk is not None:
                 hunks.append(current_hunk)
                 current_hunk = None
             continue
 
-        hunk_match = re.match(r'^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@', line)
+        if current_hunk is None and (
+                line.startswith('--- ') or line.startswith('+++ ')):
+            continue
+
+        hunk_match = _HUNK_HEADER_RE.match(line)
         if hunk_match:
             if current_hunk is not None:
                 hunks.append(current_hunk)
@@ -276,11 +474,14 @@ def _apply_hunks_to_content(raw: str, patch_text: str) -> dict:
         if hunk['old_count'] == 0:
             insert_pos = hunk['new_start'] - 1 + offset
             insert_pos = max(0, min(insert_pos, len(lines)))
-            new_lines = [txt for op, txt, _ in hunk_lines if op == '+']
+            touches_eof = insert_pos == len(lines)
+            added = [(txt, no_newline) for op, txt, no_newline in hunk_lines
+                     if op == '+']
+            new_lines = [txt for txt, _ in added]
             lines = lines[:insert_pos] + new_lines + lines[insert_pos:]
             offset += len(new_lines)
-            if new_lines:
-                trailing_newline = True
+            if new_lines and touches_eof:
+                trailing_newline = not added[-1][1]
             continue
 
         # ── Context hunk: find matching position ──
@@ -339,8 +540,13 @@ def _apply_hunks_to_content(raw: str, patch_text: str) -> dict:
 
         consumed = sum(1 for op, _, _ in hunk_lines if op in (' ', '-'))
         produced = sum(1 for op, _, _ in hunk_lines if op in (' ', '+'))
+        touches_eof = pos + consumed == len(lines)
         lines = lines[:pos] + result_lines + lines[pos + consumed:]
         offset += produced - consumed
+        if touches_eof:
+            new_side = [(op, no_newline) for op, _, no_newline in hunk_lines
+                        if op in (' ', '+')]
+            trailing_newline = bool(new_side) and not new_side[-1][1]
 
     # Reconstruct file content.
     result = '\n'.join(lines)
@@ -407,11 +613,14 @@ def apply_hunks(file_path: str, patch_text: str) -> dict:
         if hunk['old_count'] == 0:
             insert_pos = hunk['new_start'] - 1 + offset
             insert_pos = max(0, min(insert_pos, len(lines)))
-            new_lines = [txt for op, txt, _ in hunk_lines if op == '+']
+            touches_eof = insert_pos == len(lines)
+            added = [(txt, no_newline) for op, txt, no_newline in hunk_lines
+                     if op == '+']
+            new_lines = [txt for txt, _ in added]
             lines = lines[:insert_pos] + new_lines + lines[insert_pos:]
             offset += len(new_lines)
-            if new_lines:
-                trailing_newline = True
+            if new_lines and touches_eof:
+                trailing_newline = not added[-1][1]
             continue
 
         # ── Context hunk: find matching position ──────────────────────────
@@ -472,8 +681,13 @@ def apply_hunks(file_path: str, patch_text: str) -> dict:
 
         consumed = sum(1 for op, _, _ in hunk_lines if op in (' ', '-'))
         produced = sum(1 for op, _, _ in hunk_lines if op in (' ', '+'))
+        touches_eof = pos + consumed == len(lines)
         lines = lines[:pos] + result_lines + lines[pos + consumed:]
         offset += produced - consumed
+        if touches_eof:
+            new_side = [(op, no_newline) for op, _, no_newline in hunk_lines
+                        if op in (' ', '+')]
+            trailing_newline = bool(new_side) and not new_side[-1][1]
 
     # Reconstruct file content.
     result = '\n'.join(lines)
@@ -565,6 +779,11 @@ def execute(agent, args: dict) -> dict:
     # Normalise smart quotes in patch content before applying
     from backend.normalizer import normalize_code_quotes
     patch_text = normalize_code_quotes(patch_text)
+    try:
+        patch_info = validate_git_patch_format(patch_text)
+    except ValueError as e:
+        return {'error': f'Invalid Git unified diff: {e}'}
+    creating_new = patch_info['is_new_file']
 
     # /_self/ path: always route to the agent's local directory on the evonic server.
     # Sub-agents inherit their parent's directory — use effective agent ID.
@@ -575,16 +794,12 @@ def execute(agent, args: dict) -> dict:
         local_path = resolve_self_path(agent_id, file_path)
         if not local_path:
             return {'error': "Access denied — path escapes agent directory."}
+        target_exists = os.path.exists(local_path)
+        if creating_new and target_exists:
+            return {'error': f'File already exists: {file_path}'}
         # If the file doesn't exist (and patch isn't creating a new file),
         # check for similar names (typos).
-        if not os.path.exists(local_path):
-            # Check if this patch is creating a new file
-            creating_new = False
-            try:
-                hunks_temp = parse_hunks(patch_text)
-                creating_new = all(h['old_start'] == 0 and h['old_count'] == 0 for h in hunks_temp)
-            except Exception:
-                pass
+        if not target_exists:
             if not creating_new:
                 suggestion = _self_fuzzy_suggestion(agent_id, file_path)
                 if suggestion:
@@ -618,15 +833,10 @@ def execute(agent, args: dict) -> dict:
         if backend is None:
             return {'error': real_path}  # error message
 
-        # Parse hunks to check if this is creating a new file
-        creating_new = False
-        try:
-            hunks = parse_hunks(patch_text)
-            creating_new = all(h['old_start'] == 0 and h['old_count'] == 0 for h in hunks)
-        except Exception:
-            pass
-
-        if not backend.file_exists(real_path):
+        target_exists = backend.file_exists(real_path)
+        if creating_new and target_exists:
+            return {'error': f'File already exists: {file_path}'}
+        if not target_exists:
             if not creating_new:
                 return {'error': f'File not found: {file_path}'}
             parent = os.path.dirname(real_path)
@@ -666,14 +876,10 @@ def execute(agent, args: dict) -> dict:
         target_path = resolve_workspace_path(agent, file_path, _WORKSPACE_ROOT)
         # Convert host path to the backend's view (e.g. /workspace for Docker)
         target_path = backend.resolve_path(target_path)
-        creating_new = False
-        try:
-            hunks = parse_hunks(patch_text)
-            creating_new = all(h['old_start'] == 0 and h['old_count'] == 0 for h in hunks)
-        except Exception:
-            pass
-
-        if not backend.file_exists(target_path):
+        target_exists = backend.file_exists(target_path)
+        if creating_new and target_exists:
+            return {'error': f'File already exists: {file_path}'}
+        if not target_exists:
             if not creating_new:
                 return {'error': f'File not found: {file_path}'}
             parent = os.path.dirname(target_path)
@@ -708,6 +914,9 @@ def execute(agent, args: dict) -> dict:
             if resolved != file_path:
                 workspace_root = os.path.abspath(agent_workspace or fallback)
                 file_path = resolved
+
+    if creating_new and os.path.exists(file_path):
+        return {'error': f'File already exists: {file_path}'}
 
     result = apply_patch(file_path, patch_text)
 

--- a/tools/patch.json
+++ b/tools/patch.json
@@ -1,10 +1,10 @@
 {
   "id": "patch",
   "name": "Patch File",
-  "description": "Apply a single-file text patch in standard git diff format.",
+  "description": "Apply a text patch; complete git diff is canonical and legacy hunk-only input remains compatible.",
   "function": {
     "name": "patch",
-    "description": "Apply a single-file text patch in standard git diff format. Works for tracked, untracked, and new files without requiring a Git repository.",
+    "description": "Apply a text patch to a tracked, untracked, or new file without requiring a Git repository. Prefer complete single-file git diff format; legacy hunk-only input is also accepted.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -14,7 +14,7 @@
         },
         "patch": {
           "type": "string",
-          "description": "A complete single-file text patch in git diff format. It must include diff --git, ---, +++, and @@ headers. Example:\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new",
+          "description": "Prefer a complete single-file git diff with diff --git, ---, +++, and @@ headers. Legacy hunk-only input beginning with @@ remains accepted for backward compatibility. Example:\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new",
           "view": "diff"
         }
       },
@@ -24,9 +24,9 @@
       ]
     }
   },
-  "mock_response": "patch_text = args.get('patch', '')\nfile_path = args.get('file_path', 'unknown')\nif not patch_text:\n    result = {'error': \"Missing required argument: 'patch'\"}\nelif patch_text.count('diff --git ') != 1 or '\\n--- ' not in patch_text or '\\n+++ ' not in patch_text:\n    result = {'error': 'Invalid Git unified diff: include exactly one diff --git section plus --- and +++ path headers.'}\nelse:\n    hunk_count = patch_text.count('@@') // 2\n    if hunk_count == 0:\n        result = {'error': 'Invalid Git unified diff: patch contains no @@ hunks.'}\n    else:\n        result = {'result': 'success', 'file_path': file_path, 'hunks_applied': hunk_count}",
+  "mock_response": "patch_text = args.get('patch', '')\nfile_path = args.get('file_path', 'unknown')\nhunk_count = patch_text.count('@@') // 2 if patch_text else 0\nif not patch_text:\n    result = {'error': \"Missing required argument: 'patch'\"}\nelif hunk_count == 0:\n    result = {'error': 'No valid @@ hunks found in patch.'}\nelif 'diff --git ' in patch_text:\n    if patch_text.count('diff --git ') != 1 or '\\n--- ' not in patch_text or '\\n+++ ' not in patch_text:\n        result = {'error': 'Invalid Git unified diff: include exactly one diff --git section plus --- and +++ path headers.'}\n    else:\n        result = {'result': 'success', 'file_path': file_path, 'hunks_applied': hunk_count}\nelse:\n    result = {'result': 'success', 'file_path': file_path, 'hunks_applied': hunk_count, 'warning': 'Legacy hunk-only patch accepted for backward compatibility; prefer a complete single-file git diff.'}",
   "mock_response_type": "python",
-  "system_prompt": "## patch \u2014 Usage Rules\n\nThe `patch` argument MUST be a complete, single-file text patch in standard `git diff` format. Include `diff --git`, `---`, `+++`, and `@@` headers. Hunk-only patches are rejected. Use one tool call per file.\n\nFor an existing tracked or untracked file:\n```diff\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new\n```\n\nFor a new file:\n```diff\ndiff --git a/new.py b/new.py\nnew file mode 100644\n--- /dev/null\n+++ b/new.py\n@@ -0,0 +1,2 @@\n+first\n+second\n```\n\n**ALWAYS read an existing file immediately before constructing a patch.** Never rely on line numbers or content from memory or a previous read \u2014 each patch you apply shifts line numbers in the file.\n\n### Workflow\n1. `read_file` the target file when it exists\n2. Construct a complete single-file Git unified diff from the current content\n3. Apply with `patch`\n4. If you need to patch the same file again, go back to step 1\n\nBinary, rename, copy, deletion, and multi-file patches are unsupported; use the dedicated file tools or separate patch calls.\n\n",
+  "system_prompt": "## patch \u2014 Usage Rules\n\nThe canonical `patch` argument is a complete, single-file text patch in standard `git diff` format. Include `diff --git`, `---`, `+++`, and `@@` headers, and use one tool call per file. Legacy hunk-only patches are accepted for backward compatibility, but you should always generate the canonical Git diff format.\n\nFor an existing tracked or untracked file:\n```diff\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new\n```\n\nFor a new file:\n```diff\ndiff --git a/new.py b/new.py\nnew file mode 100644\n--- /dev/null\n+++ b/new.py\n@@ -0,0 +1,2 @@\n+first\n+second\n```\n\n**ALWAYS read an existing file immediately before constructing a patch.** Never rely on line numbers or content from memory or a previous read \u2014 each patch you apply shifts line numbers in the file.\n\n### Workflow\n1. `read_file` the target file when it exists\n2. Construct a complete single-file Git unified diff from the current content\n3. Apply with `patch`\n4. If you need to patch the same file again, go back to step 1\n\nBinary, rename, copy, deletion, and multi-file Git patches are unsupported; use the dedicated file tools or separate patch calls.\n\n",
   "created_at": "2026-04-12T00:00:00.000000",
   "updated_at": "2026-07-27T00:00:00.000000"
 }

--- a/tools/patch.json
+++ b/tools/patch.json
@@ -1,10 +1,10 @@
 {
   "id": "patch",
   "name": "Patch File",
-  "description": "Apply a unified diff patch to a file, enabling precise surgical edits.",
+  "description": "Apply a single-file text patch in standard git diff format.",
   "function": {
     "name": "patch",
-    "description": "Apply a unified diff patch to a file.",
+    "description": "Apply a single-file text patch in standard git diff format. Works for tracked, untracked, and new files without requiring a Git repository.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -14,7 +14,7 @@
         },
         "patch": {
           "type": "string",
-          "description": "The unified diff patch content. Must contain @@ hunk headers. Example:\n@@ -3,4 +3,4 @@\n context line\n-old line\n+new line\n context line",
+          "description": "A complete single-file text patch in git diff format. It must include diff --git, ---, +++, and @@ headers. Example:\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new",
           "view": "diff"
         }
       },
@@ -24,9 +24,9 @@
       ]
     }
   },
-  "mock_response": "patch_text = args.get('patch', '')\nfile_path = args.get('file_path', 'unknown')\nif not patch_text:\n    result = {'error': \"Missing required argument: 'patch'\"}\nelse:\n    hunk_count = patch_text.count('@@') // 2\n    if hunk_count == 0:\n        result = {'error': 'No valid hunks found in patch. Make sure it contains @@ hunk headers.'}\n    else:\n        result = {'result': 'success', 'file_path': file_path, 'hunks_applied': hunk_count}",
+  "mock_response": "patch_text = args.get('patch', '')\nfile_path = args.get('file_path', 'unknown')\nif not patch_text:\n    result = {'error': \"Missing required argument: 'patch'\"}\nelif patch_text.count('diff --git ') != 1 or '\\n--- ' not in patch_text or '\\n+++ ' not in patch_text:\n    result = {'error': 'Invalid Git unified diff: include exactly one diff --git section plus --- and +++ path headers.'}\nelse:\n    hunk_count = patch_text.count('@@') // 2\n    if hunk_count == 0:\n        result = {'error': 'Invalid Git unified diff: patch contains no @@ hunks.'}\n    else:\n        result = {'result': 'success', 'file_path': file_path, 'hunks_applied': hunk_count}",
   "mock_response_type": "python",
-  "system_prompt": "## patch \u2014 Usage Rules\n\n**ALWAYS read the file immediately before constructing a patch.** Never rely on line numbers or content from memory or a previous read \u2014 each patch you apply shifts line numbers in the file.\n\n### Workflow\n1. `read_file` the target file\n2. Construct the patch from the *current* file content\n3. Apply with `patch`\n4. If you need to patch the same file again, go back to step 1\n\n",
+  "system_prompt": "## patch \u2014 Usage Rules\n\nThe `patch` argument MUST be a complete, single-file text patch in standard `git diff` format. Include `diff --git`, `---`, `+++`, and `@@` headers. Hunk-only patches are rejected. Use one tool call per file.\n\nFor an existing tracked or untracked file:\n```diff\ndiff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n context\n-old\n+new\n```\n\nFor a new file:\n```diff\ndiff --git a/new.py b/new.py\nnew file mode 100644\n--- /dev/null\n+++ b/new.py\n@@ -0,0 +1,2 @@\n+first\n+second\n```\n\n**ALWAYS read an existing file immediately before constructing a patch.** Never rely on line numbers or content from memory or a previous read \u2014 each patch you apply shifts line numbers in the file.\n\n### Workflow\n1. `read_file` the target file when it exists\n2. Construct a complete single-file Git unified diff from the current content\n3. Apply with `patch`\n4. If you need to patch the same file again, go back to step 1\n\nBinary, rename, copy, deletion, and multi-file patches are unsupported; use the dedicated file tools or separate patch calls.\n\n",
   "created_at": "2026-04-12T00:00:00.000000",
-  "updated_at": "2026-04-17T00:00:00.000000"
+  "updated_at": "2026-07-27T00:00:00.000000"
 }

--- a/unit_tests/test_patch_tool.py
+++ b/unit_tests/test_patch_tool.py
@@ -1,8 +1,7 @@
 """Unit and Git-format compatibility tests for ``backend/tools/patch.py``.
 
-The model-facing ``execute()`` contract requires a complete, single-file text
-patch in ``git diff`` format.  The low-level Python helpers remain independently
-testable with hunk-only input.
+The model-facing ``execute()`` contract uses complete single-file ``git diff``
+patches as its canonical format while retaining legacy hunk-only compatibility.
 """
 
 import importlib.util
@@ -499,7 +498,7 @@ class TestGitPatchFormat:
         with pytest.raises(ValueError, match=message):
             validate_git_patch_format(patch)
 
-    def test_execute_rejects_hunk_only_patch(self, tmp_path):
+    def test_execute_accepts_legacy_hunk_only_patch_with_warning(self, tmp_path):
         target = tmp_path / 'file.txt'
         target.write_text('old\n')
         result = execute(
@@ -509,8 +508,35 @@ class TestGitPatchFormat:
                 'patch': '@@ -1 +1 @@\n-old\n+new\n',
             },
         )
-        assert 'Invalid Git unified diff' in result['error']
-        assert target.read_text() == 'old\n'
+        assert result['result'] == 'success'
+        assert 'Legacy hunk-only patch accepted' in result['warning']
+        assert target.read_text() == 'new\n'
+
+    def test_execute_accepts_legacy_hunk_only_new_file(self, tmp_path):
+        target = tmp_path / 'new.txt'
+        result = execute(
+            {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+            {
+                'file_path': str(target),
+                'patch': '@@ -0,0 +1,2 @@\n+first\n+second\n',
+            },
+        )
+        assert result['result'] == 'success'
+        assert 'Legacy hunk-only patch accepted' in result['warning']
+        assert target.read_text() == 'first\nsecond\n'
+
+    def test_legacy_insertion_only_patch_can_target_existing_file(self, tmp_path):
+        target = tmp_path / 'existing.txt'
+        target.write_text('existing\n')
+        result = execute(
+            {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+            {
+                'file_path': str(target),
+                'patch': '@@ -0,0 +1,1 @@\n+inserted\n',
+            },
+        )
+        assert result['result'] == 'success'
+        assert target.read_text() == 'inserted\nexisting\n'
 
 
 # ---------------------------------------------------------------------------
@@ -671,6 +697,7 @@ def test_evonic_matches_git_apply_for_supported_text_patches(
     assert evonic_result.get('result') == 'success', (
         f'{case_name}: Evonic rejected fixture: {evonic_result}'
     )
+    assert 'warning' not in evonic_result
     assert evonic_target.read_bytes() == (git_root / relative_path).read_bytes()
 
 
@@ -678,11 +705,6 @@ def test_evonic_matches_git_apply_for_supported_text_patches(
 @pytest.mark.parametrize(
     ('case_name', 'target_exists', 'patch_text'),
     [
-        (
-            'hunk-only',
-            True,
-            '@@ -1 +1 @@\n-old\n+new\n',
-        ),
         (
             'bad-hunk-count',
             True,
@@ -739,3 +761,27 @@ def test_evonic_and_git_apply_both_reject_invalid_or_inapplicable_patches(
     )
     after = evonic_target.read_bytes() if evonic_target.exists() else None
     assert after == before
+
+
+@pytest.mark.skipif(not GIT_AVAILABLE, reason='git is required for differential tests')
+def test_legacy_hunk_only_is_an_intentional_git_apply_compatibility_exception(
+        tmp_path):
+    evonic_root = tmp_path / 'evonic'
+    git_root = tmp_path / 'git'
+    evonic_root.mkdir()
+    git_root.mkdir()
+    _write_fixture(evonic_root, 'sample.txt', b'old\n')
+    _write_fixture(git_root, 'sample.txt', b'old\n')
+    patch_text = '@@ -1 +1 @@\n-old\n+new\n'
+
+    evonic_target = evonic_root / 'sample.txt'
+    evonic_result = execute(
+        {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+        {'file_path': str(evonic_target), 'patch': patch_text},
+    )
+    git_result = _git_apply(git_root, patch_text)
+
+    assert git_result.returncode != 0
+    assert evonic_result['result'] == 'success'
+    assert 'Legacy hunk-only patch accepted' in evonic_result['warning']
+    assert evonic_target.read_text() == 'new\n'

--- a/unit_tests/test_patch_tool.py
+++ b/unit_tests/test_patch_tool.py
@@ -1,20 +1,18 @@
-"""
-Unit tests for backend/tools/patch.py
+"""Unit and Git-format compatibility tests for ``backend/tools/patch.py``.
 
-The patch tool has two backends:
-  - apply_patch()  — hybrid: uses system `patch` binary if available, else Python
-  - apply_hunks()  — pure-Python fallback, always used directly to test Python behavior
-
-Tests that require specific Python-fallback behavior (drift tolerance, CRLF
-preservation, insertion-only) call apply_hunks() directly.
-Tests for core functionality (replace, insert, delete, errors) use apply_patch()
-so they run against whichever backend is active on this system.
+The model-facing ``execute()`` contract requires a complete, single-file text
+patch in ``git diff`` format.  The low-level Python helpers remain independently
+testable with hunk-only input.
 """
 
-import os
-import tempfile
-import pytest
 import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+import pytest
 
 _patch_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'backend', 'tools', 'patch.py')
 _spec = importlib.util.spec_from_file_location('patch_tool', _patch_path)
@@ -26,6 +24,8 @@ apply_hunks = _mod.apply_hunks
 parse_hunks = _mod.parse_hunks
 _find_hunk_pos = _mod._find_hunk_pos
 _find_first_anchor = _mod._find_first_anchor
+execute = _mod.execute
+validate_git_patch_format = _mod.validate_git_patch_format
 
 
 # ---------------------------------------------------------------------------
@@ -400,3 +400,342 @@ class TestFuzzyMatching:
         r = apply_hunks(p, '@@ -1,2 +1,2 @@\n TOTALLY_NONEXISTENT\n-ALSO_NONEXISTENT\n+REPLACED\n')
         assert 'error' in r
         os.unlink(p)
+
+
+# ---------------------------------------------------------------------------
+# 8. Model-facing Git patch format
+# ---------------------------------------------------------------------------
+
+class TestGitPatchFormat:
+    def test_accepts_existing_file_patch(self):
+        patch = (
+            'diff --git a/app.py b/app.py\n'
+            'index 1111111..2222222 100644\n'
+            '--- a/app.py\n'
+            '+++ b/app.py\n'
+            '@@ -1,2 +1,2 @@\n'
+            ' alpha\n'
+            '-beta\n'
+            '+BETA\n'
+        )
+        info = validate_git_patch_format(patch)
+        assert info == {
+            'old_path': 'a/app.py',
+            'new_path': 'b/app.py',
+            'is_new_file': False,
+            'hunk_count': 1,
+        }
+
+    def test_accepts_new_file_patch(self):
+        patch = (
+            'diff --git a/new.py b/new.py\n'
+            'new file mode 100644\n'
+            '--- /dev/null\n'
+            '+++ b/new.py\n'
+            '@@ -0,0 +1,2 @@\n'
+            '+first\n'
+            '+second\n'
+        )
+        info = validate_git_patch_format(patch)
+        assert info['is_new_file'] is True
+        assert info['hunk_count'] == 1
+
+    def test_accepts_git_quoted_paths(self):
+        patch = (
+            'diff --git "a/space name.txt" "b/space name.txt"\n'
+            '--- "a/space name.txt"\n'
+            '+++ "b/space name.txt"\n'
+            '@@ -1 +1 @@\n'
+            '-old\n'
+            '+new\n'
+        )
+        info = validate_git_patch_format(patch)
+        assert info['old_path'] == 'a/space name.txt'
+        assert info['new_path'] == 'b/space name.txt'
+
+    @pytest.mark.parametrize(
+        ('patch', 'message'),
+        [
+            (
+                '@@ -1 +1 @@\n-old\n+new\n',
+                'Missing "diff --git',
+            ),
+            (
+                'diff --git a/a.txt b/a.txt\n'
+                '--- a/a.txt\n'
+                '+++ b/a.txt\n'
+                '@@ -1,2 +1,2 @@\n'
+                '-old\n'
+                '+new\n',
+                'Hunk line counts do not match',
+            ),
+            (
+                'diff --git a/a.txt b/a.txt\n'
+                '--- a/a.txt\n'
+                '+++ b/a.txt\n'
+                '@@ -1 +1 @@\n'
+                '-old\n'
+                '+new\n'
+                '*** End Patch\n',
+                'Invalid hunk line',
+            ),
+            (
+                'diff --git a/a.txt b/a.txt\n'
+                'deleted file mode 100644\n'
+                '--- a/a.txt\n'
+                '+++ /dev/null\n'
+                '@@ -1 +0,0 @@\n'
+                '-old\n',
+                'File-deletion patches are not supported',
+            ),
+            (
+                'diff --git a/a.txt b/a.txt\n'
+                'diff --git a/b.txt b/b.txt\n',
+                'exactly one file per call',
+            ),
+        ],
+    )
+    def test_rejects_nonstandard_or_unsupported_input(self, patch, message):
+        with pytest.raises(ValueError, match=message):
+            validate_git_patch_format(patch)
+
+    def test_execute_rejects_hunk_only_patch(self, tmp_path):
+        target = tmp_path / 'file.txt'
+        target.write_text('old\n')
+        result = execute(
+            {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+            {
+                'file_path': str(target),
+                'patch': '@@ -1 +1 @@\n-old\n+new\n',
+            },
+        )
+        assert 'Invalid Git unified diff' in result['error']
+        assert target.read_text() == 'old\n'
+
+
+# ---------------------------------------------------------------------------
+# 9. Differential compatibility with git apply
+# ---------------------------------------------------------------------------
+
+GIT_AVAILABLE = shutil.which('git') is not None
+
+
+def _write_fixture(root: Path, relative_path: str, content):
+    if content is None:
+        return
+    target = root / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+
+def _git_apply(root: Path, patch_text: str):
+    subprocess.run(
+        ['git', 'init', '-q'],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return subprocess.run(
+        ['git', 'apply', '--whitespace=nowarn', '-'],
+        cwd=root,
+        input=patch_text,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.skipif(not GIT_AVAILABLE, reason='git is required for differential tests')
+@pytest.mark.parametrize(
+    ('case_name', 'relative_path', 'initial', 'patch_text'),
+    [
+        (
+            'existing-untracked-replacement',
+            'sample.txt',
+            b'alpha\nbeta\ngamma\n',
+            'diff --git a/sample.txt b/sample.txt\n'
+            'index 1111111..2222222 100644\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1,3 +1,3 @@\n'
+            ' alpha\n'
+            '-beta\n'
+            '+BETA\n'
+            ' gamma\n',
+        ),
+        (
+            'existing-untracked-multiple-hunks',
+            'sample.txt',
+            b'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n',
+            'diff --git a/sample.txt b/sample.txt\n'
+            'index 1111111..2222222 100644\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1,3 +1,3 @@\n'
+            ' a\n'
+            '-b\n'
+            '+B\n'
+            ' c\n'
+            '@@ -10,3 +10,3 @@\n'
+            ' j\n'
+            '-k\n'
+            '+K\n'
+            ' l\n',
+        ),
+        (
+            'existing-untracked-quoted-path',
+            'space name.txt',
+            b'old\n',
+            'diff --git "a/space name.txt" "b/space name.txt"\n'
+            'index 1111111..2222222 100644\n'
+            '--- "a/space name.txt"\n'
+            '+++ "b/space name.txt"\n'
+            '@@ -1 +1 @@\n'
+            '-old\n'
+            '+new\n',
+        ),
+        (
+            'hunk-content-resembles-file-headers',
+            'sample.txt',
+            b'-- old\n',
+            'diff --git a/sample.txt b/sample.txt\n'
+            'index 1111111..2222222 100644\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1 +1 @@\n'
+            '--- old\n'
+            '+++ new\n',
+        ),
+        (
+            'new-file',
+            'nested/new.txt',
+            None,
+            'diff --git a/nested/new.txt b/nested/new.txt\n'
+            'new file mode 100644\n'
+            'index 0000000..1111111\n'
+            '--- /dev/null\n'
+            '+++ b/nested/new.txt\n'
+            '@@ -0,0 +1,2 @@\n'
+            '+first\n'
+            '+second\n',
+        ),
+        (
+            'new-file-without-trailing-newline',
+            'new.txt',
+            None,
+            'diff --git a/new.txt b/new.txt\n'
+            'new file mode 100644\n'
+            'index 0000000..1111111\n'
+            '--- /dev/null\n'
+            '+++ b/new.txt\n'
+            '@@ -0,0 +1 @@\n'
+            '+only line\n'
+            '\\ No newline at end of file\n',
+        ),
+        (
+            'replace-file-without-trailing-newline',
+            'sample.txt',
+            b'old',
+            'diff --git a/sample.txt b/sample.txt\n'
+            'index 1111111..2222222 100644\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1 +1 @@\n'
+            '-old\n'
+            '\\ No newline at end of file\n'
+            '+new\n'
+            '\\ No newline at end of file\n',
+        ),
+    ],
+    ids=lambda value: value if isinstance(value, str) and '\n' not in value else None,
+)
+def test_evonic_matches_git_apply_for_supported_text_patches(
+        tmp_path, case_name, relative_path, initial, patch_text):
+    evonic_root = tmp_path / 'evonic'
+    git_root = tmp_path / 'git'
+    evonic_root.mkdir()
+    git_root.mkdir()
+    _write_fixture(evonic_root, relative_path, initial)
+    _write_fixture(git_root, relative_path, initial)
+
+    evonic_target = evonic_root / relative_path
+    evonic_result = execute(
+        {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+        {'file_path': str(evonic_target), 'patch': patch_text},
+    )
+    git_result = _git_apply(git_root, patch_text)
+
+    assert git_result.returncode == 0, (
+        f'{case_name}: git apply rejected fixture: {git_result.stderr}'
+    )
+    assert evonic_result.get('result') == 'success', (
+        f'{case_name}: Evonic rejected fixture: {evonic_result}'
+    )
+    assert evonic_target.read_bytes() == (git_root / relative_path).read_bytes()
+
+
+@pytest.mark.skipif(not GIT_AVAILABLE, reason='git is required for differential tests')
+@pytest.mark.parametrize(
+    ('case_name', 'target_exists', 'patch_text'),
+    [
+        (
+            'hunk-only',
+            True,
+            '@@ -1 +1 @@\n-old\n+new\n',
+        ),
+        (
+            'bad-hunk-count',
+            True,
+            'diff --git a/sample.txt b/sample.txt\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1,2 +1,2 @@\n'
+            '-old\n'
+            '+new\n',
+        ),
+        (
+            'regular-patch-for-missing-file',
+            False,
+            'diff --git a/sample.txt b/sample.txt\n'
+            '--- a/sample.txt\n'
+            '+++ b/sample.txt\n'
+            '@@ -1 +1 @@\n'
+            '-old\n'
+            '+new\n',
+        ),
+        (
+            'new-file-patch-for-existing-file',
+            True,
+            'diff --git a/sample.txt b/sample.txt\n'
+            'new file mode 100644\n'
+            '--- /dev/null\n'
+            '+++ b/sample.txt\n'
+            '@@ -0,0 +1 @@\n'
+            '+new\n',
+        ),
+    ],
+)
+def test_evonic_and_git_apply_both_reject_invalid_or_inapplicable_patches(
+        tmp_path, case_name, target_exists, patch_text):
+    evonic_root = tmp_path / 'evonic'
+    git_root = tmp_path / 'git'
+    evonic_root.mkdir()
+    git_root.mkdir()
+    initial = b'old\n' if target_exists else None
+    _write_fixture(evonic_root, 'sample.txt', initial)
+    _write_fixture(git_root, 'sample.txt', initial)
+
+    evonic_target = evonic_root / 'sample.txt'
+    before = evonic_target.read_bytes() if evonic_target.exists() else None
+    evonic_result = execute(
+        {'sandbox_enabled': 0, 'safety_checker_enabled': 0},
+        {'file_path': str(evonic_target), 'patch': patch_text},
+    )
+    git_result = _git_apply(git_root, patch_text)
+
+    assert git_result.returncode != 0, f'{case_name}: git apply unexpectedly succeeded'
+    assert 'error' in evonic_result, (
+        f'{case_name}: Evonic unexpectedly succeeded: {evonic_result}'
+    )
+    after = evonic_target.read_bytes() if evonic_target.exists() else None
+    assert after == before


### PR DESCRIPTION
## Why

Evonic's patch tool is intentionally designed around one target file per tool call. However, its model-facing contract previously described the input as a unified diff while primarily demonstrating headerless `@@` hunks.

That ambiguity creates several practical problems:

- The patch payload does not carry a machine-verifiable target path.
- The declared `file_path` cannot be checked against `diff --git`, `---`, and `+++` headers.
- Generated patches cannot be reliably inspected or validated with standard Git tooling.
- An accidental multi-file diff may be parsed as one collection of hunks and applied to the single declared `file_path`.

The last case is a correctness and safety concern, not only a formatting inconsistency. In a reproduction against the previous implementation, a two-file diff could report that both hunks were applied while both changes were actually written into the first target file and the second file remained untouched.

This change establishes complete single-file Git diff syntax as the canonical model-facing format. Explicit headers allow Evonic to fail early when paths disagree, reject accidental multi-file payloads, and keep each tool call within a clear per-file safety and atomicity boundary.

This PR standardizes what agents generate, not which patch engine Evonic uses. The custom Python engine is intentionally retained because Evonic previously removed the system `patch` backend for being too strict with model-generated patches. Its fuzzy matching remains valuable for shifted line numbers, indentation differences, escaped characters, and other minor model inaccuracies. It also allows patching to continue across local, sandboxed, and remote workplace backends without requiring a Git repository.

Legacy hunk-only input remains accepted for backward compatibility, so existing agents, saved prompts, and integrations are not broken. Tracked files, existing untracked files, and newly created files continue to work. Git-compatible syntax becomes the preferred contract while the established tolerant execution behavior is preserved.

## What changed

- Make complete single-file patches with `diff --git`, `---`, `+++`, and `@@` headers the canonical model-facing format.
- Strictly validate canonical Git patches for path consistency, quoted paths, hunk line counts, new-file ranges, and no-newline markers before writing.
- Continue accepting legacy hunk-only patches for existing and new files, returning a compatibility warning instead of failing.
- Keep the pure-Python patch engine; no Git repository or `git apply` runtime dependency is introduced.
- Preserve support for existing untracked files, insertion-only patches, and new files.
- Preserve EOF newline semantics, including new files without a trailing newline.
- Reject malformed canonical patches and unsupported multi-file, binary, rename, copy, and deletion operations with explicit errors.
- Update the tool description, mock behavior, and model instructions to prefer the canonical format without breaking old callers.

## Compatibility scope

Canonical single-file text patches are aligned with Git diff syntax and compared with real `git apply` in tests. Legacy hunk-only input is the intentional compatibility exception and is not claimed to be accepted by `git apply`. Binary, rename, copy, deletion, and multi-file Git operations remain outside this tool and must use dedicated tools or separate calls.

## Tests

- `python -m pytest -q unit_tests/test_patch_tool.py`: 63 passed.
- `python -m pytest -q unit_tests/test_patch_tool.py unit_tests/test_tool_registry.py unit_tests/test_tool_defs_cache.py`: 96 passed.
- Differential tests execute canonical patches through both Evonic and real `git apply` for existing untracked files, multiple hunks, quoted paths, new and nested files, header-like hunk content, and files without trailing newlines.
- Compatibility tests cover hunk-only edits to existing files, insertion-only edits to existing files, hunk-only new-file creation, warning behavior, and the intentional difference from `git apply`.
- Rejection parity covers malformed canonical hunk counts, missing targets, and new-file patches against existing targets.
- Python compilation, JSON validation, and `git diff --check` pass.

The complete `unit_tests/` run is currently blocked by pre-existing failures outside this change: `test_setup_timezone.py` imports a missing `DEFAULT_PLATFORM_TIMEZONE`, and the first failure after ignoring that file is an unrelated task-state timestamp assertion in `test_agent_state.py`.
