### PR TITLE
feat: add Claude Code auth and improve Codex setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,7 @@ from routes.scheduler import scheduler_bp
 from routes.models import models_bp
 from routes.providers import providers_bp
 from routes.codex import codex_bp
+from routes.claude import claude_bp
 from routes.health import health_bp
 from routes.workplaces import workplaces_bp
 from routes.logs import logs_bp
@@ -240,6 +241,7 @@ app.register_blueprint(dashboard_bp)
 app.register_blueprint(models_bp)
 app.register_blueprint(providers_bp)
 app.register_blueprint(codex_bp)
+app.register_blueprint(claude_bp)
 app.register_blueprint(health_bp)
 app.register_blueprint(workplaces_bp)
 app.register_blueprint(logs_bp)

--- a/backend/agent_runtime/context.py
+++ b/backend/agent_runtime/context.py
@@ -778,6 +778,7 @@ def build_system_prompt(agent: Dict[str, Any], injected_system_vars: Dict[str, s
         ("/jobs", "List background jobs for this session and any monitors attached to them"),
         ("/dump", "Dump current session as JSONL file for download"),
         ("/model", "Show or switch LLM model"),
+        ("/fast", "Show or set Codex Fast mode for this session"),
     ]
     slash_commands.append(("/plan", "Switch to plan mode"))
     slash_commands.append(("/unfocus", "Force-clear focus mode — use when agent is stuck in focus after a failed task"))

--- a/backend/agent_runtime/llm_loop.py
+++ b/backend/agent_runtime/llm_loop.py
@@ -670,6 +670,17 @@ def run_tool_loop(agent: Dict[str, Any],
                     if _tid not in _assigned:
                         _assigned.append(_tid)
 
+    # Fast mode is a session preference. The Codex client revalidates support
+    # against every effective model, so it cannot leak into an incompatible fallback.
+    _session_service_tier = None
+    try:
+        _session_raw = db.get_session_state(session_id, agent_id=agent_id)
+        _session_data = json.loads(_session_raw) if _session_raw else {}
+        if isinstance(_session_data, dict) and _session_data.get('service_tier') == 'priority':
+            _session_service_tier = 'priority'
+    except (TypeError, ValueError):
+        pass
+
     # Helper: build model_config dict from a model DB row
     def _build_model_config(_model: dict) -> dict:
         return {
@@ -684,6 +695,7 @@ def run_tool_loop(agent: Dict[str, Any],
             'temperature': _model.get('temperature'),
             'vision_supported': bool(_model.get('vision_supported', False)),
             'api_format': _model.get('api_format', 'openai'),
+            'service_tier': _session_service_tier,
         }
 
     # Resolve agent's default model for LLM calls

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -248,10 +248,12 @@ class LLMClient:
 
         Args:
             model_config: Dict with keys: base_url, api_key, model_name, timeout,
-                         thinking (bool), thinking_budget (int), max_tokens, temperature.
+                         thinking (bool), thinking_budget (int), max_tokens, temperature,
+                         and optional service_tier.
                          If None, uses the default model from DB or config.py defaults.
         """
         self.provider = None
+        self.service_tier = model_config.get("service_tier") if model_config else None
         self._model_api_key_override = False
         if model_config:
             self._model_api_key_override = bool(model_config.get("api_key"))
@@ -439,6 +441,7 @@ class LLMClient:
             reasoning=bool(self.thinking),
             timeout=self.timeout or 120,
             tool_choice=tool_choice,
+            service_tier=getattr(self, "service_tier", None),
         )
         duration_ms = int((time.time() - start_time) * 1000)
 

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -252,7 +252,9 @@ class LLMClient:
                          If None, uses the default model from DB or config.py defaults.
         """
         self.provider = None
+        self._model_api_key_override = False
         if model_config:
+            self._model_api_key_override = bool(model_config.get("api_key"))
             try:
                 from models.db import db
                 model_config = db.resolve_model_config(model_config)
@@ -274,6 +276,7 @@ class LLMClient:
 
                 dm = db.get_default_model()
                 if dm:
+                    self._model_api_key_override = bool(dm.get("api_key"))
                     dm = db.resolve_model_config(dm)
                     self.provider = dm.get("provider")
                     self.base_url = dm.get("base_url")
@@ -568,6 +571,17 @@ class LLMClient:
             self.base_url and "anthropic.com" in self.base_url
         )
         is_anthropic = self.api_format == "anthropic"
+        anthropic_token = self.api_key
+        anthropic_oauth = False
+        if is_anthropic:
+            from backend.provider.claude_code import is_oauth_token, resolve_credential
+            if getattr(self, "_model_api_key_override", False):
+                anthropic_oauth = is_oauth_token(anthropic_token or "")
+            else:
+                from models.db import db as _provider_db
+                anthropic_token, anthropic_oauth = resolve_credential(
+                    _provider_db, self.provider or "anthropic"
+                )
         # Cerebras is a strict OpenAI-compatible validator: it rejects the
         # non-standard reasoning_content field on input messages (unlike
         # OpenCode Go / MiniMax / DeepSeek, which require it round-tripped).
@@ -702,6 +716,11 @@ class LLMClient:
             }
             if system_msgs:
                 payload["system"] = "\n\n".join(system_msgs) if len(system_msgs) > 1 else system_msgs[0]
+            if anthropic_oauth:
+                from backend.provider.claude_code import SYSTEM_PREFIX
+                payload["system"] = SYSTEM_PREFIX + (
+                    "\n\n" + payload["system"] if payload.get("system") else ""
+                )
             if effective_temperature is not None:
                 payload["temperature"] = effective_temperature
             # Transform OpenAI tools -> Anthropic tools format
@@ -734,12 +753,8 @@ class LLMClient:
                         "type": "function", "function": {"name": tool_choice}}
 
         if is_anthropic:
-            headers = {
-                "Content-Type": "application/json",
-                "anthropic-version": "2023-06-01",
-            }
-            if self.api_key:
-                headers["x-api-key"] = self.api_key
+            from backend.provider.claude_code import auth_headers
+            headers = auth_headers(anthropic_token or "", anthropic_oauth)
         else:
             headers = {"Content-Type": "application/json"}
             if self.api_key:

