### PR TITLE
feat(plugins): support ephemeral turn context, transforms, state, and response hooks

### DIFF
--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -449,6 +449,7 @@ def run_tool_loop(agent: Dict[str, Any],
     # disable later automatic transitions for unrelated implementation tools.
     _successful_mutation = False
     _tool_errors = False
+    _plugin_response_retry_count = 0
 
     def _is_mutating_tool(tool_name: str) -> bool:
         """Return whether a tool represents implementation work."""
@@ -1835,18 +1836,13 @@ def run_tool_loop(agent: Dict[str, Any],
             })
             continue
 
-        if content:
-            is_final = not bool(tool_calls)
-            # [DONE] is an internal nudge-response signal — never user-visible.
-            if content.strip() != "[DONE]":
-                event_stream.emit('llm_response_chunk', {
-                    'agent_id': agent_id, 'session_id': session_id,
-                    'external_user_id': external_user_id, 'channel_id': channel_id,
-                    'content': content, 'is_final': is_final,
-                    # Signal frontend to also render a standalone bubble for intermediate
-                    # responses when send_intermediate_responses is enabled on the agent.
-                    'send_as_message': is_final or bool(agent.get('send_intermediate_responses')),
-                })
+        if tool_calls and content and content.strip() != "[DONE]":
+            event_stream.emit('llm_response_chunk', {
+                'agent_id': agent_id, 'session_id': session_id,
+                'external_user_id': external_user_id, 'channel_id': channel_id,
+                'content': content, 'is_final': False,
+                'send_as_message': bool(agent.get('send_intermediate_responses')),
+            })
 
         if not tool_calls:
             # Treat trivial single-character/punctuation-only responses (e.g. ">", "<")
