### PR TITLE
fix(models): preserve vision capability on create

### DIFF
--- a/routes/models.py
+++ b/routes/models.py
@@ -90,6 +90,7 @@ def api_create_model():
                 "enabled": data.get("enabled", 1),
                 "is_default": data.get("is_default", 0),
                 "model_max_concurrent": data.get("model_max_concurrent", 3),
+                "vision_supported": data.get("vision_supported", 0),
                 "context_window": data.get("context_window", 0),
             }
         )

--- a/unit_tests/test_models_routes_pathids.py
+++ b/unit_tests/test_models_routes_pathids.py
@@ -37,6 +37,10 @@ class TestSlashedIdRoutes:
         model_id = _create(client)
         assert model_id == "openrouter/anthropic/claude-3.5-sonnet"
 
+    def test_create_preserves_vision_capability(self, client):
+        model_id = _create(client, model_name="vision-model", vision_supported=1)
+        assert db.get_model_by_id(model_id)["vision_supported"] == 1
+
     def test_get_with_multi_segment_id(self, client):
         model_id = _create(client)
         resp = client.get(f"/api/models/{model_id}")


### PR DESCRIPTION
## What changed

Creating a model through `POST /api/models` now forwards `vision_supported` to the database. The settings UI already sends this value, but the create route previously dropped it, so a newly added vision model could be saved without its capability flag.

Updates and clones already preserve this field; this makes model creation behave the same way.

## Verification

- Model route tests: 12 passed
- GitHub Python 3.11 suite: the new regression test passed; 2,117 passed and 93 skipped overall, with the same 2 existing `dev` failures
- Go tests passed
- Python compilation and `git diff --check` passed