--- a/backend/provider/claude_code.py
+++ b/backend/provider/claude_code.py
@@ -1,0 +1,321 @@
+"""Anthropic API and Claude Code subscription credentials."""
+
+import base64
+import hashlib
+import json
+import os
+import platform
+import secrets
+import stat
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlencode
+
+import requests
+
+
+CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+TOKEN_URLS = (
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+)
+REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+SCOPES = "org:create_api_key user:profile user:inference"
+TOKEN_USER_AGENT = "axios/1.7.9"
+SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
+OAUTH_BETAS = "claude-code-20250219,oauth-2025-04-20"
+
+_pending_auth: Dict[str, Dict[str, Any]] = {}
+_claude_version: Optional[str] = None
+
+
+def _read_keychain() -> Optional[Dict[str, Any]]:
+    if platform.system() != "Darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+        payload = json.loads(result.stdout) if result.returncode == 0 else {}
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+    return _normalize_credentials(payload, "macos_keychain")
+
+
+def _credential_path() -> Path:
+    return Path.home() / ".claude" / ".credentials.json"
+
+
+def _read_file() -> Optional[Dict[str, Any]]:
+    try:
+        path = _credential_path()
+        return _normalize_credentials(json.loads(path.read_text()), "claude_credentials_file") if path.is_file() else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _normalize_credentials(payload: Dict[str, Any], source: str) -> Optional[Dict[str, Any]]:
+    oauth = payload.get("claudeAiOauth") if isinstance(payload, dict) else None
+    if not isinstance(oauth, dict) or not (oauth.get("accessToken") or oauth.get("refreshToken")):
+        return None
+    return {
+        "access_token": oauth.get("accessToken", ""),
+        "refresh_token": oauth.get("refreshToken", ""),
+        "expires_at_ms": int(oauth.get("expiresAt") or 0),
+        "scopes": oauth.get("scopes"),
+        "source": source,
+    }
+
+
+def _is_valid(creds: Dict[str, Any]) -> bool:
+    expires_at = creds.get("expires_at_ms", 0)
+    return bool(creds.get("access_token")) and (
+        not expires_at or int(time.time() * 1000) < int(expires_at) - 60_000
+    )
+
+
+def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
+    candidates = [item for item in (_read_keychain(), _read_file()) if item]
+    if not candidates:
+        return None
+    valid = [item for item in candidates if _is_valid(item)]
+    return max(valid or candidates, key=lambda item: item.get("expires_at_ms", 0))
+
+
+def _write_file(creds: Dict[str, Any]) -> None:
+    path = _credential_path()
+    try:
+        payload = json.loads(path.read_text()) if path.is_file() else {}
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    oauth = {
+        "accessToken": creds["access_token"],
+        "refreshToken": creds.get("refresh_token", ""),
+        "expiresAt": creds.get("expires_at_ms", 0),
+    }
+    if creds.get("scopes") is not None:
+        oauth["scopes"] = creds["scopes"]
+    payload["claudeAiOauth"] = oauth
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{secrets.token_hex(4)}")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _refresh(refresh_token: str) -> Optional[Dict[str, Any]]:
+    for endpoint in TOKEN_URLS:
+        try:
+            response = requests.post(
+                endpoint,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": CLIENT_ID,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": TOKEN_USER_AGENT},
+                timeout=15,
+            )
+        except requests.RequestException:
+            continue
+        if response.status_code != 200:
+            continue
+        try:
+            data = response.json()
+        except ValueError:
+            continue
+        if data.get("access_token"):
+            return {
+                "access_token": data["access_token"],
+                "refresh_token": data.get("refresh_token", refresh_token),
+                "expires_at_ms": int(time.time() * 1000) + int(data.get("expires_in", 3600)) * 1000,
+            }
+    return None
+
+
+def use_claude_code_credentials(db, provider_id: str) -> Dict[str, Any]:
+    creds = read_claude_code_credentials()
+    if not creds or (not _is_valid(creds) and not creds.get("refresh_token")):
+        return {"error": "No usable Claude Code login found. Run `claude setup-token` first."}
+    db.update_provider(provider_id, {
+        "api_key": "",
+        "refresh_token": "",
+        "token_expires_at": 0,
+        "auth_type": "oauth",
+        "credential_source": "claude_code",
+    })
+    return {"success": True, "detected_source": creds["source"]}
+
+
+def save_secret(db, provider_id: str, secret: str) -> Dict[str, Any]:
+    secret = secret.strip()
+    if not secret.startswith(("sk-ant-", "cc-", "eyJ")):
+        return {"error": "Enter an Anthropic API key or Claude setup-token."}
+    oauth = is_oauth_token(secret)
+    db.update_provider(provider_id, {
+        "api_key": secret,
+        "refresh_token": "",
+        "token_expires_at": 0,
+        "auth_type": "oauth" if oauth else "api_key",
+        "credential_source": "setup_token" if oauth else "api_key",
+    })
+    return {"success": True}
+
+
+def is_oauth_token(token: str) -> bool:
+    return bool(token) and not token.startswith("sk-ant-api") and token.startswith(("sk-ant-", "cc-", "eyJ"))
+
+
+def start_oauth_flow(provider_id: str) -> Dict[str, Any]:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(32)
+    _pending_auth[provider_id] = {"verifier": verifier, "state": state, "started_at": time.time()}
+    params = {
+        "code": "true",
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    return {"success": True, "auth_url": f"{AUTHORIZE_URL}?{urlencode(params)}"}
+
+
+def complete_oauth_flow(db, provider_id: str, authorization_code: str) -> Dict[str, Any]:
+    pending = _pending_auth.get(provider_id)
+    if not pending or time.time() - pending["started_at"] > 600:
+        _pending_auth.pop(provider_id, None)
+        return {"error": "OAuth login expired. Start again."}
+    code, separator, state = authorization_code.strip().partition("#")
+    if not separator or state != pending["state"]:
+        return {"error": "Invalid authorization code or OAuth state."}
+    body = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "state": state,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": pending["verifier"],
+    }
+    result = None
+    for endpoint in TOKEN_URLS:
+        try:
+            response = requests.post(
+                endpoint,
+                json=body,
+                headers={"Content-Type": "application/json", "User-Agent": TOKEN_USER_AGENT},
+                timeout=15,
+            )
+        except requests.RequestException:
+            continue
+        if response.status_code == 200:
+            try:
+                result = response.json()
+            except ValueError:
+                continue
+            break
+    _pending_auth.pop(provider_id, None)
+    if not result or not result.get("access_token"):
+        return {"error": "Anthropic token exchange failed."}
+    db.update_provider(provider_id, {
+        "api_key": result["access_token"],
+        "refresh_token": result.get("refresh_token", ""),
+        "token_expires_at": int(time.time()) + int(result.get("expires_in", 3600)),
+        "auth_type": "oauth",
+        "credential_source": "evonic_oauth",
+    })
+    return {"success": True}
+
+
+def resolve_credential(db, provider_id: str) -> Tuple[Optional[str], bool]:
+    provider = db.get_provider(provider_id)
+    if not provider or provider.get("api_format") != "anthropic":
+        return None, False
+    source = provider.get("credential_source") or "api_key"
+    if source == "claude_code":
+        creds = read_claude_code_credentials()
+        if not creds:
+            return None, True
+        if _is_valid(creds):
+            return creds["access_token"], True
+        # Re-read happened above; refresh only the current live token to avoid
+        # racing Claude Code's single-use refresh-token rotation.
+        refreshed = _refresh(creds.get("refresh_token", "")) if creds.get("refresh_token") else None
+        if refreshed:
+            refreshed["scopes"] = creds.get("scopes")
+            _write_file(refreshed)
+            return refreshed["access_token"], True
+        return None, True
+
+    token = provider.get("api_key") or ""
+    if provider.get("auth_type") != "oauth":
+        return (token or None), False
+    expires_at = int(provider.get("token_expires_at") or 0)
+    if token and (not expires_at or time.time() < expires_at - 120):
+        return token, True
+    refresh_token = provider.get("refresh_token") or ""
+    refreshed = _refresh(refresh_token) if refresh_token else None
+    if not refreshed:
+        return None, True
+    db.update_provider(provider_id, {
+        "api_key": refreshed["access_token"],
+        "refresh_token": refreshed.get("refresh_token", refresh_token),
+        "token_expires_at": int(refreshed["expires_at_ms"] / 1000),
+    })
+    return refreshed["access_token"], True
+
+
+def clear_credentials(db, provider_id: str) -> bool:
+    return db.update_provider(provider_id, {
+        "api_key": "",
+        "refresh_token": "",
+        "token_expires_at": 0,
+        "auth_type": "api_key",
+        "credential_source": "api_key",
+    })
+
+
+def claude_code_version() -> str:
+    global _claude_version
+    if _claude_version:
+        return _claude_version
+    try:
+        result = subprocess.run(["claude", "--version"], capture_output=True, text=True, timeout=5)
+        version = result.stdout.strip().split()[0]
+        _claude_version = version if result.returncode == 0 and version[:1].isdigit() else "2.1.74"
+    except (OSError, subprocess.TimeoutExpired):
+        _claude_version = "2.1.74"
+    return _claude_version
+
+
+def auth_headers(token: str, oauth: bool) -> Dict[str, str]:
+    headers = {"Content-Type": "application/json", "anthropic-version": "2023-06-01"}
+    if oauth:
+        headers.update({
+            "Authorization": f"Bearer {token}",
+            "anthropic-beta": OAUTH_BETAS,
+            "user-agent": f"claude-code/{claude_code_version()} (external, cli)",
+            "x-app": "cli",
+        })
+    else:
+        headers["x-api-key"] = token
+    return headers

--- a/backend/provider/codex_client.py
+++ b/backend/provider/codex_client.py
@@ -17,6 +17,18 @@ from backend.provider.oauth_codex import CODEX_BASE_URL, extract_account_id
 _log = logging.getLogger(__name__)
 
 
+def model_supports_fast_mode(model: Optional[str]) -> bool:
+    """Return whether Codex advertises Fast mode for this model family."""
+    model_id = str(model or "").strip().lower()
+    if "/" in model_id:
+        model_id = model_id.split("/", 1)[1]
+    model_id = model_id.split(":", 1)[0]
+    return (
+        model_id in {"gpt-5.4", "gpt-5.5", "gpt-5.6"}
+        or model_id.startswith("gpt-5.6-")
+    )
+
+
 def _classify_stream_error(code: str) -> str:
     """Map a Responses API error/incomplete code to an llm_loop error_type.
 
@@ -74,7 +86,12 @@ class CodexClient:
         """True when talking to the ChatGPT subscription backend (Codex CLI protocol)."""
         return "chatgpt.com" in self.base_url
 
-    def _headers(self, accept: str = "text/event-stream") -> Dict[str, str]:
+    def _headers(
+        self,
+        accept: str = "text/event-stream",
+        model: str = "",
+        service_tier: Optional[str] = None,
+    ) -> Dict[str, str]:
         h = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
@@ -84,6 +101,8 @@ class CodexClient:
         }
         if self._account_id:
             h["ChatGPT-Account-ID"] = self._account_id
+        if service_tier == "priority" and model_supports_fast_mode(model):
+            h["x-codex-routing-hint"] = f"model={model};tier=priority"
         return h
 
     def send_request(
@@ -97,6 +116,7 @@ class CodexClient:
         stream: bool = True,
         timeout: int = 120,
         tool_choice: Optional[str] = None,
+        service_tier: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Send a request to the Codex Responses API."""
         payload: Dict[str, Any] = {
@@ -107,6 +127,8 @@ class CodexClient:
         }
         if reasoning:
             payload["reasoning"] = {"summary": "auto"}
+        if service_tier == "priority" and model_supports_fast_mode(model):
+            payload["service_tier"] = "priority"
         # Cap the output so a reasoning model can't spend the whole budget
         # thinking and return an empty (incomplete) response. The ChatGPT
         # Codex backend only accepts the parameter set the Codex CLI sends,
@@ -159,7 +181,10 @@ class CodexClient:
                 "POST",
                 url,
                 json=payload,
-                headers=self._headers(),
+                headers=self._headers(
+                    model=payload.get("model", ""),
+                    service_tier=payload.get("service_tier"),
+                ),
             ) as resp:
                 if resp.status_code != 200:
                     body = resp.read().decode(errors="replace")[:500]
@@ -314,7 +339,11 @@ class CodexClient:
         resp = httpx.post(
             url,
             json=payload,
-            headers=self._headers(accept="application/json"),
+            headers=self._headers(
+                accept="application/json",
+                model=payload.get("model", ""),
+                service_tier=payload.get("service_tier"),
+            ),
             timeout=timeout,
         )
 
@@ -399,6 +428,7 @@ class CodexClient:
         tools: Optional[List[Dict]] = None,
         reasoning: bool = False,
         timeout: int = 120,
+        service_tier: Optional[str] = None,
     ) -> Generator[Dict[str, Any], None, None]:
         """Yield SSE delta chunks for real-time streaming to the frontend."""
         payload: Dict[str, Any] = {
@@ -409,6 +439,8 @@ class CodexClient:
         }
         if reasoning:
             payload["reasoning"] = {"summary": "auto"}
+        if service_tier == "priority" and model_supports_fast_mode(model):
+            payload["service_tier"] = "priority"
         if tools:
             payload["tools"] = self._convert_tools(tools)
 
@@ -420,7 +452,10 @@ class CodexClient:
                 "POST",
                 url,
                 json=payload,