@@ -1907,6 +1903,52 @@ def run_tool_loop(agent: Dict[str, Any],
             # Normalize "[No response needed]" variants to empty to suppress sending
             if content and content.strip().lower().startswith("[no response"):
                 content = ""
+
+            # Let plugins evaluate a final response before it is streamed or
+            # persisted. Revised messages remain ephemeral to this provider loop.
+            from backend.plugin_manager import run_final_response_handlers
+            _response_decision = run_final_response_handlers({
+                'agent_id': agent_id,
+                'session_id': session_id,
+                'content': content,
+                'messages': messages,
+                'provider': _request.provider,
+                'model': _request.model,
+                'retry_count': _plugin_response_retry_count,
+            })
+            if _response_decision:
+                _response_event = _response_decision.get('timeline')
+                if isinstance(_response_event, dict):
+                    timeline.append({
+                        'type': 'plugin_response_evaluation',
+                        'plugin': _response_decision.get('namespace'),
+                        **_response_event,
+                    })
+                _replacement = _response_decision.get('content')
+                if isinstance(_replacement, str):
+                    content = _replacement
+                _retry_messages = _response_decision.get('messages')
+                if (_response_decision.get('retry')
+                        and _plugin_response_retry_count < 2
+                        and isinstance(_retry_messages, list)
+                        and all(isinstance(message, dict) for message in _retry_messages)):
+                    messages[:] = _retry_messages
+                    _plugin_response_retry_count += 1
+                    event_stream.emit('plugin_response_retry', {
+                        'agent_id': agent_id, 'session_id': session_id,
+                        'external_user_id': external_user_id, 'channel_id': channel_id,
+                        'plugin': _response_decision.get('namespace'),
+                        'attempt': _plugin_response_retry_count,
+                    })
+                    continue
+
+            if content and content.strip() != "[DONE]":
+                event_stream.emit('llm_response_chunk', {
+                    'agent_id': agent_id, 'session_id': session_id,
+                    'external_user_id': external_user_id, 'channel_id': channel_id,
+                    'content': content, 'is_final': True,
+                    'send_as_message': True,
+                })
 
             # Run interceptors before committing the final answer.
             # Plugins (e.g. kanban) can inspect the content and inject a

--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -992,6 +992,8 @@ def run_tool_loop(agent: Dict[str, Any],
             if injected_parts:
                 merged = "\n\n".join(injected_parts)
                 messages.append({"role": "user", "content": merged})
+                from backend.plugin_manager import apply_user_message_transformers
+                apply_user_message_transformers(agent_id, session_id, messages)
                 # Reset iteration counter so injected tasks (e.g. next kanban task in
                 # autopilot mode) each get a fresh budget instead of sharing the counter
                 # with the previous task. Capped at MAX_INJECTIONS_PER_LOOP to prevent

--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -2193,6 +2193,15 @@ def run_tool_loop(agent: Dict[str, Any],
                 _tool_records.append((tc, fn_name, None, {}))
                 continue
 
+            original_args = args
+            from backend.plugin_manager import apply_tool_request_transformers
+            args = apply_tool_request_transformers(
+                agent_id, session_id, fn_name, args)
+            if not isinstance(args, dict):
+                _logger.warning(
+                    "Tool-request transformer returned non-dict args for '%s'; ignoring it",
+                    fn_name)
+                args = original_args
             pt = _param_type_map.get(fn_name, {})
             timeline.append({"type": "tool_call", "tool": fn_name, "args": args, "param_types": pt})
             event_stream.emit('tool_call_started', {
@@ -2641,6 +2650,10 @@ def run_tool_loop(agent: Dict[str, Any],
                                 elif isinstance(tool_result, str):
                                     tool_result = _warning + tool_result
                             # 'log' mode: just logs, no modification
+
+            from backend.plugin_manager import apply_tool_result_transformers
+            tool_result = apply_tool_result_transformers(
+                agent_id, session_id, fn_name, tool_result)
 
             # Serialize tool result for LLM (always valid JSON when possible)
             try:

--- a/backend/agent_runtime/runtime.py
+++ b/backend/agent_runtime/runtime.py
@@ -36,7 +36,12 @@ from backend.agent_state import AgentState
 from backend.channels.registry import channel_manager
 from backend.channels.base import BaseChannel
 from backend.event_stream import event_stream
-from backend.plugin_manager import get_busy_message, get_turn_context, apply_turn_context
+from backend.plugin_manager import (
+    apply_turn_context,
+    apply_user_message_transformers,
+    get_busy_message,
+    get_turn_context,
+)
 from backend.slash_commands import parse_command, execute_command
 from backend.agent_runtime.prefetch import TurnPrefetcher
 import atexit
@@ -2334,6 +2339,10 @@ class AgentRuntime:
                 )
                 if not _already_injected:
                     messages.insert(1, {"role": "system", "content": _long_gap_ctx})
+
+        # Plugin transforms are ephemeral: state/CMP saw the original text, while
+        # only the provider-bound message copy is changed.
+        apply_user_message_transformers(agent_id, ctx.session_id, messages)
 
         # Apply preference wrapper prefix to user messages if enabled
         _apply_wrapper_prefix(messages, _should_wrap_user_message(agent),

--- a/backend/agent_runtime/runtime.py
+++ b/backend/agent_runtime/runtime.py
@@ -36,7 +36,7 @@ from backend.agent_state import AgentState
 from backend.channels.registry import channel_manager
 from backend.channels.base import BaseChannel
 from backend.event_stream import event_stream
-from backend.plugin_manager import get_busy_message
+from backend.plugin_manager import get_busy_message, get_turn_context, apply_turn_context
 from backend.slash_commands import parse_command, execute_command
 from backend.agent_runtime.prefetch import TurnPrefetcher
 import atexit
@@ -1740,7 +1740,7 @@ class AgentRuntime:
             system_prompt = _prefetch.system_prompt
             tools = _prefetch.tools
             # Use prefetched messages as the base, then append fresh user message below
-            messages = _prefetch.messages
+            messages = list(_prefetch.messages)
             # Skip the heavy build phase — tools and system_prompt are already ready
             _tools_prebuilt = tools
             _agent_ctx_prebuilt = _prefetch.agent_context
@@ -2129,6 +2129,10 @@ class AgentRuntime:
                 'enable_atg': bool(agent.get('enable_atg')) and bool(agent.get('enable_agent_state')),
                 'enable_cmp': bool(agent.get('enable_cmp')) and bool(agent.get('enable_agent_state')),
             }
+
+        apply_turn_context(
+            messages, tools, get_turn_context(agent_id, ctx.session_id),
+        )
         _last_user = chatlog.get_last_entry(types=frozenset({'user'}))
         assigned_tool_ids, tools = _apply_restart_origin_guard(
             agent_context, assigned_tool_ids, tools,

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -179,6 +179,32 @@ def run_message_interceptors(agent_id: str, content: str, messages: list) -> lis
     return injections
 
 
+# Final-response handlers run before a no-tool response becomes visible or is
+# persisted. A handler may accept the response, replace its content, or request
+# one ephemeral provider retry with a revised message list.
+_final_response_handlers: Dict[str, Callable] = {}
+
+
+def register_final_response_handler(namespace: str, fn: Callable) -> None:
+    _final_response_handlers[namespace] = fn
+
+
+def unregister_final_response_handler(namespace: str) -> None:
+    _final_response_handlers.pop(namespace, None)
+
+
+def run_final_response_handlers(context: dict) -> Optional[dict]:
+    for namespace, handler in list(_final_response_handlers.items()):
+        try:
+            result = handler(context)
+            if isinstance(result, dict) and (
+                    result.get("retry") or isinstance(result.get("content"), str)):
+                return {**result, "namespace": namespace}
+        except Exception:
+            _logger.exception("Plugin final-response handler failed: %s", namespace)
+    return None
+
+
 # ═══════════════════════════════════════════════════════════════════
 # User Message Transformer Registry
 # ═══════════════════════════════════════════════════════════════════
@@ -482,4 +508,5 @@ def _get_all_registries():
     return (_tool_guards, _message_interceptors, _builtin_suppressors,
             _turn_context_providers, _busy_message_providers, _turn_gates,
             _tool_result_gates, _attachment_policies,
-            _agent_state_summary_providers, _user_message_transformers)
+            _agent_state_summary_providers, _user_message_transformers,
+            _final_response_handlers)

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -210,6 +210,8 @@ def run_final_response_handlers(context: dict) -> Optional[dict]:
 # ═══════════════════════════════════════════════════════════════════
 
 _user_message_transformers: Dict[str, Callable] = {}
+_tool_request_transformers: Dict[str, Callable] = {}
+_tool_result_transformers: Dict[str, Callable] = {}
 
 
 def register_user_message_transformer(namespace: str, fn: Callable) -> None:
@@ -259,6 +261,55 @@ def apply_user_message_transformers(agent_id: str, session_id: str,
             parts.append(part)
         target["content"] = parts
     return changed
+
+
+# Tool transformers operate on parsed request arguments and completed results.
+# Each callback receives (agent_id, session_id, tool_name, payload) and may return
+# a replacement payload of the same logical type. Exceptions are fail-open.
+def register_tool_request_transformer(namespace: str, fn: Callable) -> None:
+    """Register a named transformer for parsed tool-call arguments."""
+    _tool_request_transformers[namespace] = fn
+
+
+def unregister_tool_request_transformer(namespace: str) -> None:
+    _tool_request_transformers.pop(namespace, None)
+
+
+def apply_tool_request_transformers(agent_id: str, session_id: str,
+                                    tool_name: str, args):
+    """Apply registered request transformers in registration order."""
+    current = args
+    for namespace, fn in list(_tool_request_transformers.items()):
+        try:
+            result = fn(agent_id, session_id, tool_name, current)
+            if result is not None:
+                current = result
+        except Exception:
+            _logger.exception("Plugin tool-request transformer failed: %s", namespace)
+    return current
+
+
+def register_tool_result_transformer(namespace: str, fn: Callable) -> None:
+    """Register a named transformer for completed tool results."""
+    _tool_result_transformers[namespace] = fn
+
+
+def unregister_tool_result_transformer(namespace: str) -> None:
+    _tool_result_transformers.pop(namespace, None)
+
+
+def apply_tool_result_transformers(agent_id: str, session_id: str,
+                                   tool_name: str, result):
+    """Apply registered result transformers in registration order."""
+    current = result
+    for namespace, fn in list(_tool_result_transformers.items()):
+        try:
+            transformed = fn(agent_id, session_id, tool_name, current)
+            if transformed is not None:
+                current = transformed
+        except Exception:
+            _logger.exception("Plugin tool-result transformer failed: %s", namespace)
+    return current
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -243,6 +243,7 @@ def apply_user_message_transformers(agent_id: str, session_id: str,
 #   provider(agent_id: str, session_id: str) -> Optional[dict]
 # Return None to skip, or:
 #   {"id": "x", "tools": [...tool_defs...], "system_md": "...",
+#    "system_mode": "preserve|append|replace",
 #    "prefill_messages": [{"role": "user|assistant", "content": "..."}]}
 
 _turn_context_providers: list = []
@@ -276,13 +277,18 @@ def get_turn_context(agent_id: str, session_id: str) -> list:
 def apply_turn_context(messages: list, tools: list, contexts: list) -> None:
     """Apply validated, ephemeral plugin context before conversation history."""
     additions = []
+    replacement = None
     known_tools = {t.get("function", {}).get("name") for t in tools}
     for ctx in contexts:
         if not isinstance(ctx, dict):
             continue
         system_md = ctx.get("system_md")
         if isinstance(system_md, str) and system_md.strip():
-            additions.append({"role": "system", "content": system_md[:32000]})
+            mode = ctx.get("system_mode", "append")
+            if mode == "replace":
+                replacement = system_md[:32000]
+            elif mode != "preserve":
+                additions.append({"role": "system", "content": system_md[:32000]})
         prefill = ctx.get("prefill_messages")
         if isinstance(prefill, list):
             for msg in prefill[:8]:
@@ -296,6 +302,13 @@ def apply_turn_context(messages: list, tools: list, contexts: list) -> None:
             if name and name not in known_tools:
                 tools.append(tool)
                 known_tools.add(name)
+    if replacement is not None:
+        system = next((message for message in messages
+                       if isinstance(message, dict) and message.get("role") == "system"), None)
+        if system is None:
+            messages.insert(0, {"role": "system", "content": replacement})
+        else:
+            system["content"] = replacement
     messages[1:1] = additions
 
 

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -1,5 +1,5 @@
 """
-Plugin Hooks — six hook registries for extending agent behavior.
+Plugin Hooks — registries for extending agent behavior.
 
 Tool Guards, Message Interceptors, Turn Context Providers, Busy Message
 Providers, Builtin Suppressors, and State Handlers — all live here as
@@ -180,6 +180,62 @@ def run_message_interceptors(agent_id: str, content: str, messages: list) -> lis
 
 
 # ═══════════════════════════════════════════════════════════════════
+# User Message Transformer Registry
+# ═══════════════════════════════════════════════════════════════════
+
+_user_message_transformers: Dict[str, Callable] = {}
+
+
+def register_user_message_transformer(namespace: str, fn: Callable) -> None:
+    """Register a named transformer for the newest user message."""
+    _user_message_transformers[namespace] = fn
+
+
+def unregister_user_message_transformer(namespace: str) -> None:
+    _user_message_transformers.pop(namespace, None)
+
+
+def apply_user_message_transformers(agent_id: str, session_id: str,
+                                    messages: list) -> bool:
+    """Transform only the newest user message, preserving non-text media parts."""
+    target = next(
+        (message for message in reversed(messages)
+         if isinstance(message, dict) and message.get("role") == "user"),
+        None,
+    )
+    if target is None:
+        return False
+
+    changed = False
+
+    def transform(text: str) -> str:
+        nonlocal changed
+        current = text
+        for namespace, fn in list(_user_message_transformers.items()):
+            try:
+                result = fn(agent_id, session_id, current)
+                if isinstance(result, str):
+                    changed = changed or result != current
+                    current = result
+            except Exception:
+                _logger.exception("Plugin user-message transformer failed: %s", namespace)
+        return current
+
+    content = target.get("content")
+    if isinstance(content, str):
+        target["content"] = transform(content)
+    elif isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text" \
+                    and isinstance(part.get("text"), str):
+                part = {**part, "text": transform(part["text"])}
+            parts.append(part)
+        target["content"] = parts
+    return changed
+
+
+# ═══════════════════════════════════════════════════════════════════
 # Turn Context Provider Registry
 # ═══════════════════════════════════════════════════════════════════
 # Plugins can supply tools + system messages that should be present at the start of
@@ -213,7 +269,7 @@ def get_turn_context(agent_id: str, session_id: str) -> list:
             if ctx:
                 results.append(ctx)
         except Exception:
-            pass
+            _logger.exception("Plugin turn-context provider failed")
     return results
 
 
@@ -413,4 +469,4 @@ def _get_all_registries():
     return (_tool_guards, _message_interceptors, _builtin_suppressors,
             _turn_context_providers, _busy_message_providers, _turn_gates,
             _tool_result_gates, _attachment_policies,
-            _agent_state_summary_providers)
+            _agent_state_summary_providers, _user_message_transformers)

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -243,6 +243,30 @@ def apply_turn_context(messages: list, tools: list, contexts: list) -> None:
     messages[1:1] = additions
 
 
+# Read-only plugin status shown in the chat Agent State panel.
+_agent_state_summary_providers: Dict[str, Callable] = {}
+
+
+def register_agent_state_summary_provider(namespace: str, fn: Callable) -> None:
+    _agent_state_summary_providers[namespace] = fn
+
+
+def unregister_agent_state_summary_provider(namespace: str) -> None:
+    _agent_state_summary_providers.pop(namespace, None)
+
+
+def get_agent_state_summaries(agent_id: str, session_id: str) -> dict:
+    summaries = {}
+    for namespace, provider in list(_agent_state_summary_providers.items()):
+        try:
+            summary = provider(agent_id, session_id)
+            if isinstance(summary, dict) and summary.get("state"):
+                summaries[namespace] = summary
+        except Exception:
+            _logger.exception("Plugin agent-state summary failed: %s", namespace)
+    return summaries
+
+
 # ═══════════════════════════════════════════════════════════════════
 # Busy Message Provider Registry
 # ═══════════════════════════════════════════════════════════════════
@@ -388,4 +412,5 @@ def get_state_summary(agent_state) -> dict:
 def _get_all_registries():
     return (_tool_guards, _message_interceptors, _builtin_suppressors,
             _turn_context_providers, _busy_message_providers, _turn_gates,
-            _tool_result_gates, _attachment_policies)
+            _tool_result_gates, _attachment_policies,
+            _agent_state_summary_providers)

--- a/backend/plugin_hooks.py
+++ b/backend/plugin_hooks.py
@@ -186,7 +186,8 @@ def run_message_interceptors(agent_id: str, content: str, messages: list) -> lis
 # each agent turn. Providers are called once per _run_tool_loop call.
 #   provider(agent_id: str, session_id: str) -> Optional[dict]
 # Return None to skip, or:
-#   {"id": "x", "tools": [...tool_defs...], "system_md": "..."}
+#   {"id": "x", "tools": [...tool_defs...], "system_md": "...",
+#    "prefill_messages": [{"role": "user|assistant", "content": "..."}]}
 
 _turn_context_providers: list = []
 
@@ -214,6 +215,32 @@ def get_turn_context(agent_id: str, session_id: str) -> list:
         except Exception:
             pass
     return results
+
+
+def apply_turn_context(messages: list, tools: list, contexts: list) -> None:
+    """Apply validated, ephemeral plugin context before conversation history."""
+    additions = []
+    known_tools = {t.get("function", {}).get("name") for t in tools}
+    for ctx in contexts:
+        if not isinstance(ctx, dict):
+            continue
+        system_md = ctx.get("system_md")
+        if isinstance(system_md, str) and system_md.strip():
+            additions.append({"role": "system", "content": system_md[:32000]})
+        prefill = ctx.get("prefill_messages")
+        if isinstance(prefill, list):
+            for msg in prefill[:8]:
+                if not isinstance(msg, dict) or msg.get("role") not in {"user", "assistant"}:
+                    continue
+                content = msg.get("content")
+                if isinstance(content, str) and content.strip():
+                    additions.append({"role": msg["role"], "content": content[:16000]})
+        for tool in ctx.get("tools") or []:
+            name = tool.get("function", {}).get("name") if isinstance(tool, dict) else None
+            if name and name not in known_tools:
+                tools.append(tool)
+                known_tools.add(name)
+    messages[1:1] = additions
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/backend/plugin_lifecycle.py
+++ b/backend/plugin_lifecycle.py
@@ -29,6 +29,7 @@ from backend.plugin_sdk import PluginSDK
 from backend.plugin_hooks import (
     _tool_guards, _message_interceptors, _builtin_suppressors,
     _turn_gates, _tool_result_gates,
+    _tool_request_transformers, _tool_result_transformers,
     _state_handlers, _unload_plugin_state_handlers,
 )
 
@@ -260,6 +261,10 @@ class PluginManager:
                          _turn_gates, _tool_result_gates):
             registry[:] = [fn for fn in registry
                            if not getattr(fn, '__module__', '').startswith(prefix)]
+        for registry in (_tool_request_transformers, _tool_result_transformers):
+            for namespace, fn in list(registry.items()):
+                if getattr(fn, '__module__', '').startswith(prefix):
+                    registry.pop(namespace, None)
 
         self._blueprints.pop(plugin_id, None)
         self._dashboard_cards.pop(plugin_id, None)

--- a/backend/plugin_manager.py
+++ b/backend/plugin_manager.py
@@ -27,6 +27,8 @@ from backend.plugin_hooks import (  # noqa: F401
     # Message Interceptor
     register_message_interceptor, unregister_message_interceptor,
     run_message_interceptors,
+    register_user_message_transformer, unregister_user_message_transformer,
+    apply_user_message_transformers,
     # Turn Context Provider
     register_turn_context_provider, unregister_turn_context_provider,
     get_turn_context, apply_turn_context,

--- a/backend/plugin_manager.py
+++ b/backend/plugin_manager.py
@@ -30,6 +30,8 @@ from backend.plugin_hooks import (  # noqa: F401
     # Turn Context Provider
     register_turn_context_provider, unregister_turn_context_provider,
     get_turn_context, apply_turn_context,
+    register_agent_state_summary_provider, unregister_agent_state_summary_provider,
+    get_agent_state_summaries,
     # Busy Message Provider
     register_busy_message_provider, unregister_busy_message_provider,
     get_busy_message,

--- a/backend/plugin_manager.py
+++ b/backend/plugin_manager.py
@@ -31,6 +31,10 @@ from backend.plugin_hooks import (  # noqa: F401
     run_final_response_handlers,
     register_user_message_transformer, unregister_user_message_transformer,
     apply_user_message_transformers,
+    register_tool_request_transformer, unregister_tool_request_transformer,
+    apply_tool_request_transformers,
+    register_tool_result_transformer, unregister_tool_result_transformer,
+    apply_tool_result_transformers,
     # Turn Context Provider
     register_turn_context_provider, unregister_turn_context_provider,
     get_turn_context, apply_turn_context,

--- a/backend/plugin_manager.py
+++ b/backend/plugin_manager.py
@@ -29,7 +29,7 @@ from backend.plugin_hooks import (  # noqa: F401
     run_message_interceptors,
     # Turn Context Provider
     register_turn_context_provider, unregister_turn_context_provider,
-    get_turn_context,
+    get_turn_context, apply_turn_context,
     # Busy Message Provider
     register_busy_message_provider, unregister_busy_message_provider,
     get_busy_message,

--- a/backend/plugin_manager.py
+++ b/backend/plugin_manager.py
@@ -27,6 +27,8 @@ from backend.plugin_hooks import (  # noqa: F401
     # Message Interceptor
     register_message_interceptor, unregister_message_interceptor,
     run_message_interceptors,
+    register_final_response_handler, unregister_final_response_handler,
+    run_final_response_handlers,
     register_user_message_transformer, unregister_user_message_transformer,
     apply_user_message_transformers,
     # Turn Context Provider

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -2021,6 +2021,15 @@ def api_chat_agent_state(agent_id):
     else:
         payload = {'mode': None, 'active_model': None, 'loaded_skills': loaded_skills}
 
+    # Display-only plugin summaries share the existing Agent State renderer but
+    # are never persisted into workflow state or injected into the model prompt.
+    try:
+        from backend.plugin_manager import get_agent_state_summaries
+        for namespace, summary in get_agent_state_summaries(agent_id, session_id).items():
+            payload.setdefault('states', {}).setdefault(namespace, summary)
+    except Exception:
+        pass
+
     # Background processes tracked for this session (Session State panel).
     if session_id:
         background_processes = []

--- a/unit_tests/test_plugin_agent_state_summary.py
+++ b/unit_tests/test_plugin_agent_state_summary.py
@@ -1,0 +1,48 @@
+from backend.plugin_hooks import (
+    get_agent_state_summaries,
+    register_agent_state_summary_provider,
+    unregister_agent_state_summary_provider,
+)
+
+
+def test_plugin_agent_state_summary_is_display_only_and_error_isolated():
+    register_agent_state_summary_provider(
+        "example", lambda agent_id, session_id: {
+            "state": "active",
+            "data": {"agent_id": agent_id, "session_id": session_id},
+        },
+    )
+    register_agent_state_summary_provider(
+        "broken", lambda _agent_id, _session_id: 1 / 0,
+    )
+    try:
+        assert get_agent_state_summaries("agent-1", "session-1") == {
+            "example": {
+                "state": "active",
+                "data": {"agent_id": "agent-1", "session_id": "session-1"},
+            }
+        }
+    finally:
+        unregister_agent_state_summary_provider("example")
+        unregister_agent_state_summary_provider("broken")
+
+
+def test_chat_state_api_includes_plugin_summary():
+    from app import app
+
+    register_agent_state_summary_provider(
+        "example", lambda _agent_id, _session_id: {
+            "state": "active", "data": {"source": "plugin"},
+        },
+    )
+    try:
+        with app.test_client() as client:
+            with client.session_transaction() as session:
+                session["authenticated"] = True
+            response = client.get("/api/agents/plugin-state-test/chat/state")
+        assert response.status_code == 200
+        assert response.get_json()["states"]["example"] == {
+            "state": "active", "data": {"source": "plugin"},
+        }
+    finally:
+        unregister_agent_state_summary_provider("example")

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -1,4 +1,9 @@
-from backend.plugin_hooks import apply_turn_context
+from backend.plugin_hooks import (
+    apply_turn_context,
+    apply_user_message_transformers,
+    register_user_message_transformer,
+    unregister_user_message_transformer,
+)
 
 
 def test_turn_context_injects_prefill_before_history_and_deduplicates_tools():
@@ -51,3 +56,43 @@ def test_turn_context_validates_types_roles_and_size_limits():
     assert injected[0] == {"role": "system", "content": "s" * 32000}
     assert injected[1] == {"role": "user", "content": "m" * 16000}
     assert injected[-1] == {"role": "assistant", "content": "reply-6"}
+
+
+def test_user_message_transformers_only_change_newest_user_text_parts():
+    messages = [
+        {"role": "system", "content": "core"},
+        {"role": "user", "content": "old request"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": [
+            {"type": "text", "text": "new request"},
+            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,x"}},
+        ]},
+    ]
+    register_user_message_transformer("first", lambda _a, _s, text: text.upper())
+    register_user_message_transformer("second", lambda _a, _s, text: f"[{text}]")
+    try:
+        assert apply_user_message_transformers("agent", "session", messages)
+    finally:
+        unregister_user_message_transformer("first")
+        unregister_user_message_transformer("second")
+
+    assert messages[1]["content"] == "old request"
+    assert messages[-1]["content"] == [
+        {"type": "text", "text": "[NEW REQUEST]"},
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,x"}},
+    ]
+
+
+def test_user_message_transformer_errors_fail_open(caplog):
+    def broken(_agent_id, _session_id, _text):
+        raise RuntimeError("broken")
+
+    messages = [{"role": "user", "content": "unchanged"}]
+    register_user_message_transformer("broken", broken)
+    try:
+        assert not apply_user_message_transformers("agent", "session", messages)
+    finally:
+        unregister_user_message_transformer("broken")
+
+    assert messages[0]["content"] == "unchanged"
+    assert "Plugin user-message transformer failed: broken" in caplog.text

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -1,0 +1,26 @@
+from backend.plugin_hooks import apply_turn_context
+
+
+def test_turn_context_injects_prefill_before_history_and_deduplicates_tools():
+    messages = [
+        {"role": "system", "content": "core"},
+        {"role": "user", "content": "real request"},
+    ]
+    existing = {"function": {"name": "existing"}}
+    added = {"function": {"name": "added"}}
+    tools = [existing]
+
+    apply_turn_context(messages, tools, [{
+        "system_md": "plugin context",
+        "prefill_messages": [
+            {"role": "user", "content": "priming question"},
+            {"role": "assistant", "content": "primed answer"},
+            {"role": "system", "content": "rejected role"},
+        ],
+        "tools": [existing, added],
+    }])
+
+    assert [m["content"] for m in messages] == [
+        "core", "plugin context", "priming question", "primed answer", "real request",
+    ]
+    assert [t["function"]["name"] for t in tools] == ["existing", "added"]

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -1,10 +1,16 @@
 from backend.plugin_hooks import (
+    apply_tool_request_transformers,
+    apply_tool_result_transformers,
     apply_turn_context,
     apply_user_message_transformers,
     register_final_response_handler,
+    register_tool_request_transformer,
+    register_tool_result_transformer,
     register_user_message_transformer,
     run_final_response_handlers,
     unregister_final_response_handler,
+    unregister_tool_request_transformer,
+    unregister_tool_result_transformer,
     unregister_user_message_transformer,
 )
 
@@ -122,6 +128,46 @@ def test_user_message_transformer_errors_fail_open(caplog):
 
     assert messages[0]["content"] == "unchanged"
     assert "Plugin user-message transformer failed: broken" in caplog.text
+
+
+def test_tool_transformers_chain_nested_payloads_and_preserve_non_strings():
+    payload = {"prompt": "hello", "items": ["world", {"count": 2}]}
+    register_tool_request_transformer(
+        "first", lambda _a, _s, _t, value: {
+            **value, "prompt": value["prompt"].upper()})
+    register_tool_request_transformer(
+        "second", lambda _a, _s, _t, value: {
+            **value, "items": [value["items"][0].upper(), value["items"][1]]})
+    register_tool_result_transformer(
+        "result", lambda _a, _s, _t, value: {
+            **value, "data": [item.upper() if isinstance(item, str) else item
+                                for item in value["data"]]})
+    try:
+        assert apply_tool_request_transformers("agent", "session", "tool", payload) == {
+            "prompt": "HELLO", "items": ["WORLD", {"count": 2}]}
+        assert apply_tool_result_transformers(
+            "agent", "session", "tool", {"data": ["done", 1]}) == {
+                "data": ["DONE", 1]}
+    finally:
+        unregister_tool_request_transformer("first")
+        unregister_tool_request_transformer("second")
+        unregister_tool_result_transformer("result")
+
+
+def test_tool_transformer_errors_fail_open_and_none_keeps_payload(caplog):
+    def broken(_agent_id, _session_id, _tool_name, _payload):
+        raise RuntimeError("broken")
+
+    payload = {"text": "unchanged"}
+    register_tool_request_transformer("none", lambda *_args: None)
+    register_tool_request_transformer("broken", broken)
+    try:
+        assert apply_tool_request_transformers("agent", "session", "tool", payload) == payload
+    finally:
+        unregister_tool_request_transformer("none")
+        unregister_tool_request_transformer("broken")
+
+    assert "Plugin tool-request transformer failed: broken" in caplog.text
 
 
 def test_final_response_handler_can_retry_replace_or_fail_open(caplog):

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -24,3 +24,30 @@ def test_turn_context_injects_prefill_before_history_and_deduplicates_tools():
         "core", "plugin context", "priming question", "primed answer", "real request",
     ]
     assert [t["function"]["name"] for t in tools] == ["existing", "added"]
+
+
+def test_turn_context_validates_types_roles_and_size_limits():
+    messages = [
+        {"role": "system", "content": "core"},
+        {"role": "user", "content": "real request"},
+    ]
+
+    apply_turn_context(messages, [], [
+        None,
+        {"system_md": 123, "prefill_messages": "not-a-list"},
+        {
+            "system_md": "s" * 40000,
+            "prefill_messages": [
+                {"role": "user", "content": "m" * 20000},
+            ] + [
+                {"role": "assistant", "content": f"reply-{index}"}
+                for index in range(10)
+            ],
+        },
+    ])
+
+    injected = messages[1:-1]
+    assert len(injected) == 9
+    assert injected[0] == {"role": "system", "content": "s" * 32000}
+    assert injected[1] == {"role": "user", "content": "m" * 16000}
+    assert injected[-1] == {"role": "assistant", "content": "reply-6"}

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -58,6 +58,29 @@ def test_turn_context_validates_types_roles_and_size_limits():
     assert injected[-1] == {"role": "assistant", "content": "reply-6"}
 
 
+def test_turn_context_system_modes_preserve_append_or_replace_request_prompt():
+    preserve = [{"role": "system", "content": "core"},
+                {"role": "user", "content": "request"}]
+    apply_turn_context(preserve, [], [{
+        "system_md": "plugin", "system_mode": "preserve",
+        "prefill_messages": [{"role": "assistant", "content": "primed"}],
+    }])
+    assert preserve == [
+        {"role": "system", "content": "core"},
+        {"role": "assistant", "content": "primed"},
+        {"role": "user", "content": "request"},
+    ]
+
+    append = [{"role": "system", "content": "core"}]
+    apply_turn_context(append, [], [{"system_md": "plugin", "system_mode": "append"}])
+    assert [message["content"] for message in append] == ["core", "plugin"]
+
+    replace = [{"role": "system", "content": "core"},
+               {"role": "user", "content": "request"}]
+    apply_turn_context(replace, [], [{"system_md": "plugin", "system_mode": "replace"}])
+    assert [message["content"] for message in replace] == ["plugin", "request"]
+
+
 def test_user_message_transformers_only_change_newest_user_text_parts():
     messages = [
         {"role": "system", "content": "core"},

--- a/unit_tests/test_plugin_turn_context.py
+++ b/unit_tests/test_plugin_turn_context.py
@@ -1,7 +1,10 @@
 from backend.plugin_hooks import (
     apply_turn_context,
     apply_user_message_transformers,
+    register_final_response_handler,
     register_user_message_transformer,
+    run_final_response_handlers,
+    unregister_final_response_handler,
     unregister_user_message_transformer,
 )
 
@@ -119,3 +122,35 @@ def test_user_message_transformer_errors_fail_open(caplog):
 
     assert messages[0]["content"] == "unchanged"
     assert "Plugin user-message transformer failed: broken" in caplog.text
+
+
+def test_final_response_handler_can_retry_replace_or_fail_open(caplog):
+    register_final_response_handler(
+        "retry", lambda context: {
+            "retry": True,
+            "messages": context["messages"] + [{"role": "user", "content": "retry"}],
+        })
+    try:
+        decision = run_final_response_handlers({
+            "content": "refused", "messages": [{"role": "user", "content": "request"}],
+        })
+        assert decision["namespace"] == "retry"
+        assert decision["messages"][-1]["content"] == "retry"
+    finally:
+        unregister_final_response_handler("retry")
+
+    register_final_response_handler("replace", lambda _context: {"content": "accepted"})
+    try:
+        assert run_final_response_handlers({})["content"] == "accepted"
+    finally:
+        unregister_final_response_handler("replace")
+
+    def broken(_context):
+        raise RuntimeError("broken")
+
+    register_final_response_handler("broken", broken)
+    try:
+        assert run_final_response_handlers({}) is None
+    finally:
+        unregister_final_response_handler("broken")
+    assert "Plugin final-response handler failed: broken" in caplog.text


### PR DESCRIPTION
## Summary

- extend the existing plugin turn-context result with validated `prefill_messages`
- inject ephemeral user/assistant priming after the main system prompt and before conversation history
- add a generic read-only plugin summary provider for the existing chat Agent State panel
- restrict prefill roles, message count, and content length
- keep feature-specific behavior outside Evonic core

Prefill messages are request-scoped and are never persisted to SQLite or JSONL session history. Plugin summaries are display-only: they are not persisted into workflow state, do not gate tools, and are not injected into model context.

## Verification

- focused turn-context and Agent State summary checks passed
- authenticated chat-state API smoke test passed with the external plugin
- external plugin suite passed: 11 tests
- affected Python modules compile successfully
- live Evonic install and restart verification passed

## Existing CI baseline

The earlier Python job reported 2 failures and 2,035 passes. The same two unrelated failures were present on the preceding PR commit (2 failures and 2,034 passes):

- `unit_tests/test_ssh_backend_binary_read.py::test_cat_file_bytes_reads_binary_data_through_sftp`
- `unit_tests/test_token_efficiency.py::test_artifact_instructions_keep_capabilities_with_lower_token_cost`

Draft for maintainer review of the generic hook shape and placement.