### PR TITLE
fix(vision): read images from execution backends

### DIFF
--- a/backend/tools/describe_image.py
+++ b/backend/tools/describe_image.py
@@ -39,6 +39,13 @@ _SUPPORTED_IMAGE_TYPES = frozenset({
     "image/bmp",
 })
 
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+try:
+    from config import SANDBOX_WORKSPACE as _WORKSPACE_ROOT
+except ImportError:
+    _WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
 # Cached check for ffmpeg availability (lazy, checked once at module level).
 _ffmpeg_path: Optional[str] = None
 _ffmpeg_checked: bool = False
@@ -262,6 +269,80 @@ def _find_closest_attachment(agent_id: str, orig_path: str) -> Optional[str]:
     return None
 
 
+def _read_image(agent: dict, path: str) -> tuple[Optional[bytes], Optional[str], Optional[str]]:
+    """Read an image from the host first, then the agent's execution backend."""
+    from backend.tools._workspace import (
+        effective_agent_id,
+        is_self_path,
+        resolve_self_path,
+        resolve_workspace_path,
+    )
+
+    agent = agent or {}
+    host_path = path
+    self_path = is_self_path(path)
+    if self_path:
+        host_path = resolve_self_path(effective_agent_id(agent), path)
+        if not host_path:
+            return None, None, "Error: Access denied — path escapes agent directory."
+
+    if os.path.isfile(host_path):
+        try:
+            file_size = os.path.getsize(host_path)
+            if file_size > _MAX_IMAGE_BYTES:
+                return None, None, (
+                    f"Error: Image file is {file_size / (1024 * 1024):.1f} MB, "
+                    "which exceeds the 10 MB limit."
+                )
+            with open(host_path, "rb") as handle:
+                image_data = handle.read(_MAX_IMAGE_BYTES + 1)
+        except PermissionError:
+            return None, None, f"Error: Permission denied — cannot read: {path}"
+        except Exception as exc:
+            return None, None, f"Error: Failed to read image: {exc}"
+        if len(image_data) > _MAX_IMAGE_BYTES:
+            return None, None, "Error: Image file exceeds the 10 MB limit."
+        return image_data, host_path, None
+
+    if self_path:
+        return None, None, f"Error: File not found: {path}"
+
+    try:
+        from backend.tools.lib.exec_backend import registry
+
+        backend = registry.get_backend(agent.get("session_id") or "default", agent)
+        target = resolve_workspace_path(agent, path, _WORKSPACE_ROOT)
+        target = backend.resolve_path(target)
+        stat = backend.file_stat(target)
+    except Exception as exc:
+        return None, None, f"Error: Failed to access execution environment: {exc}"
+
+    if not stat.get("exists"):
+        suggestion = _find_closest_attachment(agent.get("id", ""), path)
+        suffix = f". Did you mean: {suggestion}?" if suggestion else ""
+        return None, None, f"Error: File not found: {path}{suffix}"
+
+    file_size = int(stat.get("size") or 0)
+    if file_size > _MAX_IMAGE_BYTES:
+        return None, None, (
+            f"Error: Image file is {file_size / (1024 * 1024):.1f} MB, "
+            "which exceeds the 10 MB limit."
+        )
+
+    try:
+        result = backend.cat_file_bytes(target)
+    except Exception as exc:
+        return None, None, f"Error: Failed to read image: {exc}"
+    if "error" in result:
+        return None, None, f"Error: Failed to read image: {result['error']}"
+    image_data = result.get("bytes")
+    if not isinstance(image_data, bytes):
+        return None, None, "Error: Failed to read image: execution backend returned invalid data."
+    if len(image_data) > _MAX_IMAGE_BYTES:
+        return None, None, "Error: Image file exceeds the 10 MB limit."
+    return image_data, None, None
+
+
 def execute(agent: dict, args: dict) -> Any:
     """Analyze an image file and return a text description.
 
@@ -298,36 +379,23 @@ def execute(agent: dict, args: dict) -> Any:
     if not path:
         return "Error: 'path' parameter is required. Provide the file path to the image."
 
-    # Resolve /_self/ virtual paths (e.g. /_self/artifacts/foo.webp)
-    agent_id = (agent or {}).get("id", "")
-    if agent_id:
-        from backend.tools._workspace import is_self_path, resolve_self_path, effective_agent_id
-        if is_self_path(path):
-            resolved = resolve_self_path(effective_agent_id(agent), path)
-            if resolved:
-                path = resolved
-
-    if not os.path.isfile(path):
-        suggestion = _find_closest_attachment(agent_id, path)
-        if suggestion:
-            return f"Error: File not found: {path}. Did you mean: {suggestion}?"
-        return f"Error: File not found: {path}"
+    image_data, host_path, read_error = _read_image(agent, path)
+    if read_error:
+        return read_error
 
     # If the agent operates in a remote workplace (SSH/tunnel/etc.), ensure the
-    # image file is also available on the remote filesystem so the agent can
-    # reference it via bash, runpy, or other backend-routed tools.
-    try:
-        from backend.tools._ensure_workplace_file import ensure_workplace_file
-        ensure_workplace_file(path, agent)
-    except (ImportError, RuntimeError):
-        pass  # Non-critical: file is already accessible from the host side
+    # host image is also available there. Backend images need no staging.
+    if host_path:
+        try:
+            from backend.tools._ensure_workplace_file import ensure_workplace_file
+            ensure_workplace_file(host_path, agent)
+        except (ImportError, RuntimeError):
+            pass
 
-    file_size = os.path.getsize(path)
-    if file_size > 10 * 1024 * 1024:  # 10 MB
-        return f"Error: Image file is {file_size / (1024*1024):.1f} MB, which exceeds the 10 MB limit."
+    file_size = len(image_data)
 
     # --- Detect MIME type ---
-    mime_type, _ = mimetypes.guess_type(path)
+    mime_type, _ = mimetypes.guess_type(host_path or path)
     # mimetypes may not know .webp or other newer formats on some systems.
     # Fall back to extension-based detection when mimetypes returns unknown.
     if not mime_type:
@@ -338,22 +406,13 @@ def execute(agent: dict, args: dict) -> Any:
             '.webp': 'image/webp',
             '.bmp': 'image/bmp',
         }
-        mime_type = _ext_map.get(os.path.splitext(path)[1].lower())
+        mime_type = _ext_map.get(os.path.splitext(host_path or path)[1].lower())
     if not mime_type or mime_type not in _SUPPORTED_IMAGE_TYPES:
         detected = mime_type or "unknown"
         return (
             f"Error: Unsupported image type '{detected}'. "
             f"Supported formats: JPEG, PNG, GIF, WebP, BMP."
         )
-
-    # --- Read image and encode as base64 ---
-    try:
-        with open(path, "rb") as f:
-            image_data = f.read()
-    except PermissionError:
-        return f"Error: Permission denied — cannot read: {path}"
-    except Exception as e:
-        return f"Error: Failed to read image: {e}"
 
     # --- Auto-convert / compress to JPEG if needed ---
     image_data, resolved_mime = _preprocess_image(image_data, mime_type, file_size)

--- a/tools/describe_image.json
+++ b/tools/describe_image.json
@@ -8,7 +8,7 @@
     "parameters": {
       "properties": {
         "path": {
-          "description": "Absolute or relative path to the image file (.jpg, .jpeg, .png, .gif, .webp, .bmp).",
+          "description": "Absolute or relative path to an image visible in the agent's local filesystem, sandbox, scratchpad, or workplace (.jpg, .jpeg, .png, .gif, .webp, .bmp).",
           "type": "string"
         },
         "query": {

--- a/unit_tests/test_describe_image_errors.py
+++ b/unit_tests/test_describe_image_errors.py
@@ -1,5 +1,8 @@
+import base64
 from unittest.mock import patch
 
+import backend.tools.describe_image as describe_image
+import pytest
 from backend.tools.describe_image import execute
 
 
@@ -56,3 +59,130 @@ def test_describe_image_reports_last_fallback_model_after_transient_failures(tmp
 
     assert "All vision-capable models failed (3 model(s) tried)" in error
     assert "fallback model 2 (fallback-2): service unavailable" in error
+
+
+@pytest.mark.parametrize("path", ["generated.png", "/workspace/generated.png"])
+def test_describe_image_reads_backend_only_path(path):
+    image_data = b"\x89PNG\r\n\x1a\n"
+    agent = {
+        "id": "backend-agent",
+        "session_id": "session-1",
+        "sandbox_enabled": 1,
+        "workspace": "/host/workspace",
+    }
+
+    with (
+        patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend,
+        patch("backend.tools.describe_image._resolve_vision_models",
+              return_value=([_vision_model("vision")], None)),
+        patch("backend.tools.describe_image.LLMClient") as client_class,
+    ):
+        backend = get_backend.return_value
+        backend.resolve_path.return_value = "/workspace/generated.png"
+        backend.file_stat.return_value = {"exists": True, "size": len(image_data)}
+        backend.cat_file_bytes.return_value = {"bytes": image_data}
+        client_class.return_value.timeout = None
+        client_class.return_value.chat_completion.return_value = {
+            "success": True,
+            "response": {"choices": [{"message": {"content": "backend image"}}]},
+        }
+
+        result = execute(agent, {"path": path})
+
+    assert result == "backend image"
+    get_backend.assert_called_once_with("session-1", agent)
+    backend.resolve_path.assert_called_once_with("/host/workspace/generated.png")
+    backend.file_stat.assert_called_once_with("/workspace/generated.png")
+    backend.cat_file_bytes.assert_called_once_with("/workspace/generated.png")
+    messages = client_class.return_value.chat_completion.call_args.kwargs["messages"]
+    assert messages[1]["content"][1]["image_url"]["url"] == (
+        "data:image/png;base64," + base64.b64encode(image_data).decode("ascii")
+    )
+
+
+def test_describe_image_prefers_existing_host_path(tmp_path):
+    image_path = tmp_path / "host.png"
+    _write_png(image_path)
+
+    with (
+        patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend,
+        patch("backend.tools.describe_image._resolve_vision_models",
+              return_value=([_vision_model("vision")], None)),
+        patch("backend.tools.describe_image.LLMClient") as client_class,
+    ):
+        client_class.return_value.timeout = None
+        client_class.return_value.chat_completion.return_value = {
+            "success": True,
+            "response": {"choices": [{"message": {"content": "host image"}}]},
+        }
+        result = execute(
+            {"id": "host-agent", "sandbox_enabled": 0},
+            {"path": str(image_path)},
+        )
+
+    assert result == "host image"
+    get_backend.assert_not_called()
+
+
+def test_describe_image_checks_backend_size_before_reading():
+    with patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend:
+        backend = get_backend.return_value
+        backend.resolve_path.return_value = "/workspace/large.png"
+        backend.file_stat.return_value = {
+            "exists": True,
+            "size": describe_image._MAX_IMAGE_BYTES + 1,
+        }
+
+        result = execute(
+            {"id": "backend-agent", "session_id": "session-1"},
+            {"path": "/workspace/large.png"},
+        )
+
+    assert result == "Error: Image file is 10.0 MB, which exceeds the 10 MB limit."
+    backend.cat_file_bytes.assert_not_called()
+
+
+def test_describe_image_reports_backend_read_failures():
+    with patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend:
+        backend = get_backend.return_value
+        backend.resolve_path.return_value = "/workspace/image.png"
+        backend.file_stat.return_value = {"exists": True, "size": 8}
+        backend.cat_file_bytes.return_value = {"error": "transport failed"}
+        agent = {"id": "backend-agent", "session_id": "session-1"}
+
+        assert execute(agent, {"path": "/workspace/image.png"}) == (
+            "Error: Failed to read image: transport failed"
+        )
+
+        backend.cat_file_bytes.return_value = {"bytes": "not bytes"}
+        assert execute(agent, {"path": "/workspace/image.png"}) == (
+            "Error: Failed to read image: execution backend returned invalid data."
+        )
+
+
+def test_describe_image_reports_backend_lookup_failures():
+    with patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend:
+        backend = get_backend.return_value
+        backend.resolve_path.return_value = "/workspace/missing.png"
+        backend.file_stat.return_value = {"exists": False}
+        agent = {"id": "backend-agent", "session_id": "session-1"}
+
+        assert execute(agent, {"path": "/workspace/missing.png"}) == (
+            "Error: File not found: /workspace/missing.png"
+        )
+
+        backend.file_stat.side_effect = RuntimeError("backend unavailable")
+        assert execute(agent, {"path": "/workspace/missing.png"}) == (
+            "Error: Failed to access execution environment: backend unavailable"
+        )
+
+
+def test_describe_image_denies_self_path_escape_without_backend_fallback():
+    with patch("backend.tools.lib.exec_backend.registry.get_backend") as get_backend:
+        result = execute(
+            {"id": "test-agent", "session_id": "session-1"},
+            {"path": "/_self/../../outside.png"},
+        )
+
+    assert result == "Error: Access denied — path escapes agent directory."
+    get_backend.assert_not_called()


### PR DESCRIPTION
## What changed

`describe_image` can now read images that exist only in an agent's execution environment, including Docker and bwrap sandboxes, scratchpads, SSH workplaces, and Evonet tunnel workplaces.

Existing host-local paths keep their current behavior and take priority. If the image is not available on the host, the tool resolves the path against the agent's workspace and reads it through the active execution backend. `/_self/` remains host-local and keeps its existing directory boundary checks.

The tool still accepts only `path` and the optional `query`. There are no new dependencies or configuration fields.

## Safety and compatibility

- The 10 MB limit is checked before transferring backend bytes and again after reading them.
- Unsupported image formats, invalid backend responses, missing files, and backend transport errors return explicit errors.
- Existing MIME detection, image preprocessing, and vision-model fallback behavior are unchanged.

## Verification

- Focused vision and execution-backend tests: 71 passed
- New `describe_image` regression tests: 9 passed
- Local full suite: 2,131 passed and 84 skipped; the same 3 unrelated baseline failures remain
- GitHub Python 3.11 suite: all 9 regression tests passed; 2,123 passed and 93 skipped overall, with the same 2 existing `dev` failures
- Go tests passed
- Python compilation, JSON validation, and `git diff --check` passed

Closes #109