-                headers=self._headers(),
+                headers=self._headers(
+                    model=payload.get("model", ""),
+                    service_tier=payload.get("service_tier"),
+                ),
             ) as resp:
                 if resp.status_code != 200:
                     yield {

--- a/backend/provider/oauth_codex.py
+++ b/backend/provider/oauth_codex.py
@@ -11,10 +11,14 @@ import base64
 import hashlib
 import json as _json
 import logging
+import os
+import platform
 import secrets
+import subprocess
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from typing import Dict, Optional
 from urllib.parse import urlencode, urlparse, parse_qs
 
@@ -35,6 +39,7 @@ REDIRECT_URI = "http://localhost:1455/auth/callback"
 
 # In-memory state for pending auth flows (keyed by OAuth state, not provider_id)
 _pending_auth: Dict[str, Dict] = {}
+_pending_device_auth: Dict[str, Dict] = {}
 _callback_server: Optional[HTTPServer] = None
 _callback_server_running: bool = False
 
@@ -57,6 +62,180 @@ def _generate_pkce():
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
     return code_verifier, code_challenge
+
+
+def _decode_jwt_claims(token: str) -> Dict:
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return _json.loads(base64.urlsafe_b64decode(payload))
+    except Exception:
+        return {}
+
+
+def _access_token_is_expiring(token: str, skew_seconds: int = 120) -> bool:
+    exp = _decode_jwt_claims(token).get("exp")
+    return bool(exp and time.time() >= int(exp) - skew_seconds)
+
+
+def _codex_home() -> Path:
+    return Path(os.getenv("CODEX_HOME") or Path.home() / ".codex").expanduser()
+
+
+def _read_codex_keyring(codex_home: Path) -> Optional[Dict]:
+    """Read Codex's direct macOS keyring backend without changing it."""
+    if platform.system() != "Darwin":
+        return None
+    key = "cli|" + hashlib.sha256(str(codex_home.resolve()).encode()).hexdigest()[:16]
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", "Codex Auth", "-a", key, "-w"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+        return _json.loads(result.stdout) if result.returncode == 0 else None
+    except (OSError, subprocess.TimeoutExpired, _json.JSONDecodeError):
+        return None
+
+
+def read_codex_cli_credentials() -> Optional[Dict]:
+    """Read the freshest usable Codex CLI OAuth credential snapshot."""
+    codex_home = _codex_home()
+    candidates = []
+    keyring = _read_codex_keyring(codex_home)
+    if keyring:
+        candidates.append(("codex_keyring", keyring))
+    try:
+        auth_file = codex_home / "auth.json"
+        if auth_file.is_file():
+            candidates.append(("codex_auth_file", _json.loads(auth_file.read_text())))
+    except (OSError, _json.JSONDecodeError):
+        pass
+
+    usable = []
+    for source, payload in candidates:
+        tokens = payload.get("tokens") if isinstance(payload, dict) else None
+        if not isinstance(tokens, dict) or not tokens.get("access_token"):
+            continue
+        usable.append({
+            "source": source,
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens.get("refresh_token", ""),
+            "account_id": tokens.get("account_id", ""),
+            "expires_at": int(_decode_jwt_claims(tokens["access_token"]).get("exp") or 0),
+        })
+    if not usable:
+        return None
+    return max(usable, key=lambda item: item["expires_at"])
+
+
+def use_codex_cli_credentials(db, provider_id: str) -> Dict:
+    creds = read_codex_cli_credentials()
+    if not creds:
+        return {"error": "No Codex CLI login found. Run `codex login` first."}
+    store_tokens(db, provider_id, {
+        "access_token": creds["access_token"],
+        "refresh_token": creds.get("refresh_token", ""),
+        "expires_at": creds.get("expires_at", 0),
+    }, credential_source="codex_cli_import")
+    return {"success": True, "detected_source": creds["source"]}
+
+
+def start_device_auth_flow(provider_id: str) -> Dict:
+    """Start the same device-code login flow used by the Codex CLI."""
+    try:
+        resp = requests.post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            json={"client_id": CLIENT_ID},
+            headers={"Content-Type": "application/json"},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        return {"error": f"Failed to request device code: {exc}"}
+    if resp.status_code != 200:
+        return {"error": f"Device login failed (HTTP {resp.status_code})."}
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"error": "OpenAI returned an invalid device code response."}
+    user_code = data.get("user_code")
+    device_auth_id = data.get("device_auth_id")
+    if not user_code or not device_auth_id:
+        return {"error": "OpenAI returned an incomplete device code response."}
+    _pending_device_auth[provider_id] = {
+        "user_code": user_code,
+        "device_auth_id": device_auth_id,
+        "started_at": time.time(),
+        "interval": max(3, int(data.get("interval", 5))),
+    }
+    return {
+        "success": True,
+        "user_code": user_code,
+        "verification_url": "https://auth.openai.com/codex/device",
+        "interval": _pending_device_auth[provider_id]["interval"],
+    }
+
+
+def poll_device_auth_flow(provider_id: str) -> Dict:
+    pending = _pending_device_auth.get(provider_id)
+    if not pending:
+        return {"status": "error", "error": "No pending device login."}
+    if time.time() - pending["started_at"] > 900:
+        _pending_device_auth.pop(provider_id, None)
+        return {"status": "expired", "error": "Device login timed out."}
+    try:
+        resp = requests.post(
+            "https://auth.openai.com/api/accounts/deviceauth/token",
+            json={
+                "device_auth_id": pending["device_auth_id"],
+                "user_code": pending["user_code"],
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        return {"status": "error", "error": f"Device login polling failed: {exc}"}
+    if resp.status_code in {403, 404}:
+        return {"status": "pending"}
+    if resp.status_code != 200:
+        return {"status": "error", "error": f"Device login failed (HTTP {resp.status_code})."}
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"status": "error", "error": "OpenAI returned invalid authorization data."}
+    code = data.get("authorization_code")
+    verifier = data.get("code_verifier")
+    if not code or not verifier:
+        return {"status": "error", "error": "OpenAI returned incomplete authorization data."}
+    try:
+        token_resp = requests.post(
+            TOKEN_ENDPOINT,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": "https://auth.openai.com/deviceauth/callback",
+                "client_id": CLIENT_ID,
+                "code_verifier": verifier,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        _pending_device_auth.pop(provider_id, None)
+        return {"status": "error", "error": f"Token exchange failed: {exc}"}
+    _pending_device_auth.pop(provider_id, None)
+    if token_resp.status_code != 200:
+        return {"status": "error", "error": f"Token exchange failed (HTTP {token_resp.status_code})."}
+    try:
+        tokens = token_resp.json()
+    except ValueError:
+        return {"status": "error", "error": "OpenAI returned an invalid token response."}
+    if not tokens.get("access_token"):
+        return {"status": "error", "error": "OpenAI did not return an access token."}
+    return {"status": "complete", "tokens": tokens}
 
 
 def _run_callback_server():
@@ -286,21 +465,9 @@ def exchange_code_for_tokens(provider_id: str) -> Dict:
 
 def extract_account_id(access_token: str) -> str:
     """Extract ChatGPT account ID from JWT access token claims."""
-    try:
-        parts = access_token.split(".")
-        if len(parts) < 2:
-            return ""
-        payload = parts[1]
-        padding = 4 - len(payload) % 4
-        if padding != 4:
-            payload += "=" * padding
-        claims = _json.loads(base64.urlsafe_b64decode(payload))
-        auth = claims.get("https://api.openai.com/auth", {})
-        if isinstance(auth, dict):
-            return auth.get("chatgpt_account_id", "")
-        return ""
-    except Exception:
-        return ""
+    claims = _decode_jwt_claims(access_token)
+    auth = claims.get("https://api.openai.com/auth", {})
+    return auth.get("chatgpt_account_id", "") if isinstance(auth, dict) else ""
 
 
 def refresh_access_token(refresh_token: str) -> Dict:
@@ -333,21 +500,24 @@ def refresh_access_token(refresh_token: str) -> Dict:
     }
 
 
-def store_tokens(db, provider_id: str, tokens: Dict) -> bool:
+def store_tokens(db, provider_id: str, tokens: Dict, credential_source: str = "evonic_oauth") -> bool:
     """Persist OAuth tokens to the provider row."""
-    expires_at = int(time.time()) + int(tokens.get("expires_in", 3600))
+    expires_at = int(tokens.get("expires_at") or 0)
+    if not expires_at:
+        expires_at = int(time.time()) + int(tokens.get("expires_in", 3600))
     return db.update_provider(provider_id, {
         "api_key": tokens["access_token"],
         "refresh_token": tokens.get("refresh_token", ""),
         "token_expires_at": expires_at,
         "auth_type": "oauth",
+        "credential_source": credential_source,
     })
 
 
 def get_valid_token(db, provider_id: str) -> Optional[str]:
     """Return a valid access token, refreshing if near expiry."""
     provider = db.get_provider(provider_id)
-    if not provider or provider.get("auth_type") != "oauth":
+    if not provider or provider.get("api_format") != "codex" or provider.get("auth_type") != "oauth":
         return None
 
     access_token = provider.get("api_key")
@@ -358,14 +528,25 @@ def get_valid_token(db, provider_id: str) -> Optional[str]:
     now = int(time.time())
 
     if expires_at > 0 and now >= (expires_at - 120):
+        source = provider.get("credential_source") or "evonic_oauth"
+        if source == "codex_cli_import":
+            live = read_codex_cli_credentials()
+            if live and not _access_token_is_expiring(live["access_token"]):
+                store_tokens(db, provider_id, {
+                    "access_token": live["access_token"],
+                    "refresh_token": live.get("refresh_token", ""),
+                    "expires_at": live.get("expires_at", 0),
+                }, credential_source=source)
+                return live["access_token"]
         refresh_token = provider.get("refresh_token", "")
         if refresh_token:
             new_tokens = refresh_access_token(refresh_token)
             if "error" not in new_tokens:
-                store_tokens(db, provider_id, new_tokens)
+                store_tokens(db, provider_id, new_tokens, credential_source=source)
                 return new_tokens["access_token"]
+        return None
 
-    return access_token
+    return access_token if not _access_token_is_expiring(access_token) else None
 
 
 def clear_tokens(db, provider_id: str) -> bool:
@@ -375,4 +556,5 @@ def clear_tokens(db, provider_id: str) -> bool:
         "refresh_token": "",
         "token_expires_at": 0,
         "auth_type": "",
+        "credential_source": "",
     })

--- a/backend/slash_commands.py
+++ b/backend/slash_commands.py
@@ -819,6 +819,8 @@ def _register_builtins():
         channel_id: Optional[str],
         args: str,
     ) -> str:
+        import json
+
         from models.db import db
         from backend.agent_state import AgentState
         from models.chat import agent_chat_manager
@@ -858,6 +860,25 @@ def _register_builtins():
         # Agent state: per-session (mode/plan_file) from session_state, global (focus) from agent_state
         _db = agent_chat_manager.get(agent_id)
         session_content = _db.get_session_state(session_id)
