### PR TITLE
fix(skills): restrict lazy-skill allowlist exemption to the designated super agent

### DIFF
--- a/backend/tools/use_skill.py
+++ b/backend/tools/use_skill.py
@@ -60,8 +60,14 @@ def execute(agent: dict, args: dict) -> dict:
             "available_skills": available
         }
 
-    # Per-agent allowlist check (super agents are exempt)
-    if not agent.get('is_super'):
+    # Per-agent allowlist check (only the designated super agent is exempt)
+    _super_id = None
+    try:
+        from models.db import db
+        _super_id = db.get_setting('super_agent_id')
+    except Exception:
+        pass
+    if not (agent.get('is_super') and agent.get('id') == _super_id):
         from models.db import db
         # Sub-agents inherit parent's skill assignments
         _eid = agent.get('parent_id', agent.get('id', '')) if agent.get('is_subagent') else agent.get('id', '')

--- a/defaults/super_agent_system_prompt.md
+++ b/defaults/super_agent_system_prompt.md
@@ -20,6 +20,7 @@ You are operating from the root of the Evonic project workspace. You have direct
 - **Notes.md standards**: A `notes.md` KB file exists for user preferences, tastes, and instructions (non-factual data). Only store language preferences, communication style, personal instructions, and tastes in notes.md. Do NOT store factual or memorization data (address, phone, email, birthday, token, password, secret code) there. Use `remember` for all factual and secret information. If notes.md is deleted from KB, ignore notes.md-related instructions.
 - **Agent message routing**: When the user asks to send a message to X or Y (e.g., "send message to X", "tell Y that..."), X/Y could be an agent name. Check the list of registered agents first using the available tools to look up agent IDs before attempting to send.
 - **Full tool access**: As the super agent, you have access to ALL tools available in the Evonic system, including admin operations, agent management, scheduling, skills, and plugins.
+- **Skill access is per-agent**: Being a super agent grants full code execution, but NOT automatic access to every skill. Lazy skills load only if they are in your assigned skills list (`agent_skills`). The only exception is the designated super agent (`super_agent_id` setting), which can load any skill.
 
 ## Planning and Executing Procedure
 


### PR DESCRIPTION
## Problem

`use_skill` bypasses the `agent_skills` allowlist for **any** agent with `is_super=1`:

```python
if not agent.get('is_super'):
```

So every super agent can lazy-load any skill (exa-search, etc.) without an explicit `agent_skills` row — the per-agent allowlist is meaningless for supers.

**Why it matters:** skills like `exa-search` are paid (API-key billed). Any super agent calling them repeatedly could rack up unbounded cost and break the billing. Restricting skill access is the guardrail.

## Access model (after this PR)

| Agent type | Code execution | Skill loading |
|---|---|---|
| designated super agent (`super_agent_id` setting) | **All** — full code execution | **All** — can load every skill |
| other super agent (`is_super=1`) | **All** — full code execution | **Some** — only skills granted via `agent_skills` rows (setting) |
| regular agent (not super) | **Interactive grant only** — needs approval per call (auto-rejected in `api:` sessions) | **Some** — only skills granted via `agent_skills` rows (setting) |

Grant a skill via setting (no code change):

```sql
INSERT OR IGNORE INTO agent_skills (agent_id, skill_id) VALUES ('<agent_id>', 'exa-search');
```

## Fix

Narrow the exemption to the single designated super agent, read from the existing `super_agent_id` setting (DB `app_settings`):

```python
_super_id = db.get_setting('super_agent_id')
if not (agent.get('is_super') and agent.get('id') == _super_id):
```

No hardcoding — operators can change `super_agent_id` or grant specific supers skills via `agent_skills` rows.

Also documents the change in `defaults/super_agent_system_prompt.md` (the template copied to `agents/<id>/SYSTEM.md`): super agents get full code execution but NOT automatic access to every skill; only the designated super agent loads any skill.

## Status: DONE ✅

Implemented, verified, deployed. Prevents excessive paid-skill usage from breaking billing.

## Verification

- Designated super agent (matches `super_agent_id`) → exa-search loads ✓
- Other super agent (not the designated one) → `Skill 'exa-search' is not in your allowed skills list.` ✓
- Non-super agent → unchanged behavior ✓