### PR TITLE
Add Google Vertex AI provider support with auto-refreshing OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ Manage LLM configurations:
 ./evonic model rm gpt4o
 ```
 
+Any OpenAI-compatible endpoint works via the `custom` provider type, including a plain
+Gemini API key. Google Vertex AI (project-based, OAuth-authenticated) is also supported
+with automatic access-token refresh — see [docs/vertex-ai-provider.md](docs/vertex-ai-provider.md)
+for setup.
+
 ---
 
 ## Training Data Collection

--- a/backend/llm_client.py
+++ b/backend/llm_client.py
@@ -367,10 +367,27 @@ class LLMClient:
 
         return self.model
 
+    def _maybe_refresh_google_oauth(self) -> None:
+        """Refresh self.api_key in place if this client's provider is a Google
+        OAuth-authenticated one (Vertex AI via ADC refresh token) and the
+        current access token is near/at expiry. No-op for every other
+        provider (single indexed provider-row lookup)."""
+        if not self.provider:
+            return
+        try:
+            from models.db import db as _db
+            from backend.provider.oauth_google import get_valid_token
+            token = get_valid_token(_db, self.provider)
+            if token:
+                self.api_key = token
+        except Exception:
+            pass
+
     def test_connection(self) -> Dict[str, Any]:
         """Test connection to the model endpoint."""
         if self.api_format == "codex":
             return self._test_codex_connection()
+        self._maybe_refresh_google_oauth()
         try:
             if self.api_format == "ollama":
                 models_url = f"{self.base_url}/tags"
@@ -741,6 +758,7 @@ class LLMClient:
             if self.api_key:
                 headers["x-api-key"] = self.api_key
         else:
+            self._maybe_refresh_google_oauth()
             headers = {
                 "Content-Type": "application/json",
                 "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",

--- a/backend/provider/oauth_google.py
+++ b/backend/provider/oauth_google.py
@@ -1,0 +1,108 @@
+"""
+OAuth 2.0 refresh-token flow for Google Cloud Application Default Credentials (ADC).
+
+Keeps a "custom" provider pointed at Vertex AI's OpenAI-compatible endpoint
+authenticated without the user manually pasting a fresh access token every
+~1 hour. Mirrors backend/provider/oauth_codex.py's refresh pattern.
+
+CLIENT_ID/CLIENT_SECRET below are Google's well-known public "gcloud" installed-app
+OAuth client — the same client every `gcloud auth application-default login`
+refresh token is issued under (visible in every user's own
+~/.config/gcloud/application_default_credentials.json). Not a per-project secret.
+
+Token persistence via the providers table (auth_type='google_oauth').
+"""
+
+import logging
+import time
+from typing import Dict, Optional
+
+import requests
+
+_log = logging.getLogger(__name__)
+
+TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+CLIENT_ID = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
+CLIENT_SECRET = "d-FL95Q19q7MQmFpd7hHD0Ty"
+
+# Refresh this many seconds before actual expiry, so a slow request never
+# starts mid-flight with a token that dies before the response comes back.
+_REFRESH_MARGIN_SECONDS = 300
+
+
+def refresh_access_token(refresh_token: str) -> Dict:
+    """Use a refresh token to get a new short-lived access token."""
+    resp = requests.post(
+        TOKEN_ENDPOINT,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+        },
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        timeout=15,
+    )
+
+    if resp.status_code != 200:
+        return {"error": f"Token refresh failed (HTTP {resp.status_code}): {resp.text[:200]}"}
+
+    data = resp.json()
+    if "access_token" not in data:
+        return {"error": "No access_token in refresh response"}
+
+    return {
+        "access_token": data["access_token"],
+        "expires_in": data.get("expires_in", 3600),
+    }
+
+
+def store_tokens(db, provider_id: str, tokens: Dict) -> bool:
+    """Persist the refreshed access token + expiry to the provider row."""
+    expires_at = int(time.time()) + int(tokens.get("expires_in", 3600))
+    return db.update_provider(provider_id, {
+        "api_key": tokens["access_token"],
+        "token_expires_at": expires_at,
+    })
+
+
+def get_valid_token(db, provider_id: str) -> Optional[str]:
+    """Return a valid access token for a google_oauth provider, refreshing if
+    near/at expiry. Returns None for providers that aren't google_oauth-
+    authenticated (cheap no-op for every other provider type)."""
+    provider = db.get_provider(provider_id)
+    if not provider or provider.get("auth_type") != "google_oauth":
+        return None
+
+    access_token = provider.get("api_key")
+    expires_at = provider.get("token_expires_at", 0) or 0
+    now = int(time.time())
+
+    if not access_token or expires_at <= 0 or now >= (expires_at - _REFRESH_MARGIN_SECONDS):
+        refresh_token = provider.get("refresh_token", "")
+        if not refresh_token:
+            _log.warning("google_oauth provider '%s' has no refresh_token stored.", provider_id)
+            return access_token or None
+        new_tokens = refresh_access_token(refresh_token)
+        if "error" in new_tokens:
+            _log.warning("Google token refresh failed for '%s': %s", provider_id, new_tokens["error"])
+            return access_token or None
+        store_tokens(db, provider_id, new_tokens)
+        _log.info("Refreshed Google OAuth access token for provider '%s'.", provider_id)
+        return new_tokens["access_token"]
+
+    return access_token
+
+
+def clear_tokens(db, provider_id: str) -> bool:
+    """Remove stored tokens and disconnect."""
+    return db.update_provider(provider_id, {
+        "api_key": "",
+        "refresh_token": "",
+        "token_expires_at": 0,
+        "auth_type": "api_key",
+    })

--- a/docs/vertex-ai-provider.md
+++ b/docs/vertex-ai-provider.md
@@ -1,0 +1,152 @@
+# Google Vertex AI as a Provider
+
+Evonic's built-in provider presets (`openrouter`, `togetherai`, `ollama`, `ollama_cloud`,
+`opencode_zen`, `opencode_go`, `deepseek`, `llama.cpp`, `custom`) don't include Google
+Vertex AI, because Vertex's project-based auth model (short-lived OAuth access tokens,
+~1 hour expiry) doesn't fit the static-`api_key` shape every other provider uses.
+
+This adds a `google_oauth` auth mode so a `custom` provider can point at Vertex AI's
+OpenAI-compatible endpoint and stay authenticated automatically, refreshing the access
+token in the background using a Google Cloud [Application Default Credentials
+(ADC)](https://cloud.google.com/docs/authentication/application-default-credentials)
+refresh token — no manual token pasting after initial setup.
+
+> This is a **project-based Vertex AI** setup (billed to a GCP project, full model
+> access). It is a different product from a plain Gemini API key
+> (`AIza...`, from [AI Studio](https://aistudio.google.com/apikey)) and from Vertex AI
+> **Express Mode** API keys (`AQ...`) — both of those are simpler static-key auth, but
+> Express Mode currently only exposes Google's native `generateContent` REST API, not
+> the OpenAI-compatible `/chat/completions` endpoint this integration uses. If your key
+> starts with `AIza`, follow the *Gemini API key* path below instead — it works with the
+> existing `custom` provider type today, with no code changes needed.
+
+## Option A — Gemini API key (simplest, no code changes)
+
+If you have a static Gemini API key (`AIza...`) from AI Studio, this already works with
+Evonic's stock `custom` provider type:
+
+```
+Provider type: custom
+base_url:      https://generativelanguage.googleapis.com/v1beta/openai
+api_key:       <your Gemini API key>
+api_format:    openai
+```
+
+Add it from **Settings → Providers → Add Provider** in the web UI, then add a model
+under it (e.g. `model_name: gemini-2.5-flash`).
+
+## Option B — Vertex AI via ADC OAuth (project-based, auto-refreshing)
+
+Use this when you only have `gcloud` project access (no static API key), via:
+
+```bash
+gcloud auth application-default login
+```
+
+This writes a refresh token to
+`~/.config/gcloud/application_default_credentials.json`. Evonic can use that refresh
+token to keep a Vertex AI provider authenticated indefinitely.
+
+### 1. Read your ADC credentials
+
+```bash
+cat ~/.config/gcloud/application_default_credentials.json
+```
+
+You need `refresh_token` from this file, plus your GCP **project ID** and a
+**region** that has your target model enabled (e.g. `us-central1`,
+`asia-southeast1` — check
+[Model Garden](https://console.cloud.google.com/vertex-ai/model-garden) for
+regional availability).
+
+### 2. Create the provider and model
+
+There is currently no `./evonic` CLI subcommand or Settings UI flow for the
+`google_oauth` auth mode — create the rows directly against the database, the same way
+`routes/providers.py` and `routes/models.py` do internally:
+
+```python
+from models.db import db
+
+PROJECT = "<your-gcp-project-id>"
+REGION = "asia-southeast1"          # any Vertex AI region with your model enabled
+REFRESH_TOKEN = "<refresh_token from application_default_credentials.json>"
+
+BASE_URL = (
+    f"https://{REGION}-aiplatform.googleapis.com/v1beta1/"
+    f"projects/{PROJECT}/locations/{REGION}/endpoints/openapi"
+)
+
+db.create_provider({
+    "id": "gemini_vertex",
+    "name": "Gemini (Vertex AI)",
+    "type": "remote",
+    "base_url": BASE_URL,
+    "api_format": "openai",
+    "enabled": 1,
+})
+db.update_provider("gemini_vertex", {
+    "auth_type": "google_oauth",
+    "refresh_token": REFRESH_TOKEN,
+    "token_expires_at": 0,   # force a refresh on first use
+})
+
+db.create_model({
+    "name": "Gemini 2.5 Flash (Vertex)",
+    "type": "remote",
+    "provider": "gemini_vertex",
+    "base_url": BASE_URL,
+    "api_key": "",              # left empty on purpose — see note below
+    "model_name": "google/gemini-2.5-flash",  # publisher-prefixed: <publisher>/<model>
+    "api_format": "openai",
+    "vision_supported": 1,
+    "enabled": 1,
+})
+```
+
+Run it with the project's own interpreter so it picks up the right dependencies and
+DB path: `.venv/bin/python3 your_script.py` (or `venv/bin/python3`, whichever exists).
+
+**Leave the model's own `api_key` empty.** `resolve_model_config()` only falls back to
+the provider's `api_key` when the model's own field is empty — since the provider's key
+is the one that gets auto-refreshed, a non-empty model-level key would silently pin the
+model to a stale, soon-to-expire token forever.
+
+**Model name must be publisher-prefixed** (`google/gemini-2.5-flash`, not
+`gemini-2.5-flash`) — Vertex's OpenAI-compat endpoint rejects a bare model name with
+`400 Malformed publisher model ... expected '<publisher>/<model>'`.
+
+### 3. Assign the model to an agent
+
+From the web UI: agent's Settings → Model, or via the DB / `db.update_agent(agent_id,
+{"model_id": "gemini_vertex/google/gemini-2.5-flash"})` (use the actual model `id`
+returned by `create_model`).
+
+### How the auto-refresh works
+
+`backend/provider/oauth_google.py` mirrors the existing
+`backend/provider/oauth_codex.py` OAuth pattern already used for the OpenAI Codex
+provider:
+
+- `get_valid_token(db, provider_id)` reads the provider row; if `auth_type` isn't
+  `google_oauth` it returns `None` immediately (no-op for every other provider).
+- If the stored access token is missing, has no known expiry, or is within 5 minutes of
+  expiring, it exchanges the stored `refresh_token` for a new access token via
+  `POST https://oauth2.googleapis.com/token` and persists the new token +
+  `token_expires_at` back to the provider row.
+- `backend/llm_client.py` calls this once, right before building request headers, in
+  both `chat_completion()` and `test_connection()` — a cheap, indexed provider-row
+  lookup that's a no-op for the ~20+ other provider configs in a typical install.
+
+The `CLIENT_ID`/`CLIENT_SECRET` constants in `oauth_google.py` are Google's well-known
+public "gcloud" installed-app OAuth client — the same one every
+`gcloud auth application-default login` refresh token is issued under (visible in your
+own `application_default_credentials.json`). They are not a per-project secret.
+
+### Caveat
+
+If you ever run `gcloud auth application-default revoke` (or otherwise invalidate the
+ADC credential) on the machine that generated the refresh token, the stored
+`refresh_token` stops working and `get_valid_token()` will start returning the last
+known (expired) access token. Re-run `gcloud auth application-default login` and update
+the provider's `refresh_token` to fix it.


