### PR TITLE
fix(chat): invalidate AgentChatManager cache on agent delete

### DIFF
--- a/backend/tools/super_agent_tools.py
+++ b/backend/tools/super_agent_tools.py
@@ -511,6 +511,11 @@ def _exec_delete_agent(args: dict) -> dict:
         agent_dir = os.path.join(AGENTS_DIR, agent_id)
         if os.path.isdir(agent_dir):
             shutil.rmtree(agent_dir)
+        try:
+            from models.chat import agent_chat_manager
+            agent_chat_manager.drop(agent_id)
+        except Exception:
+            pass
         return {'success': True, 'message': f"Agent '{agent_id}' deleted."}
     except Exception as e:
         return {'error': str(e)}

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1588,6 +1588,11 @@ def agent_remove(agent_id):
         )
         if os.path.isdir(agent_dir):
             shutil.rmtree(agent_dir)
+        try:
+            from models.chat import agent_chat_manager
+            agent_chat_manager.drop(agent_id)
+        except Exception:
+            pass
         print(f"Agent removed: {agent_id}")
     except Exception as e:
         print(f"Error: {e}")

--- a/models/chat.py
+++ b/models/chat.py
@@ -1060,5 +1060,19 @@ class AgentChatManager:
                     self._dbs[agent_id] = AgentChatDB(agent_id)
         return self._dbs[agent_id]
 
+    def drop(self, agent_id: str) -> None:
+        """Drop a cached AgentChatDB (e.g. when the agent is deleted).
+
+        Closes the persistent connection first so it cannot keep reading a
+        chat.db inode that is about to be unlinked from disk. Without this,
+        recreating an agent with the same id returns the stale cached
+        instance whose connection points at the deleted file → queries
+        fail with 'no such table: chat_sessions'.
+        """
+        with self._lock:
+            db = self._dbs.pop(agent_id, None)
+        if db is not None:
+            db.close()
+
 
 agent_chat_manager = AgentChatManager()

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -471,6 +471,13 @@ def api_delete_agent(agent_id):
     agent_dir = os.path.join(AGENTS_DIR, agent_id)
     if os.path.isdir(agent_dir):
         shutil.rmtree(agent_dir)
+    # Drop the cached chat DB so a recreated agent with the same id gets a
+    # fresh connection instead of a stale handle on the deleted chat.db inode.
+    try:
+        from models.chat import agent_chat_manager
+        agent_chat_manager.drop(agent_id)
+    except Exception:
+        pass
     audit.log_agent_crud(user_id='admin', agent_id=agent_id, action='delete', ip=_audit_ip())
     return jsonify({'success': True})
 

--- a/unit_tests/test_agent_chat_cache_invalidation.py
+++ b/unit_tests/test_agent_chat_cache_invalidation.py
@@ -1,0 +1,80 @@
+"""
+Tests for AgentChatManager cache invalidation on agent delete/recreate.
+
+Regression: deleting an agent (which rmtrees its chat.db) while the
+AgentChatManager still holds a cached AgentChatDB leaves a stale handle.
+Recreating an agent with the same id returns that stale instance; if its
+persistent connection was closed, _get_conn lazily opens a *fresh empty*
+chat.db (mode=rwc) and _init_tables() never runs for it → queries fail
+with 'no such table: chat_sessions'.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from models.chat import AgentChatManager, AGENTS_DIR
+
+
+@pytest.fixture
+def chat_env(monkeypatch, tmp_path):
+    """Point AGENTS_DIR at a temp dir so tests never touch the real agents/."""
+    agents_root = tmp_path / 'agents'
+    agents_root.mkdir()
+    monkeypatch.setattr('models.chat.AGENTS_DIR', str(agents_root))
+    return str(agents_root)
+
+
+def _create_and_use(mgr, agent_id):
+    db = mgr.get(agent_id)
+    with db._connect() as c:
+        c.execute(
+            "INSERT INTO chat_sessions (id, agent_id, external_user_id) VALUES (?, ?, ?)",
+            ('s1', agent_id, 'u1'))
+    return db
+
+
+def test_recreate_after_delete_without_drop_fails(chat_env):
+    """OLD behavior: stale cached instance + closed conn + rmtree → no such table."""
+    mgr = AgentChatManager()
+    agent_id = 'recreate_test'
+
+    db1 = _create_and_use(mgr, agent_id)
+    db1.close()                      # simulates GC/restart dropping the conn
+    shutil.rmtree(os.path.join(chat_env, agent_id))
+    os.makedirs(os.path.join(chat_env, agent_id))
+
+    db2 = mgr.get(agent_id)          # cached stale instance
+    assert db2 is db1                # same object → lazy reopen of empty file
+    with pytest.raises(Exception) as exc:
+        with db2._connect() as c:
+            c.execute('SELECT * FROM chat_sessions').fetchall()
+    assert 'no such table' in str(exc.value)
+
+
+def test_drop_then_recreate_initializes_tables(chat_env):
+    """NEW behavior: drop() invalidates the cache → fresh instance with tables."""
+    mgr = AgentChatManager()
+    agent_id = 'recreate_test'
+
+    db1 = _create_and_use(mgr, agent_id)
+    db1.close()
+    shutil.rmtree(os.path.join(chat_env, agent_id))
+    os.makedirs(os.path.join(chat_env, agent_id))
+
+    mgr.drop(agent_id)               # the fix
+    db3 = mgr.get(agent_id)
+    assert db3 is not db1            # fresh AgentChatDB → _init_tables() ran
+    with db3._connect() as c:
+        row = c.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='chat_sessions'"
+        ).fetchone()
+    assert row is not None
+    assert row[0] == 'chat_sessions'
+
+
+def test_drop_missing_agent_is_noop(chat_env):
+    mgr = AgentChatManager()
+    mgr.drop('never_existed')        # should not raise


### PR DESCRIPTION
When an agent is deleted, its chat.db is rmtree'd but AgentChatManager keeps the cached AgentChatDB instance. Recreating an agent with the same id returns the stale instance; if its persistent connection was closed, _get_conn lazily opens a fresh empty chat.db (mode=rwc) and _init_tables() never runs for it - first query fails with "no such table: chat_sessions".

Fix: add AgentChatManager.drop() (closes + removes cached instance) and call it from all three delete paths (API route, super-agent tool, CLI). Add regression tests.

Verified: repro script shows the exact error before the fix and clean recovery after; 3/3 new tests pass.