+        try:
+            session_data = json.loads(session_content) if session_content else {}
+        except (TypeError, ValueError):
+            session_data = {}
+        if not isinstance(session_data, dict):
+            session_data = {}
+        try:
+            resolved_model = db.resolve_model_config(model) if model else {}
+        except Exception:
+            resolved_model = model or {}
+        from backend.provider.codex_client import model_supports_fast_mode
+        fast_available = (
+            resolved_model.get("api_format") == "codex"
+            and model_supports_fast_mode(resolved_model.get("model_name"))
+        )
+        lines.append(
+            f"Fast: {'on' if session_data.get('service_tier') == 'priority' else 'off'}"
+            if fast_available else "Fast: unavailable"
+        )
         if session_content:
             sess_ms = AgentState.deserialize(session_content)
             lines.append(f"Mode: {sess_ms.mode}")
@@ -1148,6 +1169,58 @@ def _register_builtins():
         model_handler,
         "Show or switch LLM model — /model, /model list|ls, /model [number|provider/model]",
         parameters=[{"name": "action", "options": ["current", "list", "set"]}, {"name": "model"}],
+    )
+
+    # /fast — Session-scoped Codex Priority Processing toggle
+    def fast_handler(
+        session_id: str,
+        agent_id: str,
+        external_user_id: str,
+        channel_id: Optional[str],
+        args: str,
+    ) -> str:
+        import json
+
+        from backend.provider.codex_client import model_supports_fast_mode
+        from models.chat import agent_chat_manager
+        from models.db import db
+
+        model = db.get_agent_model(agent_id)
+        model = db.resolve_model_config(model) if model else {}
+        if (model.get("api_format") != "codex"
+                or not model_supports_fast_mode(model.get("model_name"))):
+            return "Fast mode is not supported by the current model."
+
+        chat_db = agent_chat_manager.get(agent_id)
+        raw = chat_db.get_session_state(session_id)
+        try:
+            session_data = json.loads(raw) if raw else {}
+        except (TypeError, ValueError):
+            session_data = {}
+        if not isinstance(session_data, dict):
+            session_data = {}
+
+        action = args.strip().lower()
+        if action in ("", "status"):
+            mode = "on" if session_data.get("service_tier") == "priority" else "off"
+            return f"Fast mode: {mode}."
+        if action in ("on", "fast"):
+            session_data["service_tier"] = "priority"
+            reply = "Fast mode enabled for this session (higher credit usage)."
+        elif action in ("off", "normal"):
+            session_data.pop("service_tier", None)
+            reply = "Fast mode disabled for this session."
+        else:
+            return "Usage: /fast [on|off|status]"
+
+        chat_db.upsert_session_state(session_id, json.dumps(session_data))
+        return reply
+
+    command_registry.register(
+        "fast",
+        fast_handler,
+        "Show or set Codex Fast mode for this session — /fast [on|off|status]",
+        parameters=[{"name": "mode", "options": ["on", "off", "status", "fast", "normal"]}],
     )
 
 

--- a/models/mixins/providers.py
+++ b/models/mixins/providers.py
@@ -14,7 +14,7 @@ class ProvidersMixin:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT id, name, type, base_url, api_key, api_format, enabled, "
-                "auth_type, refresh_token, token_expires_at, "
+                "auth_type, refresh_token, token_expires_at, credential_source, "
                 "created_at, updated_at FROM providers ORDER BY name"
             )
             return [dict(row) for row in cursor.fetchall()]
@@ -25,7 +25,7 @@ class ProvidersMixin:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT id, name, type, base_url, api_key, api_format, enabled, "
-                "auth_type, refresh_token, token_expires_at, "
+                "auth_type, refresh_token, token_expires_at, credential_source, "
                 "created_at, updated_at FROM providers WHERE id = ?",
                 (provider_id,),
             )
@@ -37,8 +37,8 @@ class ProvidersMixin:
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "INSERT INTO providers (id, name, type, base_url, api_key, api_format, enabled) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO providers (id, name, type, base_url, api_key, api_format, enabled, auth_type, credential_source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     pid,
                     data.get("name", pid),
@@ -47,6 +47,8 @@ class ProvidersMixin:
                     data.get("api_key", ""),
                     data.get("api_format", "openai"),
                     data.get("enabled", 1),
+                    data.get("auth_type", "api_key"),
+                    data.get("credential_source", "api_key"),
                 ),
             )
             conn.commit()
@@ -54,7 +56,7 @@ class ProvidersMixin:
 
     def update_provider(self, provider_id: str, data: Dict[str, Any]) -> bool:
         allowed = {"name", "type", "base_url", "api_key", "api_format", "enabled",
-                   "auth_type", "refresh_token", "token_expires_at"}
+                   "auth_type", "refresh_token", "token_expires_at", "credential_source"}
         updates = {k: v for k, v in data.items() if k in allowed}
         if not updates:
             return False

--- a/models/schema.py
+++ b/models/schema.py
@@ -783,11 +783,43 @@ class SchemaMixin:
                 "auth_type TEXT DEFAULT 'api_key'",
                 "refresh_token TEXT",
                 "token_expires_at INTEGER",
+                "credential_source TEXT DEFAULT 'api_key'",
             ]:
                 try:
                     cursor.execute(f"ALTER TABLE providers ADD COLUMN {col}")
                 except sqlite3.OperationalError:
                     pass
+
+            # Built-in subscription providers. Kept outside the one-shot seed
+            # migration so existing installations receive them too.
+            cursor.executemany(
+                "INSERT OR IGNORE INTO providers "
+                "(id, name, type, base_url, api_format, auth_type, credential_source) "
+                "VALUES (?, ?, 'remote', ?, ?, ?, ?)",
+                [
+                    (
+                        "openai-codex",
+                        "OpenAI Codex",
+                        "https://chatgpt.com/backend-api/codex",
+                        "codex",
+                        "",
+                        "",
+                    ),
+                    (
+                        "anthropic",
+                        "Anthropic / Claude Code",
+                        "https://api.anthropic.com/v1",
+                        "anthropic",
+                        "api_key",
+                        "api_key",
+                    ),
+                ],
+            )
+            cursor.execute(
+                "UPDATE providers SET credential_source = "
+                "CASE WHEN COALESCE(api_key, '') <> '' THEN 'evonic_oauth' ELSE '' END "
+                "WHERE api_format = 'codex' AND credential_source = 'api_key'"
+            )
 
             # ==================== LLM Models Table ====================
 

--- a/routes/claude.py
+++ b/routes/claude.py
@@ -1,0 +1,80 @@
+"""Anthropic API key and Claude Code subscription setup routes."""
+
+from flask import Blueprint, jsonify, request
+
+from backend.provider.claude_code import (
+    clear_credentials,
+    complete_oauth_flow,
+    read_claude_code_credentials,
+    resolve_credential,
+    save_secret,
+    start_oauth_flow,
+    use_claude_code_credentials,
+)
+from models.db import db
+
+
+claude_bp = Blueprint("claude", __name__)
+
+
+def _provider(provider_id):
+    provider = db.get_provider(provider_id)
+    return provider if provider and provider.get("api_format") == "anthropic" else None
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/status", methods=["GET"])
+def claude_status(provider_id):
+    provider = _provider(provider_id)
+    if not provider:
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    token, _ = resolve_credential(db, provider_id)
+    existing = read_claude_code_credentials()
+    return jsonify({
+        "connected": bool(token),
+        "provider_id": provider_id,
+        "provider_kind": "claude",
+        "credential_source": provider.get("credential_source") or "api_key",
+        "existing_available": bool(existing and (existing.get("access_token") or existing.get("refresh_token"))),
+        "existing_source": existing.get("source") if existing else None,
+    })
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/use-existing", methods=["POST"])
+def claude_use_existing(provider_id):
+    if not _provider(provider_id):
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    result = use_claude_code_credentials(db, provider_id)
+    return jsonify(result), (400 if result.get("error") else 200)
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/oauth", methods=["POST"])
+def claude_oauth_start(provider_id):
+    if not _provider(provider_id):
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    return jsonify(start_oauth_flow(provider_id))
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/oauth/complete", methods=["POST"])
+def claude_oauth_complete(provider_id):
+    if not _provider(provider_id):
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    data = request.get_json(silent=True) or {}
+    result = complete_oauth_flow(db, provider_id, data.get("code", ""))
+    return jsonify(result), (400 if result.get("error") else 200)
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/secret", methods=["POST"])
+def claude_secret(provider_id):
+    if not _provider(provider_id):
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    data = request.get_json(silent=True) or {}
+    result = save_secret(db, provider_id, data.get("secret", ""))
+    return jsonify(result), (400 if result.get("error") else 200)
+
+
+@claude_bp.route("/api/providers/<provider_id>/auth/claude/disconnect", methods=["POST"])
+def claude_disconnect(provider_id):
+    if not _provider(provider_id):
+        return jsonify({"error": "Anthropic provider not found."}), 404
+    clear_credentials(db, provider_id)
+    return jsonify({"success": True})

--- a/routes/codex.py
+++ b/routes/codex.py
@@ -13,15 +13,22 @@ from backend.provider.oauth_codex import (
     clear_tokens,
     receive_callback,
     process_callback_url,
+    poll_device_auth_flow,
+    read_codex_cli_credentials,
+    start_device_auth_flow,
+    use_codex_cli_credentials,
 )
 
 codex_bp = Blueprint("codex", __name__)
 
 
-def _find_codex_provider():
-    """Find the first provider with auth_type='oauth' or api_format='codex'."""
+def _find_codex_provider(provider_id=None):
+    """Resolve only Codex-format providers; OAuth alone is not provider identity."""
+    if provider_id:
+        provider = db.get_provider(provider_id)
+        return provider if provider and provider.get("api_format") == "codex" else None
     for p in db.get_providers():
-        if p.get("auth_type") == "oauth" or p.get("api_format") == "codex":
+        if p.get("api_format") == "codex":
             return p
     return None
 
@@ -60,9 +67,10 @@ def codex_auth_callback():
     return render_template_string(_CALLBACK_HTML, message="Authentication successful! You can close this tab.")
 
 
-@codex_bp.route("/api/provider/codex/status", methods=["GET"])
-def codex_status():
-    provider = _find_codex_provider()
+@codex_bp.route("/api/provider/codex/status", methods=["GET"], defaults={"provider_id": None})
+@codex_bp.route("/api/providers/<provider_id>/auth/codex/status", methods=["GET"])
+def codex_status(provider_id):
+    provider = _find_codex_provider(provider_id)
     if not provider:
         return jsonify({"connected": False, "provider_id": None})
 