### PR DESCRIPTION
## Summary
- Adds a `google_oauth` auth mode so a `custom` provider can point at Vertex AI's OpenAI-compatible endpoint (`.../endpoints/openapi/chat/completions`) and stay authenticated automatically, refreshing the short-lived (~1hr) access token from a stored Google Cloud ADC refresh token — no manual token pasting after initial setup.
- Mirrors the existing `backend/provider/oauth_codex.py` OAuth pattern already used for the Codex provider, just against Google's token endpoint instead of OpenAI's.
- `backend/llm_client.py` calls the refresh check once, right before headers are built, in both `chat_completion()` and `test_connection()`. It's a single indexed provider-row lookup that's a no-op for every provider whose `auth_type` isn't `google_oauth`.
- Adds `docs/vertex-ai-provider.md` covering both the simple static Gemini API key path (already works today via the existing `custom` provider type, no code change needed) and the new ADC/OAuth path, including the two footguns discovered while building this: Vertex's OpenAI-compat endpoint requires the model to be `<publisher>/<model>`-prefixed (e.g. `google/gemini-2.5-flash`, not a bare model name), and the model row's own `api_key` must stay empty so it inherits (and keeps inheriting) the provider's auto-refreshed key instead of pinning to a stale one-time snapshot.
- Linked from the README's Models section.

There's currently no `./evonic` CLI subcommand or Settings UI flow for the `google_oauth` auth mode — the doc shows the one-time DB setup snippet (same fields `routes/providers.py`/`routes/models.py` write internally) since Vertex AI wasn't in scope for the existing provider-preset wizard. Happy to follow up with a proper CLI/UI flow if that's wanted.

## Test plan
- [x] `EVONIC_TESTING=1 pytest unit_tests/` — 2066 passed, 14 failed (all pre-existing, unrelated to this change: bubblewrap/Linux-sandbox tests failing on macOS, an SSH-backend test needing a local SSH server, knowledge-graph pipeline, process-tracker — none touch `llm_client.py` or providers).
- [x] Manually verified end-to-end against a real Vertex AI project: OAuth refresh mints a fresh access token from a stored ADC refresh token, and a real `chat/completions` call against `asia-southeast1` returns a `200` with `google/gemini-2.5-flash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)