### PR TITLE
fix(llm_client): send browser User-Agent to avoid Cloudflare 1010 blocking vision payloads

### DIFF
--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -683,7 +683,10 @@ class LLMClient:
             if self.api_key:
                 headers["x-api-key"] = self.api_key
         else:
-            headers = {"Content-Type": "application/json"}
+            headers = {
+                "Content-Type": "application/json",
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+            }
             if self.api_key:
                 headers["Authorization"] = f"Bearer {self.api_key}"
 


### PR DESCRIPTION
## Problem

Vision (multimodal) requests to OpenAI-compatible endpoints sitting behind Cloudflare fail with HTTP 403 `error code: 1010` — Cloudflare's WAF bans the `python-requests` default User-Agent for large payloads, while small text requests pass.

## Root cause

`backend/llm_client.py` builds headers with only `Content-Type` and `Authorization`. The requests library sends `User-Agent: python-requests/x.y` by default, which Cloudflare 1010 blocks when the body is large (e.g. base64 image).

## Fix

Add a standard Chrome User-Agent header so multimodal payloads reach the endpoint.

## Verification

- Before: image_url payload → HTTP 403 `error code: 1010`
- After: same payload with browser UA → `mimo-v2.5` returns `Light green.` (correct vision answer)
- Text requests unaffected.