@@ -70,11 +78,43 @@ def codex_status():
     connected = token is not None
     expires_at = provider.get("token_expires_at", 0) or 0
 
+    cli_creds = read_codex_cli_credentials()
     return jsonify({
         "connected": connected,
         "provider_id": provider["id"],
         "expires_at": expires_at,
+        "credential_source": provider.get("credential_source") or "",
+        "existing_available": cli_creds is not None,
+        "existing_source": cli_creds.get("source") if cli_creds else None,
+        "provider_kind": "codex",
     })
+
+
+@codex_bp.route("/api/providers/<provider_id>/auth/codex/use-existing", methods=["POST"])
+def codex_use_existing(provider_id):
+    provider = _find_codex_provider(provider_id)
+    if not provider:
+        return jsonify({"success": False, "error": "Codex provider not found."}), 404
+    result = use_codex_cli_credentials(db, provider_id)
+    return jsonify(result), (400 if result.get("error") else 200)
+
+
+@codex_bp.route("/api/providers/<provider_id>/auth/codex/device", methods=["POST"])
+def codex_device_start(provider_id):
+    if not _find_codex_provider(provider_id):
+        return jsonify({"success": False, "error": "Codex provider not found."}), 404
+    result = start_device_auth_flow(provider_id)
+    return jsonify(result), (502 if result.get("error") else 200)
+
+
+@codex_bp.route("/api/providers/<provider_id>/auth/codex/device/poll", methods=["POST"])
+def codex_device_poll(provider_id):
+    if not _find_codex_provider(provider_id):
+        return jsonify({"status": "error", "error": "Codex provider not found."}), 404
+    result = poll_device_auth_flow(provider_id)
+    if result.get("status") == "complete":
+        store_tokens(db, provider_id, result.pop("tokens"), credential_source="evonic_oauth")
+    return jsonify(result)
 
 
 @codex_bp.route("/api/provider/codex/connect", methods=["POST"])
@@ -147,9 +187,10 @@ def codex_paste_callback():
     return jsonify({"success": True, "status": "complete"})
 
 
-@codex_bp.route("/api/provider/codex/disconnect", methods=["POST"])
-def codex_disconnect():
-    provider = _find_codex_provider()
+@codex_bp.route("/api/provider/codex/disconnect", methods=["POST"], defaults={"provider_id": None})
+@codex_bp.route("/api/providers/<provider_id>/auth/codex/disconnect", methods=["POST"])
+def codex_disconnect(provider_id):
+    provider = _find_codex_provider(provider_id)
     if not provider:
         return jsonify({"success": False, "error": "No Codex provider found"}), 404
 

--- a/routes/providers.py
+++ b/routes/providers.py
@@ -11,6 +11,9 @@ _SENSITIVE_KEYS = frozenset({"api_key", "refresh_token"})
 
 
 def _sanitize(provider: Dict[str, Any]) -> Dict[str, Any]:
+    provider["credential_configured"] = bool(provider.get("api_key")) or (
+        provider.get("credential_source") == "claude_code"
+    )
     for key in _SENSITIVE_KEYS:
         provider.pop(key, None)
     return provider
@@ -113,6 +116,12 @@ def api_fetch_provider_models(provider_id):
         if not token:
             return jsonify({"success": False, "error": "Not connected. Click Connect first."}), 401
         headers["Authorization"] = f"Bearer {token}"
+    elif api_format == "anthropic":
+        from backend.provider.claude_code import auth_headers, resolve_credential
+        token, oauth = resolve_credential(db, provider_id)
+        if not token:
+            return jsonify({"success": False, "error": "Not connected. Set up credentials first."}), 401
+        headers = auth_headers(token, oauth)
     else:
         api_key = provider.get("api_key")
         if api_key:
@@ -209,6 +218,12 @@ def api_test_provider(provider_id):
         if not token:
             return jsonify({"success": False, "error": "Not connected. Click Connect first."}), 401
         headers["Authorization"] = f"Bearer {token}"
+    elif api_format == "anthropic":
+        from backend.provider.claude_code import auth_headers, resolve_credential
+        token, oauth = resolve_credential(db, provider_id)
+        if not token:
+            return jsonify({"success": False, "error": "Not connected. Set up credentials first."}), 401
+        headers = auth_headers(token, oauth)
     else:
         api_key = provider.get("api_key")
         if api_key:

--- a/static/js/settings-models.js
+++ b/static/js/settings-models.js
@@ -8,11 +8,12 @@ window.settingsModels = {
     searchQuery: "",
     _currentTestModelId: null,
     _fetchProviderId: null,
-    _codexStatus: null,
+    _authProviderId: null,
+    _authKind: null,
+    _authPollTimer: null,
 
     async init() {
         await this.load();
-        this._checkCodexStatus();
     },
 
     async load() {
@@ -95,20 +96,18 @@ window.settingsModels = {
                     ? models.map((model) => this._renderModelCard(model)).join("")
                     : `<div class="col-span-full text-center py-4 text-sm text-gray-400 dark:text-gray-500">No models yet — click <strong>Fetch Models</strong> to discover available models from this provider.</div>`;
 
-                const isCodex = prov.api_format === "codex" || prov.auth_type === "oauth";
-                const codexConnected = this._codexStatus && this._codexStatus.connected && this._codexStatus.provider_id === pid;
+                const hasCredentialSetup = ["codex", "anthropic"].includes(prov.api_format);
+                const connected = Boolean(prov.credential_configured);
 
                 let actionButtons;
                 const addModelBtn = `<button class="px-2 py-1 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/50 rounded hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors" onclick="settingsModels.addModelForProvider('${pid}')" title="Add a custom model">+ Model</button>`;
-                if (isCodex) {
-                    const statusDot = codexConnected
-                        ? '<span class="inline-block w-2 h-2 rounded-full bg-green-500 mr-1" title="Connected"></span>'
-                        : '<span class="inline-block w-2 h-2 rounded-full bg-gray-400 mr-1" title="Not connected"></span>';
-                    const connectBtn = codexConnected
-                        ? `<button class="px-2 py-1 text-xs font-medium text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/50 rounded hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors" onclick="settingsModels.codexDisconnect()" title="Disconnect OAuth">Disconnect</button>`
-                        : `<button class="px-2 py-1 text-xs font-medium text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/50 rounded hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors" onclick="settingsModels.codexConnect('${pid}')" title="Connect via OAuth">Connect</button>`;
-                    actionButtons = `${statusDot}${connectBtn}` +
-                        (codexConnected ? `<button class="px-2 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/50 rounded hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors" onclick="settingsModels.fetchModels('${pid}')" title="Discover models">Fetch Models</button>` : "") +
+                if (hasCredentialSetup) {
+                    const status = connected
+                        ? '<span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300"><span class="w-2 h-2 rounded-full bg-emerald-500"></span>Ready</span>'
+                        : '<span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300"><span class="w-2 h-2 rounded-full bg-amber-500"></span>Setup needed</span>';
+                    actionButtons = `${status}` +
+                        `<button class="px-2 py-1 text-xs font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/50 rounded hover:bg-indigo-100 dark:hover:bg-indigo-900/50 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition-colors" onclick="settingsModels.openCredentialSetup('${pid}')">${connected ? "Manage login" : "Set up"}</button>` +
+                        (connected ? `<button class="px-2 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/50 rounded hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors" onclick="settingsModels.fetchModels('${pid}')" title="Discover models">Fetch Models</button>` : "") +
                         addModelBtn +
                         `<button class="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 rounded hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors" onclick="settingsModels.editProvider('${pid}')" title="Edit provider settings">Edit</button>` +
                         `<button class="px-2 py-1 text-xs font-medium text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/50 rounded hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors" onclick="settingsModels.deleteProvider('${pid}')" title="Delete provider">Del</button>`;
@@ -123,13 +122,13 @@ window.settingsModels = {
 
                 return `
                     <div class="provider-group">
-                        <div class="flex items-center justify-between mb-2 px-1">
+                        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2 px-1">
                             <div class="flex items-center gap-2">
                                 <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">${this._escapeHtml(prov.name)}</h3>
                                 ${typeBadge}
                                 <span class="text-xs text-gray-400">${models.length} model${models.length !== 1 ? "s" : ""}</span>
                             </div>
-                            <div class="flex items-center gap-1.5">
+                            <div class="flex flex-wrap items-center gap-1.5">
                                 ${actionButtons}
                             </div>
                         </div>
@@ -710,150 +709,198 @@ window.settingsModels = {
         return div.innerHTML;
     },
 
-    /* ---- Codex OAuth (PKCE flow) ---- */
+    /* ---- Provider credential setup ---- */
 
-    async _checkCodexStatus() {
+    _authBase() {
+        return `/api/providers/${encodeURIComponent(this._authProviderId)}/auth/${this._authKind}`;
+    },
+
+    _credentialSourceLabel(source) {
+        return ({
+            api_key: "Anthropic API key",
+            setup_token: "Claude setup-token",
+            claude_code: "Claude Code credential store",
+            codex_cli_import: "Imported Codex CLI login",
+            evonic_oauth: "Evonic-managed OAuth",
+        })[source] || "Not configured";
+    },
+
+    async openCredentialSetup(providerId) {
+        const provider = this.providers.find((item) => item.id === providerId);
+        if (!provider) return;
+        this.closeCredentialSetup();
+        this._authProviderId = providerId;
+        this._authKind = provider.api_format === "codex" ? "codex" : "claude";
+        document.getElementById("provider-auth-title").textContent = `Set up ${provider.name}`;
+        document.getElementById("provider-auth-content").innerHTML =
+            '<div class="text-center py-10"><div class="spinner mx-auto" style="width:28px;height:28px;border-width:2px;"></div><p class="mt-3 text-sm text-gray-600 dark:text-gray-300">Checking available credentials…</p></div>';
+        openModal("provider-auth-modal");
         try {
-            this._codexStatus = await apiGet("/api/provider/codex/status");
-            this.render();
-        } catch (e) {
-            this._codexStatus = null;
+            const status = await apiGet(this._authBase() + "/status");
+            this._renderCredentialChoices(status);
+        } catch (error) {
+            this._showAuthError(error.message || "Could not check credentials.");
         }
     },
 
-    async codexConnect(providerId) {
+    _renderCredentialChoices(status) {
+        const isCodex = this._authKind === "codex";
+        const source = this._credentialSourceLabel(status.credential_source);
+        const existingLabel = isCodex ? "Import Codex CLI login" : "Use Claude Code login";
+        const existingHelp = isCodex
+            ? "Imports the current CLI credential snapshot. A separate login is safer if Codex CLI is used often."
+            : "Links the freshest credential from macOS Keychain or ~/.claude/.credentials.json.";
+        document.getElementById("provider-auth-content").innerHTML = `
+            <div class="flex items-start justify-between gap-4 pb-5 border-b border-gray-200 dark:border-gray-700">
+                <div>
+                    <p class="font-semibold text-gray-900 dark:text-gray-100">${status.connected ? "Connected" : "Choose how to connect"}</p>
+                    <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">${status.connected ? this._escapeHtml(source) : "Evonic uses only the credential source you choose."}</p>
+                </div>
+                <span class="inline-flex items-center gap-2 text-sm font-medium ${status.connected ? "text-emerald-700 dark:text-emerald-300" : "text-amber-700 dark:text-amber-300"}">
+                    <span class="w-2 h-2 rounded-full ${status.connected ? "bg-emerald-500" : "bg-amber-500"}"></span>${status.connected ? "Ready" : "Setup needed"}
+                </span>
+            </div>
+            <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                <div class="py-5 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                    <div class="max-w-md"><p class="font-medium text-gray-900 dark:text-gray-100">${existingLabel}</p><p class="mt-1 text-sm text-gray-600 dark:text-gray-300">${existingHelp}</p></div>
+                    <button type="button" onclick="settingsModels.authUseExisting()" ${status.existing_available ? "" : "disabled"} class="px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed">${status.existing_available ? "Use existing" : "Not detected"}</button>
+                </div>
+                <div class="py-5 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                    <div class="max-w-md"><p class="font-medium text-gray-900 dark:text-gray-100">Sign in with another account</p><p class="mt-1 text-sm text-gray-600 dark:text-gray-300">${isCodex ? "Use OpenAI's device-code flow without changing your Codex CLI login." : "Authorize a Claude Pro or Max account and paste the returned code."}</p></div>
+                    <button type="button" onclick="settingsModels.authStartNew()" class="px-3 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2">Start sign-in</button>
+                </div>
+                ${isCodex ? "" : `<div class="py-5"><label for="provider-auth-secret" class="font-medium text-gray-900 dark:text-gray-100">API key or setup-token</label><p class="mt-1 mb-3 text-sm text-gray-600 dark:text-gray-300">Use a pay-per-token API key, or paste a token created by <code>claude setup-token</code>.</p><div class="flex flex-col sm:flex-row gap-2"><input id="provider-auth-secret" type="password" autocomplete="new-password" data-1p-ignore="true" data-lpignore="true" placeholder="sk-ant-…" class="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"><button type="button" onclick="settingsModels.authSaveSecret()" class="px-3 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400">Save credential</button></div></div>`}
+            </div>
+            ${status.connected ? '<div class="pt-5 border-t border-gray-200 dark:border-gray-700"><button type="button" onclick="settingsModels.authDisconnect()" class="text-sm font-medium text-red-600 dark:text-red-400 hover:underline focus:outline-none focus:ring-2 focus:ring-red-400 rounded">Disconnect this provider</button></div>' : ""}`;
+    },
+
+    async authUseExisting() {
         try {
-            const result = await apiPost("/api/provider/codex/connect", {});
-            if (result.error) {
-                if (window.toast) toast.error(result.error, 5000);
-                return;
-            }
-            window.open(result.auth_url, "_blank");
-            this._showAuthWaitingModal();
-        } catch (e) {
-            if (window.toast) toast.error("Failed: " + e.message, 5000);
+            const result = await apiPost(this._authBase() + "/use-existing", {});
+            if (result.error) return this._showAuthError(result.error);
+            await this._finishAuth("Existing credentials connected.");
+        } catch (error) {
+            this._showAuthError(error.message || "Could not use existing credentials.");
         }
     },
 
-    _showAuthWaitingModal() {
-        const testStatus = document.getElementById("connection-test-status");
-        const footer = document.getElementById("connection-test-footer");
-        const title = document.getElementById("connection-test-title");
-        const header = document.getElementById("connection-test-header");
-
-        if (header) header.className = "flex justify-between items-center p-5 border-b border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20";
-        title.textContent = "Connect to OpenAI Codex";
-        title.className = "m-0 text-indigo-700 dark:text-indigo-400";
-        testStatus.innerHTML =
-            '<div class="text-center py-4">' +
-            '<p class="text-sm text-gray-600 dark:text-gray-400 mb-4">Complete the login in the OpenAI page that just opened.</p>' +
-            '<p class="text-xs text-gray-400 mb-3">Waiting for authorization…</p>' +
-            '<div class="spinner mx-auto" style="width:24px;height:24px;border-width:2px;"></div>' +
-            '<p id="codex-poll-status" class="text-xs text-gray-400 mt-3"></p>' +
-            '<hr class="my-4 border-gray-200 dark:border-gray-700">' +
-            '<p class="text-xs text-gray-500 dark:text-gray-400 mb-2">Trouble auto-redirecting?</p>' +
-            '<p class="text-xs text-gray-400 mb-2">Paste the full callback URL from your browser address bar below:</p>' +
-            '<textarea id="codex-callback-url" rows="2" class="w-full text-xs p-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200" placeholder="http://localhost:1455/auth/callback?code=...&state=..."></textarea>' +
-            '<button onclick="settingsModels.pasteCallback()" class="mt-2 px-3 py-1 text-xs font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded transition-colors">Submit</button>' +
-            '</div>';
-        footer.classList.add("hidden");
-        openModal("connection-test-modal");
-
-        this._pollAuthCallback();
+    async authStartNew() {
+        const providerId = this._authProviderId;
+        try {
+            if (this._authKind === "codex") {
+                const result = await apiPost(this._authBase() + "/device", {});
+                if (result.error) return this._showAuthError(result.error);
+                document.getElementById("provider-auth-content").innerHTML = `
+                    <div class="py-3 text-center">
+                        <p class="text-sm text-gray-600 dark:text-gray-300">Open the OpenAI sign-in page and enter this one-time code.</p>
+                        <div class="my-6"><code class="text-3xl font-semibold tracking-wider text-gray-900 dark:text-white select-all">${this._escapeHtml(result.user_code)}</code></div>
+                        <a href="${result.verification_url}" target="_blank" rel="noopener" class="inline-flex px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400">Open OpenAI sign-in</a>
+                        <div class="mt-6 flex items-center justify-center gap-3 text-sm text-gray-600 dark:text-gray-300"><div class="spinner" style="width:20px;height:20px;border-width:2px;"></div><span id="provider-auth-progress">Waiting for approval…</span></div>
+                    </div>`;
+                window.open(result.verification_url, "_blank", "noopener");
+                this._pollCodexDevice(providerId, Math.max(3, result.interval || 5));
+            } else {
+                const result = await apiPost(this._authBase() + "/oauth", {});
+                if (result.error) return this._showAuthError(result.error);
+                document.getElementById("provider-auth-content").innerHTML = `
+                    <div class="py-2">
+                        <p class="text-sm text-gray-600 dark:text-gray-300">Authorize Evonic in the Claude page. Copy the full code shown after approval, including the part after <code>#</code>.</p>
+                        <a href="${result.auth_url}" target="_blank" rel="noopener" class="inline-flex mt-4 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400">Open Claude authorization</a>
+                        <label for="provider-auth-code" class="block mt-6 mb-2 text-sm font-medium text-gray-900 dark:text-gray-100">Authorization code</label>
+                        <textarea id="provider-auth-code" rows="3" placeholder="code#state" class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"></textarea>
+                        <button type="button" onclick="settingsModels.authCompleteClaude()" class="mt-3 px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400">Complete sign-in</button>
+                    </div>`;
+                window.open(result.auth_url, "_blank", "noopener");
+            }
+        } catch (error) {
+            this._showAuthError(error.message || "Could not start sign-in.");
+        }
     },
 
-    _pollAuthCallback() {
-        const deadline = Date.now() + 300_000;
-
-        const poll = setInterval(async () => {
-            if (Date.now() > deadline) {
-                clearInterval(poll);
-                const el = document.getElementById("codex-poll-status");
-                if (el) el.textContent = "Timed out. Close and try again.";
-                return;
-            }
+    _pollCodexDevice(providerId, interval) {
+        clearTimeout(this._authPollTimer);
+        this._authPollTimer = setTimeout(async () => {
+            if (this._authProviderId !== providerId) return;
             try {
-                const result = await apiPost("/api/provider/codex/poll", {});
-                if (result.status === "complete") {
-                    clearInterval(poll);
-                    closeModal("connection-test-modal");
-                    await this._checkCodexStatus();
-                    await this.reload();
-                    if (window.toast) toast.success("Connected to Codex!", 3000);
-                } else if (result.status === "error" || result.status === "expired") {
-                    clearInterval(poll);
-                    const el = document.getElementById("codex-poll-status");
-                    if (el) el.textContent = result.error || "Authorization failed.";
-                }
-            } catch (e) { /* ignore, retry next tick */ }
-        }, 3000);
-
-        this._codexPollTimer = poll;
+                const result = await apiPost(this._authBase() + "/device/poll", {});
+                if (result.status === "complete") return this._finishAuth("OpenAI Codex connected.");
+                if (["error", "expired"].includes(result.status)) return this._showAuthError(result.error || "Sign-in failed.");
+            } catch (error) {
+                const progress = document.getElementById("provider-auth-progress");
+                if (progress) progress.textContent = "Connection interrupted; retrying…";
+            }
+            this._pollCodexDevice(providerId, interval);
+        }, interval * 1000);
     },
 
-    async codexDisconnect() {
+    async authCompleteClaude() {
+        const code = document.getElementById("provider-auth-code")?.value.trim();
+        if (!code) return this._showAuthError("Paste the authorization code first.");
+        try {
+            const result = await apiPost(this._authBase() + "/oauth/complete", { code });
+            if (result.error) return this._showAuthError(result.error);
+            await this._finishAuth("Claude connected.");
+        } catch (error) {
+            this._showAuthError(error.message || "Could not complete sign-in.");
+        }
+    },
+
+    async authSaveSecret() {
+        const secret = document.getElementById("provider-auth-secret")?.value.trim();
+        if (!secret) return this._showAuthError("Enter an API key or setup-token first.");
+        try {
+            const result = await apiPost(this._authBase() + "/secret", { secret });
+            if (result.error) return this._showAuthError(result.error);
+            await this._finishAuth("Anthropic credential saved.");
+        } catch (error) {
+            this._showAuthError(error.message || "Could not save the credential.");
+        }
+    },
+
+    async authDisconnect() {
+        const provider = this.providers.find((item) => item.id === this._authProviderId);
         if (!(await showConfirm({
-            title: "Disconnect Codex",
-            message: "This will remove the stored OAuth tokens. You’ll need to reconnect to use Codex models.",
+            title: "Disconnect provider",
+            message: `Remove Evonic's active credential for ${provider?.name || "this provider"}? External CLI credentials are not deleted.`,
             confirmText: "Disconnect",
         }))) return;
-
         try {
-            const result = await apiPost("/api/provider/codex/disconnect", {});
-            if (result.success) {
-                this._codexStatus = null;
-                await this._checkCodexStatus();
-                this.render();
-                if (window.toast) toast.show("Codex disconnected", "success");
-            } else {
-                if (window.toast) toast.error(result.error || "Failed", 5000);
-            }
-        } catch (e) {
-            if (window.toast) toast.error("Failed: " + e.message, 5000);
+            const result = await apiPost(this._authBase() + "/disconnect", {});
+            if (result.error) return this._showAuthError(result.error);
+            await this._finishAuth("Provider disconnected.");
+        } catch (error) {
+            this._showAuthError(error.message || "Could not disconnect the provider.");
         }
     },
 
-    async pasteCallback() {
-        const textarea = document.getElementById("codex-callback-url");
-        const statusEl = document.getElementById("codex-poll-status");
-        const url = textarea ? textarea.value.trim() : "";
-
-        if (!url) {
-            if (window.toast) toast.error("Please paste the callback URL first.", 3000);
-            return;
+    _showAuthError(message) {
+        let error = document.getElementById("provider-auth-error");
+        if (!error) {
+            error = document.createElement("div");
+            error.id = "provider-auth-error";
+            error.setAttribute("role", "alert");
+            error.className = "mb-4 p-3 rounded-lg bg-red-50 dark:bg-red-950/40 text-sm text-red-800 dark:text-red-200";
+            document.getElementById("provider-auth-content")?.prepend(error);
         }
+        error.textContent = message;
+    },
 
-        if (!url.includes("code=") || !url.includes("state=")) {
-            if (window.toast) toast.error("URL must contain 'code' and 'state' parameters. Paste the full URL.", 5000);
-            return;
-        }
+    async _finishAuth(message) {
+        this.closeCredentialSetup();
+        await this.reload();
+        if (window.toast) toast.success(message, 3000);
+    },
 
-        if (statusEl) statusEl.textContent = "Processing callback URL…";
-
-        try {
-            const result = await apiPost("/api/provider/codex/callback", { url });
-            if (result.success) {
-                if (statusEl) statusEl.textContent = "Connected!";
-                closeModal("connection-test-modal");
-                await this._checkCodexStatus();
-                await this.reload();
-                if (window.toast) toast.success("Connected to Codex!", 3000);
-            } else {
-                if (statusEl) statusEl.textContent = result.error || "Failed to process callback.";
-                if (window.toast) toast.error(result.error || "Failed", 5000);
-            }
-        } catch (e) {
-            if (statusEl) statusEl.textContent = "Error: " + e.message;
-            if (window.toast) toast.error("Failed: " + e.message, 5000);
-        }
+    closeCredentialSetup() {
+        clearTimeout(this._authPollTimer);
+        this._authPollTimer = null;
+        closeModal("provider-auth-modal");
+        this._authProviderId = null;
+        this._authKind = null;
     },
 
     closeTestModal() {
         closeModal("connection-test-modal");
-        if (this._codexPollTimer) {
-            clearInterval(this._codexPollTimer);
-            this._codexPollTimer = null;
-        }
         if (this._currentTestModelId) {
             const testBtn = document.querySelector(
                 `button[onclick*="testConnection('${this._currentTestModelId}')"]`,

--- a/templates/partials/settings/models.html
+++ b/templates/partials/settings/models.html
@@ -184,6 +184,46 @@
     </div>
 </div>
 
+<!-- Provider Credential Setup Modal -->
+<div id="provider-auth-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="provider-auth-title">
+    <div
+        class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl mx-4 flex flex-col max-h-[90vh]"
+    >
+        <div
+            class="flex items-center justify-between gap-4 px-6 pt-5 pb-4 border-b border-gray-200 dark:border-gray-700 flex-shrink-0"
+        >
+            <div>
+                <h3 id="provider-auth-title" class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Set up provider
+                </h3>
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    Select an existing login or connect a different credential.
+                </p>
+            </div>
+            <button
+                type="button"
+                onclick="settingsModels.closeCredentialSetup()"
+                aria-label="Close credential setup"
+                class="text-gray-500 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white text-2xl leading-none rounded focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            >
+                &times;
+            </button>
+        </div>
+        <div id="provider-auth-content" aria-live="polite" class="overflow-y-auto p-6 flex-1">
+            <!-- Dynamically populated -->
+        </div>
+        <div class="flex justify-end px-6 pb-5 pt-4 border-t border-gray-200 dark:border-gray-700 flex-shrink-0">
+            <button
+                type="button"
+                onclick="settingsModels.closeCredentialSetup()"
+                class="px-4 py-2 text-sm font-medium text-gray-800 dark:text-gray-100 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+            >
+                Close
+            </button>
+        </div>
+    </div>
+</div>
+
 <!-- Model Modal -->
 <div id="model-modal" class="modal">
     <div

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -47,5 +47,5 @@
 <script src="{{ url_for('static', filename='js/settings-core.js') }}?v=2"></script>
 <script src="{{ url_for('static', filename='js/settings-general.js') }}?v=2"></script>
 <script src="{{ url_for('static', filename='js/settings-tools.js') }}?v=1"></script>
-<script src="{{ url_for('static', filename='js/settings-models.js') }}?v=2"></script>
+<script src="{{ url_for('static', filename='js/settings-models.js') }}?v=3"></script>
 {% endblock %}

--- a/unit_tests/test_codex_fast_mode.py
+++ b/unit_tests/test_codex_fast_mode.py
@@ -1,0 +1,146 @@
+"""Session-scoped Fast mode for the Codex Responses API."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from backend.provider.codex_client import CodexClient, model_supports_fast_mode
+from backend.slash_commands import execute_command
+
+
+class _ChatDB:
+    def __init__(self):
+        self.states = {}
+
+    def get_session_state(self, session_id):
+        return self.states.get(session_id)
+
+    def upsert_session_state(self, session_id, content):
+        self.states[session_id] = content
+
+    def get_agent_state(self):
+        return None
+
+
+def _codex_model(model_name="gpt-5.6-luna"):
+    return {
+        "id": f"openai/{model_name}",
+        "name": model_name,
+        "provider": "openai",
+        "model_name": model_name,
+        "api_format": "codex",
+    }
+
+
+def _completed_response(model):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "id": "resp_fast",
+        "model": model,
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }],
+        "usage": {},
+    }
+    return response
+
+
+def test_fast_model_gate_matches_codex_catalog_families():
+    assert model_supports_fast_mode("gpt-5.4")
+    assert model_supports_fast_mode("openai/gpt-5.5")
+    assert model_supports_fast_mode("gpt-5.6-luna:high")
+    assert not model_supports_fast_mode("gpt-5.4-mini")
+    assert not model_supports_fast_mode("gpt-5.3-codex-spark")
+    assert not model_supports_fast_mode("claude-opus-4-6")
+
+
+def test_codex_fast_request_adds_priority_payload_and_routing_header():
+    client = CodexClient("token", "https://chatgpt.com/backend-api/codex")
+    model = "gpt-5.6-luna"
+    with patch("backend.provider.codex_client.httpx.post",
+               return_value=_completed_response(model)) as post:
+        result = client.send_request(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            service_tier="priority",
+        )
+
+    assert result["success"]
+    assert post.call_args.kwargs["json"]["service_tier"] == "priority"
+    assert post.call_args.kwargs["headers"]["x-codex-routing-hint"] == (
+        "model=gpt-5.6-luna;tier=priority"
+    )
+
+
+def test_codex_fast_request_is_omitted_for_unsupported_model():
+    client = CodexClient("token", "https://chatgpt.com/backend-api/codex")
+    model = "gpt-5.4-mini"
+    with patch("backend.provider.codex_client.httpx.post",
+               return_value=_completed_response(model)) as post:
+        client.send_request(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            service_tier="priority",
+        )
+
+    assert "service_tier" not in post.call_args.kwargs["json"]
+    assert "x-codex-routing-hint" not in post.call_args.kwargs["headers"]
+
+
+def test_fast_command_is_session_scoped_and_preserves_state(monkeypatch):
+    from models.chat import agent_chat_manager
+    from models.db import db
+
+    chat_db = _ChatDB()
+    chat_db.states["session-a"] = json.dumps({"workspace_marker": "keep"})
+    monkeypatch.setattr(db, "get_agent_model", lambda _agent_id: _codex_model())
+    monkeypatch.setattr(db, "resolve_model_config", lambda model: model)
+    monkeypatch.setattr(agent_chat_manager, "get", lambda _agent_id: chat_db)
+
+    assert "enabled" in execute_command("fast", "fast", "session-a", "agent", "user")
+    assert execute_command("fast", "status", "session-a", "agent", "user") == "Fast mode: on."
+    assert execute_command("fast", "status", "session-b", "agent", "user") == "Fast mode: off."
+    assert json.loads(chat_db.states["session-a"])["workspace_marker"] == "keep"
+
+    assert "disabled" in execute_command("fast", "normal", "session-a", "agent", "user")
+    assert "service_tier" not in json.loads(chat_db.states["session-a"])
+
+
+def test_fast_command_rejects_non_codex_model_without_writing(monkeypatch):
+    from models.chat import agent_chat_manager
+    from models.db import db
+
+    model = {**_codex_model(), "api_format": "openai"}
+    monkeypatch.setattr(db, "get_agent_model", lambda _agent_id: model)
+    monkeypatch.setattr(db, "resolve_model_config", lambda value: value)
+    monkeypatch.setattr(
+        agent_chat_manager,
+        "get",
+        lambda _agent_id: (_ for _ in ()).throw(AssertionError("must not write session state")),
+    )
+
+    assert execute_command("fast", "on", "session", "agent", "user") == (
+        "Fast mode is not supported by the current model."
+    )
+
+
+def test_status_reports_effective_fast_session_setting(monkeypatch):
+    from models.chat import agent_chat_manager
+    from models.db import db
+
+    chat_db = _ChatDB()
+    chat_db.states["session"] = json.dumps({"service_tier": "priority"})
+    monkeypatch.setattr(agent_chat_manager, "get", lambda _agent_id: chat_db)
+    monkeypatch.setattr(db, "get_agent", lambda _agent_id: {"id": "agent", "name": "Agent"})
+    monkeypatch.setattr(db, "get_agent_model", lambda _agent_id: _codex_model())
+    monkeypatch.setattr(db, "resolve_model_config", lambda model: model)
+    monkeypatch.setattr(db, "get_agent_tools", lambda _agent_id: [])
+    monkeypatch.setattr(db, "get_agent_skills", lambda _agent_id: [])
+    monkeypatch.setattr(db, "get_channels", lambda _agent_id: [])
+
+    result = execute_command("status", "", "session", "agent", "user")
+
+    assert "Fast: on" in result

--- a/unit_tests/test_codex_usage.py
+++ b/unit_tests/test_codex_usage.py
@@ -60,6 +60,7 @@ def test_codex_chat_completion_propagates_usage():
     client.max_tokens = 4096
     client.temperature = None
     client.thinking = False
+    client.service_tier = 'priority'
     client.timeout = 120
     client.provider = 'codex'
     client._codex_provider_id = 'codex'
@@ -92,6 +93,7 @@ def test_codex_chat_completion_propagates_usage():
     # traces/archive get a request payload now (was None)
     assert result['request_payload']['model'] == 'gpt-5.6-terra'
     assert result['request_payload']['messages'][0]['content'] == 'halo'
+    assert codex.send_request.call_args.kwargs['service_tier'] == 'priority'
     record_usage.assert_called_once_with(
         model='gpt-5.6-terra',
         provider='codex',

--- a/unit_tests/test_provider_credentials.py
+++ b/unit_tests/test_provider_credentials.py
@@ -1,0 +1,146 @@
+"""Credential-source isolation for Codex and Claude providers."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+
+def _authenticated_client(app):
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["authenticated"] = True
+    return client
+
+
+def test_subscription_providers_are_seeded():
+    from models.db import db
+
+    codex = db.get_provider("openai-codex")
+    claude = db.get_provider("anthropic")
+    assert (codex["api_format"], codex["credential_source"]) == ("codex", "")
+    assert (claude["api_format"], claude["credential_source"]) == ("anthropic", "api_key")
+
+
+def test_legacy_codex_route_never_selects_anthropic_oauth():
+    from app import app
+    from models.db import db
+
+    db.update_provider("anthropic", {"auth_type": "oauth", "credential_source": "claude_code"})
+    with patch("routes.codex.get_valid_token", return_value=None), \
+         patch("routes.codex.read_codex_cli_credentials", return_value=None):
+        response = _authenticated_client(app).get("/api/provider/codex/status")
+
+    assert response.status_code == 200
+    assert response.get_json()["provider_id"] == "openai-codex"
+
+
+def test_codex_existing_login_is_imported_into_its_provider_only():
+    from backend.provider.oauth_codex import use_codex_cli_credentials
+    from models.db import db
+
+    creds = {
+        "source": "codex_auth_file",
+        "access_token": "access",
+        "refresh_token": "refresh",
+        "expires_at": int(time.time()) + 3600,
+    }
+    with patch("backend.provider.oauth_codex.read_codex_cli_credentials", return_value=creds):
+        result = use_codex_cli_credentials(db, "openai-codex")
+
+    codex = db.get_provider("openai-codex")
+    claude = db.get_provider("anthropic")
+    assert result["success"]
+    assert (codex["api_key"], codex["credential_source"]) == ("access", "codex_cli_import")
+    assert not claude["api_key"]
+
+
+def test_codex_device_flow_returns_tokens_after_approval():
+    from backend.provider import oauth_codex
+
+    oauth_codex._pending_device_auth.clear()
+    user_code = MagicMock(status_code=200)
+    user_code.json.return_value = {"user_code": "ABCD-EFGH", "device_auth_id": "device", "interval": 3}
+    approval = MagicMock(status_code=200)
+    approval.json.return_value = {"authorization_code": "code", "code_verifier": "verifier"}
+    exchange = MagicMock(status_code=200)
+    exchange.json.return_value = {"access_token": "access", "refresh_token": "refresh", "expires_in": 3600}
+
+    with patch("backend.provider.oauth_codex.requests.post", side_effect=[user_code, approval, exchange]):
+        started = oauth_codex.start_device_auth_flow("openai-codex")
+        finished = oauth_codex.poll_device_auth_flow("openai-codex")
+
+    assert started["user_code"] == "ABCD-EFGH"
+    assert finished["status"] == "complete"
+    assert finished["tokens"]["access_token"] == "access"
+
+
+def test_codex_device_flow_rejects_invalid_json():
+    from backend.provider import oauth_codex
+
+    response = MagicMock(status_code=200)
+    response.json.side_effect = ValueError
+    with patch("backend.provider.oauth_codex.requests.post", return_value=response):
+        result = oauth_codex.start_device_auth_flow("openai-codex")
+    assert result == {"error": "OpenAI returned an invalid device code response."}
+
+
+def test_claude_chooses_freshest_valid_store():
+    from backend.provider.claude_code import read_claude_code_credentials
+
+    now = int(time.time() * 1000)
+    keychain = {"access_token": "old", "expires_at_ms": now + 120_000, "source": "macos_keychain"}
+    file_creds = {"access_token": "new", "expires_at_ms": now + 240_000, "source": "claude_credentials_file"}
+    with patch("backend.provider.claude_code._read_keychain", return_value=keychain), \
+         patch("backend.provider.claude_code._read_file", return_value=file_creds):
+        assert read_claude_code_credentials()["access_token"] == "new"
+
+
+def test_claude_existing_login_links_without_copying_secret():
+    from backend.provider.claude_code import use_claude_code_credentials
+    from models.db import db
+
+    creds = {
+        "access_token": "secret-not-for-db",
+        "refresh_token": "refresh-not-for-db",
+        "expires_at_ms": int(time.time() * 1000) + 3600_000,
+        "source": "macos_keychain",
+    }
+    with patch("backend.provider.claude_code.read_claude_code_credentials", return_value=creds):
+        result = use_claude_code_credentials(db, "anthropic")
+
+    provider = db.get_provider("anthropic")
+    assert result["success"]
+    assert provider["credential_source"] == "claude_code"
+    assert provider["api_key"] == provider["refresh_token"] == ""
+
+
+def test_claude_oauth_headers_match_claude_code_identity():
+    from backend.provider.claude_code import SYSTEM_PREFIX, auth_headers
+
+    with patch("backend.provider.claude_code.claude_code_version", return_value="9.9.9"):
+        headers = auth_headers("token", oauth=True)
+    assert headers["Authorization"] == "Bearer token"
+    assert headers["anthropic-beta"] == "claude-code-20250219,oauth-2025-04-20"
+    assert headers["user-agent"] == "claude-code/9.9.9 (external, cli)"
+    assert headers["x-app"] == "cli"
+    assert "x-api-key" not in headers
+    assert SYSTEM_PREFIX.startswith("You are Claude Code")
+    assert auth_headers("api-key", oauth=False)["x-api-key"] == "api-key"
+
+
+def test_provider_api_never_returns_tokens():
+    from app import app
+    from models.db import db
+
+    db.update_provider("openai-codex", {
+        "api_key": "access-secret",
+        "refresh_token": "refresh-secret",
+        "auth_type": "oauth",
+        "credential_source": "evonic_oauth",
+    })
+    response = _authenticated_client(app).get("/api/providers")
+    payload = response.get_json()
+    encoded = str(payload)
+    assert "access-secret" not in encoded
+    assert "refresh-secret" not in encoded
+    codex = next(item for item in payload["providers"] if item["id"] == "openai-codex")
+    assert codex["credential_configured"] is True


### PR DESCRIPTION
## Branch hygiene

This replaces #100 with the same provider commit cherry-picked onto a dedicated branch based directly on `anvie/dev`. It prevents unrelated future commits on `binsarjr/dev` from entering the PR.

## Context

Evonic already had a working Codex transport and a basic OAuth callback flow. This PR does not replace that implementation. It fills in the missing credential-management and setup experience around it, then adds the same kind of first-class support for Claude Code / Anthropic.

For Codex, the existing transport and legacy routes are kept intact. The new pieces are:

- detection of an existing Codex CLI login from CODEX_HOME/auth.json or the macOS Keychain
- an explicit option to import that credential snapshot into Evonic
- a separate OpenAI device-code login for users who do not want to reuse their CLI session
- safer provider lookup so another OAuth provider cannot accidentally be treated as Codex
- refresh handling that checks for a newer CLI credential before spending a possibly stale refresh token

## Claude Code / Anthropic support

This adds a native Anthropic provider with three setup choices:

- use the current Claude Code login from the macOS Keychain or ~/.claude/.credentials.json
- sign in with a separate Claude Pro / Max account through PKCE OAuth
- provide an Anthropic API key or a token generated by claude setup-token

When the Claude Code credential store is selected, Evonic reads it directly instead of copying the token into the providers table. OAuth requests use the Claude Code headers and system identity expected by the Anthropic Messages API. Refresh tokens are re-read before refresh and file updates are written atomically with mode 0600.

The credential behavior follows the same approach used by Hermes Agent, while staying within Evonic's existing provider and LLM client structure.

## Settings experience

Codex and Anthropic appear as built-in providers. Provider API responses expose only a configured/not-configured flag; access and refresh tokens are removed before responses reach the browser.

## Compatibility

- existing Codex routes remain available
- existing Codex provider rows are migrated to the new credential-source field
- model-level API key overrides still take precedence
- no new dependency was added

## Verification

- the original focused provider suite reported 15 passing tests
- Python compilation and git diff checks pass after the clean cherry-pick
- the resulting branch contains one feature commit and only the original 13 files